### PR TITLE
New nginx structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,7 @@ extras/newrelic
 
 # Emacs
 *~
+
+# generated files
+extras/nginx/site.conf
+extras/nginx/locations/tropo.conf

--- a/extras/nginx/Makefile
+++ b/extras/nginx/Makefile
@@ -14,6 +14,7 @@ KEY_FILE=iplantc.key
 KEY_PATH=/etc/ssl/private/$(KEY_FILE)
 
 TROPOSPHERE_PATH=/opt/dev/troposphere
+ASSETS_PATH=$(TROPOSPHERE_PATH)/troposphere/assets
 
 SITES_AVAILABLE_DIR=/etc/nginx/sites-available
 SITES_ENABLED_DIR=/etc/nginx/sites-enabled
@@ -45,7 +46,7 @@ setup: copy setup-tropo
 	sed -i "s#@DHPARAM#$(DHPARAM)#g" $(SITE_CONFIG)
 
 setup-tropo:
-	sed -i "s#@TROPOSPHERE_PATH#$(TROPOSPHERE_PATH)#g" $(TROPO_CONFIG)
+	sed -i "s#@ASSETS_PATH#$(ASSETS_PATH)#g" $(TROPO_CONFIG)
 
 $(COMBINED_CERT_PATH):
 	cat $(CERT_PATH) $(BUNDLE_PATH) > $(COMBINED_CERT_PATH)

--- a/extras/nginx/Makefile
+++ b/extras/nginx/Makefile
@@ -1,0 +1,80 @@
+SERVER_URL=$(shell hostname -f)
+
+CERT_DIR=/etc/ssl/certs
+CERT_FILE=iplantc.org.crt
+CERT_PATH=$(CERT_DIR)/$(CERT_FILE)
+
+COMBINED_CERT_FILE=iplantc_combined.crt
+COMBINED_CERT_PATH=$(CERT_DIR)/$(COMBINED_CERT_FILE)
+
+BUNDLE_FILE=gd_bundle.crt
+BUNDLE_PATH=$(CERT_DIR)/$(BUNDLE_FILE)
+
+KEY_FILE=iplantc.key
+KEY_PATH=/etc/ssl/private/$(KEY_FILE)
+
+TROPOSPHERE_PATH=/opt/dev/troposphere
+
+SITES_AVAILABLE_DIR=/etc/nginx/sites-available
+SITES_ENABLED_DIR=/etc/nginx/sites-enabled
+LOCATIONS_DIR=/etc/nginx/locations
+
+DHPARAM=/etc/ssl/certs/dhparam.pem
+KEY_SIZE=2048
+
+SITE_FILE=site.conf
+SITE_CONFIG=$(TROPOSPHERE_PATH)/extras/nginx/$(SITE_FILE)
+TROPO_FILE=tropo.conf
+TROPO_CONFIG=$(TROPOSPHERE_PATH)/extras/nginx/locations/$(TROPO_FILE)
+
+.PHONY: all clean
+
+all: deploy
+
+copy:
+	cp $(SITE_CONFIG).dist $(SITE_CONFIG)
+	cp $(TROPO_CONFIG).dist $(TROPO_CONFIG)
+
+$(DHPARAM):
+	openssl dhparam -out $(DHPARAM) $(KEY_SIZE)
+
+setup: copy setup-tropo
+	sed -i "s#@SERVER_URL#$(SERVER_URL)#g" $(SITE_CONFIG)
+	sed -i "s#@COMBINED_CERT_PATH#$(COMBINED_CERT_PATH)#g" $(SITE_CONFIG)
+	sed -i "s#@KEY_PATH#$(KEY_PATH)#g" $(SITE_CONFIG)
+	sed -i "s#@DHPARAM#$(DHPARAM)#g" $(SITE_CONFIG)
+
+setup-tropo:
+	sed -i "s#@TROPOSPHERE_PATH#$(TROPOSPHERE_PATH)#g" $(TROPO_CONFIG)
+
+$(COMBINED_CERT_PATH):
+	cat $(CERT_PATH) $(BUNDLE_PATH) > $(COMBINED_CERT_PATH)
+
+deploy: $(COMBINED_CERT_PATH) setup $(DHPARAM) unlink deploy-tropo
+	mkdir -p $(SITES_AVAILABLE_DIR)
+	mkdir -p $(SITES_ENABLED_DIR)
+	ln -fs $(TROPOSPHERE_PATH)/extras/nginx/$(SITE_FILE) $(SITES_AVAILABLE_DIR)/$(SITE_FILE)
+	ln -fs $(SITES_AVAILABLE_DIR)/$(SITE_FILE) $(SITES_ENABLED_DIR)/$(SITE_FILE)
+
+deploy-tropo:
+	mkdir -p $(LOCATIONS_DIR)
+	ln -fs $(TROPO_CONFIG) $(LOCATIONS_DIR)/$(TROPO_FILE)
+
+unlink: unlink-tropo
+	-rm $(SITES_ENABLED_DIR)/$(SITE_FILE)
+	-rm $(SITES_AVAILABLE_DIR)/$(SITE_FILE)
+
+unlink-tropo:
+	-rm $(LOCATIONS_DIR)/$(TROPO_FILE)
+
+test:
+	service nginx configtest
+
+restart:
+	service nginx restart
+
+clean: unlink
+	-rm $(COMBINED_CERT_PATH)
+	-rm $(SITE_CONFIG)
+	-rm $(TROPO_CONFIG)
+	-rm $(DHPARAM)

