### PR TITLE
Fix volume loading

### DIFF
--- a/troposphere/static/js/components/modals/volume/VolumeCreateModal.react.js
+++ b/troposphere/static/js/components/modals/volume/VolumeCreateModal.react.js
@@ -265,7 +265,7 @@ define(
               </div>
 
               <div className='form-group'>
-                <label htmlFor='volumeSize' className="col-sm-3 control-label">Volume Size</label>
+                <label htmlFor='volumeSize' className="col-sm-3 control-label">Volume Size (GB)</label>
                 <div className="col-sm-9">
                   <input type="number" className="form-control" value={size} onChange={this.onVolumeSizeChange}/>
                 </div>

--- a/troposphere/static/js/components/projects/detail/resources/ButtonBar.react.js
+++ b/troposphere/static/js/components/projects/detail/resources/ButtonBar.react.js
@@ -59,6 +59,7 @@ define(function (require) {
             isVisible={context.profile.get('is_superuser') && this.props.isVisible}
           />
           <ResourceActionButtons
+            onUnselect={this.props.onUnselect}
             previewedResource={this.props.previewedResource}
             project={this.props.project}
           />

--- a/troposphere/static/js/components/projects/detail/resources/InstanceActionButtons.react.js
+++ b/troposphere/static/js/components/projects/detail/resources/InstanceActionButtons.react.js
@@ -30,6 +30,7 @@ define(function (require) {
     },
 
     onDelete: function(){
+      this.props.onUnselect(this.props.instance);
       modals.InstanceModals.destroy({
         instance:this.props.instance,
         project: this.props.project

--- a/troposphere/static/js/components/projects/detail/resources/ProjectDetails.react.js
+++ b/troposphere/static/js/components/projects/detail/resources/ProjectDetails.react.js
@@ -151,6 +151,7 @@ define(function (require) {
             onReportSelectedResources={this.onReportSelectedResources}
             onRemoveSelectedResources={this.onRemoveSelectedResources}
             previewedResource={previewedResource}
+            onUnselect={this.onResourceDeselected}
             project={project}
           />
           <div className="resource-list">

--- a/troposphere/static/js/components/projects/detail/resources/ResourceActionButtons.react.js
+++ b/troposphere/static/js/components/projects/detail/resources/ResourceActionButtons.react.js
@@ -23,6 +23,7 @@ define(function (require) {
       if (resource instanceof Instance) {
         return (
           <InstanceActionButtons
+            onUnselect={this.props.onUnselect}
             instance={resource}
             project={project}
           />

--- a/troposphere/static/js/components/projects/detail/resources/ResourceActionButtons.react.js
+++ b/troposphere/static/js/components/projects/detail/resources/ResourceActionButtons.react.js
@@ -30,6 +30,7 @@ define(function (require) {
       }else if (resource instanceof Volume){
         return (
           <VolumeActionButtons
+            onUnselect={this.props.onUnselect}
             volume={resource}
             project={project}
           />

--- a/troposphere/static/js/components/projects/detail/resources/VolumeActionButtons.react.js
+++ b/troposphere/static/js/components/projects/detail/resources/VolumeActionButtons.react.js
@@ -22,6 +22,7 @@ define(function (require) {
     },
 
     onDelete: function(){
+      this.props.onUnselect(this.props.volume);
       modals.VolumeModals.destroy({
         volume: this.props.volume,
         project: this.props.project


### PR DESCRIPTION
Fixes bug where resource preview pane shows infinite loading after a volume is deleted. This was because the resource was never unselected after deletion, leading to a constant loading of a resource that no longer exists.