### PR TITLE
Remove modal warnings

### DIFF
--- a/troposphere/static/js/components/modals/ModalHelpers.js
+++ b/troposphere/static/js/components/modals/ModalHelpers.js
@@ -12,7 +12,9 @@ define(
 
     return {
 
-      renderModal: function(modal, cb){
+      renderModal: function(ModalComponent, props, cb){
+        props = props || {};
+        var modal = React.createFactory(ModalComponent)(props);
         modal.props.onConfirm = cb;
         modal.props.onCancel = onCancel;
         modal.props.handleHidden = onCancel;

--- a/troposphere/static/js/components/modals/VersionInformationModal.react.js
+++ b/troposphere/static/js/components/modals/VersionInformationModal.react.js
@@ -1,154 +1,120 @@
-/** @jsx React.DOM */
+define(function (require) {
 
-define(
-  [
-    'react',
-    'components/mixins/BootstrapModalMixin.react',
-    'stores',
-    'moment'
-  ],
-  function (React, BootstrapModalMixin, stores, moment) {
+  var React = require('react'),
+      BootstrapModalMixin = require('components/mixins/BootstrapModalMixin.react'),
+      stores = require('stores'),
+      moment = require('moment');
 
-    // Example Usage from http://bl.ocks.org/insin/raw/8449696/
-    // render: function(){
-    // <div>
-    //   ...custom components...
-    //   <ExampleModal
-    //      ref="modal"
-    //      show={false}
-    //      header="Example Modal"
-    //      buttons={buttons}
-    //      handleShow={this.handleLog.bind(this, 'Modal about to show', 'info')}
-    //      handleShown={this.handleLog.bind(this, 'Modal showing', 'success')}
-    //      handleHide={this.handleLog.bind(this, 'Modal about to hide', 'warning')}
-    //      handleHidden={this.handleLog.bind(this, 'Modal hidden', 'danger')}
-    //    >
-    //      <p>I'm the content.</p>
-    //      <p>That's about it, really.</p>
-    //    </ExampleModal>
-    // </div>
+  return React.createClass({
+    mixins: [BootstrapModalMixin],
+
     //
+    // Mounting & State
+    // ----------------
+    //
+    getInitialState: function(){
+      return this.getState.apply(this);
+    },
 
-    // To show the modal, call this.refs.modal.show() from the parent component:
-    // handleShowModal: function() {
-    //   this.refs.modal.show();
-    // }
-
-    function getState() {
+    getState: function(){
       return {
         version: stores.VersionStore.getVersion()
       };
-    }
+    },
 
-    return React.createClass({
-      mixins: [BootstrapModalMixin],
+    updateState: function () {
+      if (this.isMounted()) this.setState(this.getState.apply(this));
+    },
 
-      propTypes: {
-        onClose: React.PropTypes.func.isRequired
-      },
+    componentDidMount: function () {
+      stores.VersionStore.addChangeListener(this.updateState);
+    },
 
-      //
-      // Mounting & State
-      // ----------------
-      //
-      getInitialState: function(){
-        return getState.apply(this);
-      },
+    componentWillUnmount: function () {
+      stores.VersionStore.removeChangeListener(this.updateState);
+    },
 
-      updateState: function () {
-        if (this.isMounted()) this.setState(getState.apply(this));
-      },
+    //
+    // Internal Modal Callbacks
+    // ------------------------
+    //
 
-      componentDidMount: function () {
-        stores.VersionStore.addChangeListener(this.updateState);
-      },
+    close: function () {
+      this.hide();
+    },
 
-      componentWillUnmount: function () {
-        stores.VersionStore.removeChangeListener(this.updateState);
-      },
+    //
+    // Render
+    // ------
+    //
 
-      //
-      // Internal Modal Callbacks
-      // ------------------------
-      //
+    render: function () {
+      var buttonArray = [
+        {type: 'primary', text: "Close", handler: this.close}
+      ];
 
-      close: function () {
-        this.hide();
-        this.props.onClose();
-      },
-
-      //
-      // Render
-      // ------
-      //
-
-      render: function () {
-        var buttonArray = [
-          {type: 'primary', text: "Close", handler: this.close}
-        ];
-
-        var buttons = buttonArray.map(function (button) {
-          return (
-            <button key={button.text} type="button" className={'btn btn-' + button.type} onClick={button.handler}>
-              {button.text}
-            </button>
-          );
-        }.bind(this));
-
-        var content;
-        if(this.state.version){
-          var client = this.state.version.client;
-          var clientVersion = client.get("git_branch") + " " + client.get("git_sha_abbrev");
-          var clientLastUpdated = moment(client.get('commit_date')).format("MMM Do YYYY");
-
-          var server = this.state.version.server;
-          var serverVersion = server.get("git_branch") + " " + server.get("git_sha_abbrev");
-          var serverLastUpdated = moment(server.get('commit_date')).format("MMM Do YYYY");
-
-          content = (
-            <div role='form'>
-
-              <div className='form-group'>
-                <div>
-                  <label>Client</label>
-                  {", " + clientLastUpdated}
-                  <p>{clientVersion}</p>
-                </div>
-                <div>
-                  <label>Server</label>
-                  {", " + serverLastUpdated}
-                  <p>{serverVersion}</p>
-                </div>
-              </div>
-
-            </div>
-          );
-        }else{
-          content = (
-            <div className="loading"></div>
-          );
-        }
-
+      var buttons = buttonArray.map(function (button) {
         return (
-          <div className="modal fade">
-            <div className="modal-dialog modal-sm">
-              <div className="modal-content">
-                <div className="modal-header">
-                  {this.renderCloseButton()}
-                  <strong>{this.props.header}</strong>
-                </div>
-                <div className="modal-body">
-                  {content}
-                </div>
-                <div className="modal-footer">
-                  {buttons}
-                </div>
+          <button key={button.text} type="button" className={'btn btn-' + button.type} onClick={button.handler}>
+            {button.text}
+          </button>
+        );
+      }.bind(this));
+
+      var content;
+      if(this.state.version){
+        var client = this.state.version.client;
+        var clientVersion = client.get("git_branch") + " " + client.get("git_sha_abbrev");
+        var clientLastUpdated = moment(client.get('commit_date')).format("MMM Do YYYY");
+
+        var server = this.state.version.server;
+        var serverVersion = server.get("git_branch") + " " + server.get("git_sha_abbrev");
+        var serverLastUpdated = moment(server.get('commit_date')).format("MMM Do YYYY");
+
+        content = (
+          <div role='form'>
+
+            <div className='form-group'>
+              <div>
+                <label>Client</label>
+                {", " + clientLastUpdated}
+                <p>{clientVersion}</p>
+              </div>
+              <div>
+                <label>Server</label>
+                {", " + serverLastUpdated}
+                <p>{serverVersion}</p>
               </div>
             </div>
+
           </div>
+        );
+      }else{
+        content = (
+          <div className="loading"></div>
         );
       }
 
-    });
+      return (
+        <div className="modal fade">
+          <div className="modal-dialog modal-sm">
+            <div className="modal-content">
+              <div className="modal-header">
+                {this.renderCloseButton()}
+                <strong>{this.props.header}</strong>
+              </div>
+              <div className="modal-body">
+                {content}
+              </div>
+              <div className="modal-footer">
+                {buttons}
+              </div>
+            </div>
+          </div>
+        </div>
+      );
+    }
 
   });
+
+});

--- a/troposphere/static/js/modals/help/requestMoreResources.js
+++ b/troposphere/static/js/modals/help/requestMoreResources.js
@@ -8,9 +8,7 @@ define(function (require) {
   return {
 
     requestMoreResources: function(){
-      var modal = RequestMoreResourcesModal();
-
-      ModalHelpers.renderModal(modal, function(identity, quota, reason){
+      ModalHelpers.renderModal(RequestMoreResourcesModal, null, function(identity, quota, reason){
         actions.HelpActions.requestMoreResources({
           identity: identity,
           quota: quota,

--- a/troposphere/static/js/modals/help/showFeedbackModal.js
+++ b/troposphere/static/js/modals/help/showFeedbackModal.js
@@ -8,12 +8,12 @@ define(function (require) {
 
     showFeedbackModal: function(){
 
-      var modal = FeedbackModal({
+      var props = {
         header: "Send Feedback",
         confirmButtonMessage: "Send feedback"
-      });
+      };
 
-      ModalHelpers.renderModal(modal, function(feedback){
+      ModalHelpers.renderModal(FeedbackModal, props, function(feedback){
 
         actions.HelpActions.sendFeedback({
           feedback: feedback

--- a/troposphere/static/js/modals/instance/createAndAddToProject.js
+++ b/troposphere/static/js/modals/instance/createAndAddToProject.js
@@ -12,10 +12,9 @@ define(function (require) {
     createAndAddToProject: function(options){
       if(!options.project) throw new Error("Missing project");
 
-      var project = options.project,
-          modal = React.createElement(ProjectInstanceLaunchModal);
+      var project = options.project;
 
-      ModalHelpers.renderModal(modal, function (application, identity, machineId, sizeId, instanceName) {
+      ModalHelpers.renderModal(ProjectInstanceLaunchModal, null, function (application, identity, machineId, sizeId, instanceName) {
         var size = stores.SizeStore.get(sizeId),
             machine = application.get('machines').get(machineId);
 

--- a/troposphere/static/js/modals/instance/destroy.js
+++ b/troposphere/static/js/modals/instance/destroy.js
@@ -17,20 +17,23 @@ define(function (require) {
       var project = payload.project,
           instance = payload.instance,
           attachedVolumes = stores.VolumeStore.getVolumesAttachedToInstance(instance),
-          modal;
+          ModalComponent,
+          props;
 
       if(attachedVolumes.length > 0){
-        modal = ExplainInstanceDeleteConditionsModal({
+        ModalComponent = ExplainInstanceDeleteConditionsModal;
+        props = {
           attachedVolumes: attachedVolumes,
           backdrop: 'static'
-        });
+        };
       }else{
-        modal = InstanceDeleteModal({
+        ModalComponent = InstanceDeleteModal;
+        props = {
           instance: payload.instance
-        });
+        };
       }
 
-      ModalHelpers.renderModal(modal, function () {
+      ModalHelpers.renderModal(ModalComponent, props, function () {
         if(attachedVolumes.length > 0) return;
         actions.InstanceActions.destroy(payload, options);
         Router.getInstance().transitionTo("project-resources", {projectId: project.id});

--- a/troposphere/static/js/modals/instance/launch.js
+++ b/troposphere/static/js/modals/instance/launch.js
@@ -9,11 +9,11 @@ define(function (require) {
   return {
 
     launch: function(application){
-      var modal = InstanceLaunchModal({
+      var props = {
         application: application
-      });
+      };
 
-      ModalHelpers.renderModal(modal, function (identity, machineId, sizeId, instanceName, project) {
+      ModalHelpers.renderModal(InstanceLaunchModal, props, function (identity, machineId, sizeId, instanceName, project) {
         var size = stores.SizeStore.get(sizeId),
             machine = application.get('machines').get(machineId);
 

--- a/troposphere/static/js/modals/instance/reboot.js
+++ b/troposphere/static/js/modals/instance/reboot.js
@@ -8,9 +8,7 @@ define(function (require) {
   return {
 
     reboot: function (instance) {
-      var modal = InstanceRebootModal();
-
-      ModalHelpers.renderModal(modal, function () {
+      ModalHelpers.renderModal(InstanceRebootModal, null, function () {
         actions.InstanceActions.reboot({
           instance: instance
         });

--- a/troposphere/static/js/modals/instance/report.js
+++ b/troposphere/static/js/modals/instance/report.js
@@ -11,11 +11,11 @@ define(function (require) {
       if(!params.instance) throw new Error("Missing instance");
 
       var instance = params.instance,
-          modal = InstanceReportModal({
+          props = {
             instance: instance
-          });
+          };
 
-      ModalHelpers.renderModal(modal, function (reportInfo) {
+      ModalHelpers.renderModal(InstanceReportModal, props, function (reportInfo) {
         actions.InstanceActions.report({
           instance: instance,
           reportInfo: reportInfo

--- a/troposphere/static/js/modals/instance/requestImage.js
+++ b/troposphere/static/js/modals/instance/requestImage.js
@@ -11,11 +11,11 @@ define(function (require) {
       if(!params.instance) throw new Error("Missing instance");
 
       var instance = params.instance,
-          modal = InstanceImageWizardModal({
+          props = {
             instance: instance
-          });
+          };
 
-      ModalHelpers.renderModal(modal, function (params) {
+      ModalHelpers.renderModal(InstanceImageWizardModal, props, function (params) {
         actions.InstanceActions.requestImage({
           instance: instance,
           name: params.name,

--- a/troposphere/static/js/modals/instance/resume.js
+++ b/troposphere/static/js/modals/instance/resume.js
@@ -8,9 +8,7 @@ define(function (require) {
   return {
 
     resume: function(instance){
-      var modal = InstanceResumeModal();
-
-      ModalHelpers.renderModal(modal, function () {
+      ModalHelpers.renderModal(InstanceResumeModal, null, function () {
         actions.InstanceActions.resume({
           instance: instance
         })

--- a/troposphere/static/js/modals/instance/start.js
+++ b/troposphere/static/js/modals/instance/start.js
@@ -8,9 +8,7 @@ define(function (require) {
   return {
 
     start: function(instance){
-      var modal = InstanceStartModal();
-
-      ModalHelpers.renderModal(modal, function () {
+      ModalHelpers.renderModal(InstanceStartModal, null, function () {
         actions.InstanceActions.start({
           instance: instance
         })

--- a/troposphere/static/js/modals/instance/stop.js
+++ b/troposphere/static/js/modals/instance/stop.js
@@ -8,9 +8,7 @@ define(function (require) {
   return {
 
     stop: function(instance){
-      var modal = InstanceStopModal();
-
-      ModalHelpers.renderModal(modal, function () {
+      ModalHelpers.renderModal(InstanceStopModal, null, function () {
         actions.InstanceActions.stop({
           instance: instance
         });

--- a/troposphere/static/js/modals/instance/suspend.js
+++ b/troposphere/static/js/modals/instance/suspend.js
@@ -8,9 +8,7 @@ define(function (require) {
   return {
 
     suspend: function (instance) {
-      var modal = InstanceSuspendModal();
-
-      ModalHelpers.renderModal(modal, function () {
+      ModalHelpers.renderModal(InstanceSuspendModal, null, function () {
         actions.InstanceActions.suspend({
           instance: instance
         })

--- a/troposphere/static/js/modals/instanceVolume/attach.js
+++ b/troposphere/static/js/modals/instanceVolume/attach.js
@@ -8,12 +8,12 @@ define(function (require) {
   return {
 
     attach: function(volume, project){
-      var modal = VolumeAttachModal({
+      var props = {
         volume: volume,
         project: project
-      });
+      };
 
-      ModalHelpers.renderModal(modal, function (instance, mountLocation) {
+      ModalHelpers.renderModal(VolumeAttachModal, null, function (instance, mountLocation) {
         actions.InstanceVolumeActions.attach({
           instance: instance,
           volume: volume,

--- a/troposphere/static/js/modals/instanceVolume/detach.js
+++ b/troposphere/static/js/modals/instanceVolume/detach.js
@@ -8,11 +8,11 @@ define(function (require) {
   return {
 
     detach: function (volume) {
-      var modal = VolumeDetachModal({
+      var props = {
         volume: volume
-      });
+      };
 
-      ModalHelpers.renderModal(modal, function () {
+      ModalHelpers.renderModal(VolumeDetachModal, props, function () {
         actions.InstanceVolumeActions.detach({
           volume: volume
         })

--- a/troposphere/static/js/modals/project/create.js
+++ b/troposphere/static/js/modals/project/create.js
@@ -9,10 +9,7 @@ define(function (require) {
   return {
 
     create: function () {
-
-      var modal = ProjectCreateModal();
-
-      ModalHelpers.renderModal(modal, function(name, description){
+      ModalHelpers.renderModal(ProjectCreateModal, null, function(name, description){
         actions.ProjectActions.create({
           name: name,
           description: description

--- a/troposphere/static/js/modals/project/destroy.js
+++ b/troposphere/static/js/modals/project/destroy.js
@@ -8,11 +8,11 @@ define(function (require) {
 
     destroy: function (project) {
 
-      var modal = ProjectDeleteModal({
+      var props = {
         project: project
-      });
+      };
 
-      ModalHelpers.renderModal(modal, function(){
+      ModalHelpers.renderModal(ProjectDeleteModal, props, function(){
         actions.ProjectActions.destroy({
           project: project
         });

--- a/troposphere/static/js/modals/project/explainProjectDeleteConditions.js
+++ b/troposphere/static/js/modals/project/explainProjectDeleteConditions.js
@@ -6,9 +6,7 @@ define(function (require) {
 
   return {
     explainProjectDeleteConditions: function(){
-      var modal = ProjectDeleteConditionsModal();
-
-      ModalHelpers.renderModal(modal, function(){});
+      ModalHelpers.renderModal(ProjectDeleteConditionsModal, null, function(){});
     }
   }
 

--- a/troposphere/static/js/modals/project/moveResources.js
+++ b/troposphere/static/js/modals/project/moveResources.js
@@ -8,12 +8,12 @@ define(function (require) {
 
     moveResources: function (resources, currentProject) {
 
-      var modal = ProjectMoveResourceModal({
+      var props = {
         currentProject: currentProject,
         resources: resources
-      });
+      };
 
-      ModalHelpers.renderModal(modal, function(newProject){
+      ModalHelpers.renderModal(ProjectMoveResourceModal, null, function(newProject){
         actions.ProjectActions.moveResources({
           currentProject: currentProject,
           resources: resources,

--- a/troposphere/static/js/modals/project/moveResources.js
+++ b/troposphere/static/js/modals/project/moveResources.js
@@ -13,7 +13,7 @@ define(function (require) {
         resources: resources
       };
 
-      ModalHelpers.renderModal(ProjectMoveResourceModal, null, function(newProject){
+      ModalHelpers.renderModal(ProjectMoveResourceModal, props, function(newProject){
         actions.ProjectActions.moveResources({
           currentProject: currentProject,
           resources: resources,

--- a/troposphere/static/js/modals/project/removeResources.js
+++ b/troposphere/static/js/modals/project/removeResources.js
@@ -7,13 +7,12 @@ define(function (require) {
   return {
 
     removeResources: function(resources, project){
-
-      var modal = ProjectRemoveResourceModal({
+      var props = {
         project: project,
         resources: resources
-      });
+      };
 
-      ModalHelpers.renderModal(modal, function(){
+      ModalHelpers.renderModal(ProjectRemoveResourceModal, props, function(){
         actions.ProjectActions.removeResources({
           project: project,
           resources: resources

--- a/troposphere/static/js/modals/tag/create.js
+++ b/troposphere/static/js/modals/tag/create.js
@@ -8,12 +8,11 @@ define(function (require) {
   return {
 
     create: function(initialTagName){
-
       var props = {
         initialTagName: initialTagName
       };
 
-      ModalHelpers.renderModal(TagCreateModal, null, function(name, description){
+      ModalHelpers.renderModal(TagCreateModal, props, function(name, description){
         actions.TagActions.create({
           name: name,
           description: description

--- a/troposphere/static/js/modals/tag/create.js
+++ b/troposphere/static/js/modals/tag/create.js
@@ -9,11 +9,11 @@ define(function (require) {
 
     create: function(initialTagName){
 
-      var modal = TagCreateModal({
+      var props = {
         initialTagName: initialTagName
-      });
+      };
 
-      ModalHelpers.renderModal(modal, function(name, description){
+      ModalHelpers.renderModal(TagCreateModal, null, function(name, description){
         actions.TagActions.create({
           name: name,
           description: description

--- a/troposphere/static/js/modals/tag/create_AddToInstance.js
+++ b/troposphere/static/js/modals/tag/create_AddToInstance.js
@@ -8,12 +8,11 @@ define(function (require) {
   return {
 
     create_AddToInstance: function(initialTagName, instance){
-
-      var modal = TagCreateModal({
+      var props = {
         initialTagName: initialTagName
-      });
+      };
 
-      ModalHelpers.renderModal(modal, function(name, description){
+      ModalHelpers.renderModal(TagCreateModal, props, function(name, description){
         actions.TagActions.create_AddToInstance({
           name: name,
           description: description,

--- a/troposphere/static/js/modals/version/showVersion.js
+++ b/troposphere/static/js/modals/version/showVersion.js
@@ -1,30 +1,16 @@
 define(function (require) {
 
-  var React = require('react'),
-      AppDispatcher = require('dispatchers/AppDispatcher'),
-      ModalHelpers = require('components/modals/ModalHelpers'),
+  var ModalHelpers = require('components/modals/ModalHelpers'),
       VersionInformationModal = require('components/modals/VersionInformationModal.react');
 
   return {
 
-    showVersion: function (volume) {
-
-      var onClose = function(){
-        // Important! We need to un-mount the component so it un-registers from Stores and
-        // also so that we can relaunch it again later.
-        React.unmountComponentAtNode(document.getElementById('modal'));
+    showVersion: function () {
+      var props = {
+        header: "Atmosphere Version"
       };
-      var headerMessage = "Atmosphere Version";
 
-      var modal = VersionInformationModal({
-        header: headerMessage,
-        onClose: onClose
-      });
-
-      ModalHelpers.renderModal(modal, function(){
-      });
-
-      //React.render(modal, document.getElementById('modal'));
+      ModalHelpers.renderModal(VersionInformationModal, props, function(){});
     }
 
   };

--- a/troposphere/static/js/modals/volume/createAndAddToProject.js
+++ b/troposphere/static/js/modals/volume/createAndAddToProject.js
@@ -9,10 +9,9 @@ define(function (require) {
     createAndAddToProject: function(payload){
       if(!payload.project) throw new Error("Missing project");
 
-      var project = payload.project,
-          modal = VolumeCreateModal();
+      var project = payload.project;
 
-      ModalHelpers.renderModal(modal, function (volumeName, volumeSize, identity) {
+      ModalHelpers.renderModal(VolumeCreateModal, null, function (volumeName, volumeSize, identity) {
         actions.VolumeActions.createAndAddToProject({
           volumeName: volumeName,
           volumeSize: volumeSize,

--- a/troposphere/static/js/modals/volume/destroy.js
+++ b/troposphere/static/js/modals/volume/destroy.js
@@ -17,20 +17,23 @@ define(function (require) {
           volume = payload.volume,
           instanceUUID = volume.get('attach_data').instance_id,
           isAttached = !!instanceUUID,
-          modal;
+          ModalComponent,
+          props;
 
       if(isAttached){
-        modal = ExplainVolumeDeleteConditionsModal({
+        ModalComponent = ExplainVolumeDeleteConditionsModal;
+        props = {
           volume: volume,
           instance: stores.InstanceStore.getAll().findWhere({uuid: instanceUUID})
-        });
+        };
       }else{
-        modal = VolumeDeleteModal({
+        ModalComponent = VolumeDeleteModal;
+        props = {
           volume: volume
-        });
+        };
       }
 
-      ModalHelpers.renderModal(modal, function () {
+      ModalHelpers.renderModal(ModalComponent, props, function () {
         if(isAttached) return;
         actions.VolumeActions.destroy({
           project: project,

--- a/troposphere/static/js/modals/volume/report.js
+++ b/troposphere/static/js/modals/volume/report.js
@@ -11,11 +11,11 @@ define(function (require) {
       if(!params.volume) throw new Error("Missing volume");
 
       var volume = params.volume,
-          modal = VolumeReportModal({
+          props = {
             volume: volume
-          });
+          };
 
-      ModalHelpers.renderModal(modal, function (reportInfo) {
+      ModalHelpers.renderModal(VolumeReportModal, props, function (reportInfo) {
         actions.VolumeActions.report({
           reportInfo: reportInfo,
           volume: volume


### PR DESCRIPTION
**Problem**: Every time a modal is rendered React issues the following warning:

```
Warning: Something is calling a React component directly. Use a factory or JSX instead. See: http://fb.me/react-legacyfactory
```

**Solution**: Change the approach we use to generate modals.  The three options are described in the following JIRA:

https://pods.iplantcollaborative.org/jira/browse/ATMO-862

After talking with @prosif @erbriones and @steve-gregory solution 3 was selected as the best of the bunch.




