### PR TITLE
Fix owner image edit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 python-dateutil==2.2
 requests==2.2.1
-django==1.8c1
+django==1.7.4
 django-jenkins==0.16.2
 djangorestframework==3.0.4
 coverage==3.7.1

--- a/troposphere/auth_backends.py
+++ b/troposphere/auth_backends.py
@@ -21,10 +21,12 @@ def create_user_token_from_cas_profile(profile, access_token):
         value = attr[key]
         profile_dict[key] = value
 
+    user = get_or_create_user(profile_dict)
     user_token = UserToken.objects.create(token=access_token, user=user)
     return user_token
 
-def get_or_create_user(username, profile, access_token=None):
+
+def get_or_create_user(profile):
     user, created = User.objects.get_or_create(username=profile['username'])
     user.first_name = profile['firstName']
     user.last_name = profile['lastName']
@@ -32,6 +34,7 @@ def get_or_create_user(username, profile, access_token=None):
     user.is_staff = ('staff' in profile['entitlement'])
     user.save()
     return user
+
 
 class OAuthLoginBackend(object):
     """
@@ -102,12 +105,13 @@ class MockLoginBackend(authentication.BaseAuthentication):
         Return user if Always
         Return None Never.
         """
-        return get_or_create_user(username, {
+        return get_or_create_user({
             'username':settings.ALWAYS_AUTH_USER,
             'firstName':"Mocky Mock",
             'lastName':"MockDoodle",
             'email': '%s@iplantcollaborative.org' % settings.ALWAYS_AUTH_USER,
-            'entitlement': []})
+            'entitlement': []
+        })
 
     def get_user(self, user_id):
         """

--- a/troposphere/auth_backends.py
+++ b/troposphere/auth_backends.py
@@ -4,7 +4,6 @@ from caslib import OAuthClient as CAS_OAuthClient
 from api.models import UserToken
 from django.contrib.auth.models import User
 from rest_framework import authentication, exceptions
-from uuid import uuid4
 
 logger = logging.getLogger(__name__)
 cas_oauth_client = CAS_OAuthClient(settings.CAS_SERVER,

--- a/troposphere/static/js/components/applications/detail/EditApplicationDetails.react.js
+++ b/troposphere/static/js/components/applications/detail/EditApplicationDetails.react.js
@@ -10,7 +10,8 @@ define(function (require) {
       AuthorView = require('./author/AuthorView.react'),
       EditDescriptionView = require('./description/EditDescriptionView.react'),
       VersionsView = require('./versions/VersionsView.react'),
-      actions = require('actions');
+      actions = require('actions'),
+      stores = require('stores');
 
   return React.createClass({
 
@@ -70,7 +71,7 @@ define(function (require) {
           providers = this.props.providers,
           identities = this.props.identities,
           allTags = this.props.tags,
-          imageTags = stores.ImageTagStore.getAllFor(application),
+          imageTags = stores.TagStore.getImageTags(application),
           availabilityView,
           versionView;
 

--- a/troposphere/static/js/components/applications/detail/ViewApplicationDetails.react.js
+++ b/troposphere/static/js/components/applications/detail/ViewApplicationDetails.react.js
@@ -35,7 +35,7 @@ define(
         var profile = stores.ProfileStore.get(),
             image = this.props.application;
 
-        if(profile.id && profile.get('username') === image.get('created_by')){
+        if(profile.id && profile.get('username') === image.get('created_by').username){
           return (
             <div className="edit-link-row">
               <a className="edit-link" onClick={this.props.onEditImageDetails}>Edit details</a>


### PR DESCRIPTION
This re-enables the ability for image owners to edit the name, description and tags of images they own.

1. The core issue why users couldn't edit images anymore was because **image.created_by** is now a resource, and not just a username anymore.  So I needed to add **image.created_by.username** to fix the logic check for whether to show the edit link.  There was also a secondary issue related to the component trying to use the **ImageTagStore** instead of the **TagStore** to get all the tags for an image.  While **ImageTagStore** is the correct store, it doesn't actually exist in the UI code at the moment.  But it should be added later and current code should be updated to use it.

2. Fixed the CAS OAuth login flow (there was a bug about user not being defined)

3. Dropped Django version back down to 1.7.4 due to known issues between the 1.8RC and DRF 3.0.4 (which Tropo uses).  I propose we upgrade Django and DRF to 1.8 and 3.1.1 respectively in the next release (or later) when there's more time to make the required changes.