### PR TITLE
Expose user preferences in api

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 from django.contrib.auth.models import User
+from api.models import UserPreferences
 
 
 class UserSerializer(serializers.HyperlinkedModelSerializer):
@@ -15,4 +16,19 @@ class UserSerializer(serializers.HyperlinkedModelSerializer):
             'is_staff',
             'is_superuser',
             'date_joined'
+        )
+
+
+class UserPreferenceSerializer(serializers.HyperlinkedModelSerializer):
+    user = UserSerializer()
+
+    class Meta:
+        model = UserPreferences
+        fields = (
+            'id',
+            'url',
+            'show_beta_interface',
+            'user',
+            'created_date',
+            'modified_date'
         )

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -3,6 +3,16 @@ from django.contrib.auth.models import User
 from api.models import UserPreferences
 
 
+class UserRelatedField(serializers.PrimaryKeyRelatedField):
+
+    def use_pk_only_optimization(self):
+        return False
+
+    def to_representation(self, value):
+        serializer = UserSerializer(value, context=self.context)
+        return serializer.data
+
+
 class UserSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = User
@@ -20,7 +30,7 @@ class UserSerializer(serializers.HyperlinkedModelSerializer):
 
 
 class UserPreferenceSerializer(serializers.HyperlinkedModelSerializer):
-    user = UserSerializer()
+    user = UserRelatedField(read_only=True)
 
     class Meta:
         model = UserPreferences

--- a/api/urls.py
+++ b/api/urls.py
@@ -4,6 +4,7 @@ from api import views
 
 router = routers.DefaultRouter(trailing_slash=False)
 router.register(r'users', views.UserViewSet)
