### PR TITLE
only show admin view to staff

### DIFF
--- a/troposphere/static/js/components/Header.react.js
+++ b/troposphere/static/js/components/Header.react.js
@@ -51,7 +51,8 @@ define(function(require) {
       name: "Admin",
       linksTo: "admin",
       icon: "cog",
-      requiresLogin: true
+      requiresLogin: true,
+      requiresStaff: true
     }
   ];
 
@@ -135,6 +136,11 @@ define(function(require) {
       if(!profile) {
         links = links.filter(function (link) {
           return !link.requiresLogin;
+        })
+      }else{
+        links = links.filter(function (link) {
+          if(link.requiresStaff) return profile.get('is_staff');
+          return true;
         })
       }
 


### PR DESCRIPTION
This fixes a bug where the admin view to modify resource requests is shown to everyone and not just staff.