--- a/extras/nginx/locations/tropo.conf.dist
+++ b/extras/nginx/locations/tropo.conf.dist
@@ -1,0 +1,15 @@
+location /assets {
+    alias @TROPOSPHERE_PATH/troposphere/assets;
+}
+
+location ~^/(application|maintenance|login|logout|forbidden|version|cf2) {
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    uwsgi_pass troposphere;
+    include /etc/nginx/uwsgi_params;
+}
+
+location ~^/cas/(oauth2.0|service) {
+    uwsgi_pass unix:///tmp/troposphere.sock;
+    include /etc/nginx/uwsgi_params;
+}

--- a/extras/nginx/locations/tropo.conf.dist
+++ b/extras/nginx/locations/tropo.conf.dist
@@ -1,5 +1,5 @@
 location /assets {
-    alias @TROPOSPHERE_PATH/troposphere/assets;
+    alias @ASSETS_PATH;
 }
 
 location ~^/(application|maintenance|login|logout|forbidden|version|cf2) {

--- a/extras/nginx/site.conf.dist
+++ b/extras/nginx/site.conf.dist
@@ -1,0 +1,35 @@
+server {
+    listen 80;
+    server_name @SERVER_URL;
+    rewrite ^ https://$server_name$request_uri? permanent;
+}
+
+server {
+    listen   443;
+
+    server_name @SERVER_URL;
+    charset utf-8;
+
+    ssl    on;
+    ssl_certificate @COMBINED_CERT_PATH;
+    ssl_certificate_key @KEY_PATH;
+
+    ssl_ciphers 'AES128+EECDH:AES128+EDH';
+
+    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+    ssl_session_cache shared:SSL:10m;
+
+    # Cache OSCP protects against DoS attacks
+    ssl_stapling on;
+    ssl_stapling_verify on;
+    resolver 8.8.4.4 8.8.8.8 valid=300s;
+    resolver_timeout 10s;
+
+    ssl_prefer_server_ciphers on;
+    ssl_dhparam @DHPARAM;
+
+    add_header Strict-Transport-Security max-age=63072000;
+    add_header X-Frame-Options DENY;
+    add_header X-Content-Type-Options nosniff;
+    include locations/*.conf
+}


### PR DESCRIPTION
Add nginx configuration to support *standalone* version of troposphere as well as being installed side-by-side with atmosphere.

The site configuration generated is identical between atmosphere and troposphere.

For details on how this works see [#ATMO-PR 41](https://github.com/iPlantCollaborativeOpenSource/atmosphere/pull/41)