+router.register(r'user_preferences', views.UserPreferenceViewSet)
 
 urlpatterns = patterns('',
     url(r'^', include(router.urls)),

--- a/api/views.py
+++ b/api/views.py
@@ -11,7 +11,6 @@ class UserViewSet(viewsets.ReadOnlyModelViewSet):
     """
     queryset = User.objects.all()
     serializer_class = UserSerializer
-    permission_classes = (IsAuthenticatedOrReadOnly,)
     filter_fields = ('email',)
     http_method_names = ['get', 'head', 'options', 'trace']
 
@@ -22,4 +21,3 @@ class UserPreferenceViewSet(viewsets.ModelViewSet):
     """
     queryset = UserPreferences.objects.all()
     serializer_class = UserPreferenceSerializer
-    permission_classes = (IsAuthenticatedOrReadOnly,)

--- a/api/views.py
+++ b/api/views.py
@@ -1,5 +1,4 @@
 from rest_framework import viewsets
-from rest_framework.permissions import IsAuthenticatedOrReadOnly, IsAuthenticated, IsAdminUser
 from django.contrib.auth.models import User
 from api.models import UserPreferences
 from .serializers import UserSerializer, UserPreferenceSerializer
@@ -14,6 +13,13 @@ class UserViewSet(viewsets.ReadOnlyModelViewSet):
     filter_fields = ('email',)
     http_method_names = ['get', 'head', 'options', 'trace']
 
+    def get_queryset(self):
+        """
+        Filter users to return only current user
+        """
+        user = self.request.user
+        return User.objects.filter(username=user.username)
+
 
 class UserPreferenceViewSet(viewsets.ModelViewSet):
     """
@@ -21,3 +27,10 @@ class UserPreferenceViewSet(viewsets.ModelViewSet):
     """
     queryset = UserPreferences.objects.all()
     serializer_class = UserPreferenceSerializer
+
+    def get_queryset(self):
+        """
+        Filter users to return only current user
+        """
+        user = self.request.user
+        return UserPreferences.objects.filter(user=user)

--- a/api/views.py
+++ b/api/views.py
@@ -27,6 +27,7 @@ class UserPreferenceViewSet(viewsets.ModelViewSet):
     """
     queryset = UserPreferences.objects.all()
     serializer_class = UserPreferenceSerializer
+    http_method_names = ['get', 'put', 'patch', 'head', 'options', 'trace']
 
     def get_queryset(self):
         """

--- a/api/views.py
+++ b/api/views.py
@@ -1,7 +1,8 @@
 from rest_framework import viewsets
 from rest_framework.permissions import IsAuthenticatedOrReadOnly, IsAuthenticated, IsAdminUser
 from django.contrib.auth.models import User
-from .serializers import UserSerializer
+from api.models import UserPreferences
+from .serializers import UserSerializer, UserPreferenceSerializer
 
 
 class UserViewSet(viewsets.ReadOnlyModelViewSet):
@@ -13,3 +14,12 @@ class UserViewSet(viewsets.ReadOnlyModelViewSet):
     permission_classes = (IsAuthenticatedOrReadOnly,)
     filter_fields = ('email',)
     http_method_names = ['get', 'head', 'options', 'trace']
+
+
+class UserPreferenceViewSet(viewsets.ModelViewSet):
+    """
+    API endpoint that allows users to be viewed.
+    """
+    queryset = UserPreferences.objects.all()
+    serializer_class = UserPreferenceSerializer
+    permission_classes = (IsAuthenticatedOrReadOnly,)

--- a/troposphere/auth_backends.py
+++ b/troposphere/auth_backends.py
@@ -1,11 +1,9 @@
 import logging
-
 from django.conf import settings
-
 from caslib import OAuthClient as CAS_OAuthClient
-
 from api.models import UserToken
 from django.contrib.auth.models import User
+from rest_framework.authentication import BaseAuthentication
 
 
 logger = logging.getLogger(__name__)
@@ -14,6 +12,27 @@ cas_oauth_client = CAS_OAuthClient(settings.CAS_SERVER,
                                    settings.OAUTH_CLIENT_KEY,
                                    settings.OAUTH_CLIENT_SECRET,
                                    auth_prefix=settings.CAS_AUTH_PREFIX)
+
+
+def create_user_token_from_access_token(access_token):
+    profile = cas_oauth_client.get_profile(access_token=access_token)
+
+    profile_dict = dict()
+    profile_dict['username'] = profile['id']
+    for attr in profile['attributes']:
+        key = attr.keys()[0]
+        value = attr[key]
+        profile_dict[key] = value
+
+    user, created = User.objects.get_or_create(username=profile_dict['username'])
+    user.first_name = profile_dict['firstName']
+    user.last_name = profile_dict['lastName']
+    user.email = profile_dict['email']
+    user.is_staff = ('staff' in profile_dict['entitlement'])
+    user.save()
+
+    user_token = UserToken.objects.create(token=access_token, user=user)
+    return user_token
 
 
 class OAuthLoginBackend(object):
@@ -57,3 +76,28 @@ class OAuthLoginBackend(object):
             return User.objects.get(pk=user_id)
         except User.DoesNotExist:
             return None
+
+
+class OAuthTokenLoginBackend(BaseAuthentication):
+    """
+    CAS OAuth Authentication Backend
+
+    Exchanges an access_token for a user, creates if does not exist
+    """
+
+    def authenticate(self, request):
+        access_token = None
+        auth = request.META.get('HTTP_AUTHORIZATION', '').split()
+        if len(auth) == 2 and auth[0].lower() == "token":
+            access_token = auth[1]
+        else:
+            return None
+
+        try:
+            user_token = UserToken.objects.get(token=access_token)
+
+        except UserToken.DoesNotExist:
+            user_token = create_user_token_from_access_token(access_token)
+
+        user = user_token.user
+        return (user_token.user, user_token)

--- a/troposphere/auth_backends.py
+++ b/troposphere/auth_backends.py
@@ -3,7 +3,7 @@ from django.conf import settings
 from caslib import OAuthClient as CAS_OAuthClient
 from api.models import UserToken
 from django.contrib.auth.models import User
-from rest_framework.authentication import BaseAuthentication
+from rest_framework import authentication, exceptions
 
 
 logger = logging.getLogger(__name__)
@@ -14,9 +14,7 @@ cas_oauth_client = CAS_OAuthClient(settings.CAS_SERVER,
                                    auth_prefix=settings.CAS_AUTH_PREFIX)
 
 
-def create_user_token_from_access_token(access_token):
-    profile = cas_oauth_client.get_profile(access_token=access_token)
-
+def create_user_token_from_cas_profile(profile, access_token):
     profile_dict = dict()
     profile_dict['username'] = profile['id']
     for attr in profile['attributes']:
@@ -48,22 +46,8 @@ class OAuthLoginBackend(object):
 
         except UserToken.DoesNotExist:
             profile = cas_oauth_client.get_profile(access_token=access_token)
-
-            profile_dict = dict()
-            profile_dict['username'] = profile['id']
-            for attr in profile['attributes']:
-                key = attr.keys()[0]
-                value = attr[key]
-                profile_dict[key] = value
-
-            user, created = User.objects.get_or_create(username=profile_dict['username'])
-            user.first_name = profile_dict['firstName']
-            user.last_name = profile_dict['lastName']
-            user.email = profile_dict['email']
-            user.is_staff = ('staff' in profile_dict['entitlement'])
-            user.save()
-
-            user_token = UserToken.objects.create(token=access_token, user=user)
+            # todo: handle [profile.get('error') = 'expired_accessToken'] error
+            user_token = create_user_token_from_cas_profile(profile, access_token)
 
         user = user_token.user
         return user
@@ -78,7 +62,7 @@ class OAuthLoginBackend(object):
             return None
 
 
-class OAuthTokenLoginBackend(BaseAuthentication):
+class OAuthTokenLoginBackend(authentication.BaseAuthentication):
     """
     CAS OAuth Authentication Backend
 
@@ -97,7 +81,13 @@ class OAuthTokenLoginBackend(BaseAuthentication):
             user_token = UserToken.objects.get(token=access_token)
 
         except UserToken.DoesNotExist:
-            user_token = create_user_token_from_access_token(access_token)
+            profile = cas_oauth_client.get_profile(access_token=access_token)
+            error = profile.get('error')
+
+            if error:
+                raise exceptions.AuthenticationFailed(error)
+
+            user_token = create_user_token_from_cas_profile(profile, access_token)
 
         user = user_token.user
-        return (user_token.user, user_token)
+        return (user, user_token)

--- a/troposphere/settings/default.py
+++ b/troposphere/settings/default.py
@@ -117,6 +117,7 @@ REST_FRAMEWORK = {
     # ),
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework.authentication.SessionAuthentication',
+        'troposphere.auth_backends.OAuthTokenLoginBackend'
     ),
     'PAGINATE_BY': 20,                 # Default to 20
     'PAGINATE_BY_PARAM': 'page_size',  # Allow client to override, using `?page_size=xxx`.


### PR DESCRIPTION
1. Expose API endpoint for users.  Currently limited to return only the current user's information.
2. Expose API endpoint for user preferences.  Currently limited to return only the current user's preferences.
3. Added OAuthToken backend to allow for a CAS token to be sent in an API request to interact with the API.
4. Updated token authentication so that the user is automatically created if a) the token is valid and b) user doesn't already exist.
