### PR TITLE
Add instance metrics

### DIFF
--- a/troposphere/settings/local.py.dist
+++ b/troposphere/settings/local.py.dist
@@ -29,6 +29,9 @@ SERVER_URL = 'https://SERVERNAME'
 ALLOWED_HOSTS = [SERVER_URL.replace("https://",""), "localhost"]
 
 
+# Uncomment to include instance metrics, 
+# the version of atmosphere must include the metrics endpoint 
+# SHOW_INSTANCE_METRICS = True
 
 # CAS
 CAS_SERVER = 'https://cas.example.com'

--- a/troposphere/static/css/app/instance.scss
+++ b/troposphere/static/css/app/instance.scss
@@ -3,6 +3,9 @@
 // todo: make this inherit from a resource version so we can reuse for volumes
 //
 
+// Styling for instance metrics component
+@import "instance_metrics";
+
 .instance-status-light {
   width: 12px;
   height: 12px;

--- a/troposphere/static/css/app/instance_metrics.scss
+++ b/troposphere/static/css/app/instance_metrics.scss
@@ -1,0 +1,112 @@
+// Styling for instance metrics component
+// js/components/projects/resources/instance/details/sections/InstanceMetricsSection.react.js
+
+#InstanceMetrics {
+    
+    // Colors 
+    $soft_black: #777;
+    $softer_black: #aaa;
+    $softest_black: #ddd;
+    $refresh_green: $brand-primary;
+    $refresh_hover_green: darken($brand-primary, 6.5%);
+    $light_red: #FADEE3;
+    $dark_red: brown;
+    $light_blue: #E9F0FC;
+    $dark_blue: darkblue;
+
+    // This height ensures that when the graph hides dom elements
+    // no scroll occurs, 
+    $graph_height: 400px;
+
+    // Default margin on elements
+    $margin_below: 15px;
+
+    margin: auto;
+    margin-bottom: $margin_below;
+    width: 600px;
+    text-align: center;
+
+    #controls {
+        text-align: right;
+        margin-bottom: $margin_below + 5px;
+        color: $soft_black;
+
+        .breadcrumb {
+            margin: 0px;
+            display: inline-block;
+        }
+        #refresh {
+            color: $softest_black;
+            top: 3px;
+        }
+        #refresh:not(.disabled) {
+            color: $refresh_green;
+        }
+        #refresh:hover:not(.disabled) {
+            color: $refresh_hover_green;
+            cursor: pointer;
+        }
+
+        #timestamp {
+            color: $softer_black;
+            display: inline-block;
+            padding: 5px;
+        }
+    }
+
+    #not-available {
+        text-align: center
+    }
+    #graphs {
+        text-align: center;
+        min-height: $graph_height;
+    }
+
+    #labeledXAxis {
+        margin-bottom: $margin_below;
+    }
+
+    .loading {
+        margin: 0 auto;
+        top: $graph_height / 4; 
+    }
+
+    .x.line {
+      stroke: $softer_black;
+    }
+
+    text {
+      fill: $soft_black;
+      font: 14px/1.4 Helvetica,arial,nimbussansl,liberationsans,freesans,clean,sans-serif,"Segoe UI Emoji","Segoe UI Symbol";            
+    }
+
+    svg {
+        margin-bottom: $margin_below;
+    }
+
+    .axis path,
+    .axis line {
+        fill: none;
+        stroke: $softer_black;
+    }
+    .line {
+      fill: none;
+      stroke: steelblue;
+      stroke-width: 2px;
+    }
+    .rx.area {
+        fill: $light_red;
+    }
+    .rx.line {
+      stroke: $dark_red;
+    }
+    .tx.area {
+      fill: $light_blue;
+    }
+    .tx.line {
+      stroke: $dark_blue;
+    }
+    .mean.line {
+      stroke: $softer_black;
+    }
+}

--- a/troposphere/static/js/components/projects/resources/instance/details/InstanceDetailsView.react.js
+++ b/troposphere/static/js/components/projects/resources/instance/details/InstanceDetailsView.react.js
@@ -46,8 +46,9 @@ define(function (require) {
               <InstanceDetailsSection instance={instance}/>
               <hr/>
               { 
-                show_instance_metrics ?  
-                <InstanceMetricsSection instance={instance}/> : <div></div>
+                typeof show_instance_metrics != "undefined" 
+                ? <InstanceMetricsSection instance={instance}/> 
+                : ""
               }
             </div>
             <div className="col-md-3">

--- a/troposphere/static/js/components/projects/resources/instance/details/InstanceDetailsView.react.js
+++ b/troposphere/static/js/components/projects/resources/instance/details/InstanceDetailsView.react.js
@@ -5,6 +5,7 @@ define(function (require) {
     BreadcrumbBar = require('components/projects/common/BreadcrumbBar.react'),
     InstanceInfoSection = require('./sections/InstanceInfoSection.react'),
     InstanceDetailsSection = require('./sections/InstanceDetailsSection.react'),
+    InstanceMetricsSection = require('./sections/InstanceMetricsSection.react'),
     InstanceActionsAndLinks = require('./actions/InstanceActionsAndLinks.react'),
     stores = require('stores');
 
@@ -44,6 +45,10 @@ define(function (require) {
               <hr/>
               <InstanceDetailsSection instance={instance}/>
               <hr/>
+              { 
+                show_instance_metrics ?  
+                <InstanceMetricsSection instance={instance}/> : <div></div>
+              }
             </div>
             <div className="col-md-3">
               <InstanceActionsAndLinks

--- a/troposphere/static/js/components/projects/resources/instance/details/sections/InstanceMetricsSection.react.js
+++ b/troposphere/static/js/components/projects/resources/instance/details/sections/InstanceMetricsSection.react.js
@@ -1,0 +1,23 @@
+define(function(require) {
+  var React = require('react'),
+    InstanceMetrics = require('./metrics/InstanceMetrics.react');
+
+  return React.createClass({ 
+    render: function() {
+
+    return (
+        <div>
+          <div className="resource-details-section section">
+            <h4 className="title">Instance Metrics</h4>
+          </div>
+          <div id="container" className="metrics"> 
+            <InstanceMetrics 
+              instance={ this.props.instance } 
+            />
+          </div> 
+        </div>
+    )
+    }
+
+  })
+});

--- a/troposphere/static/js/components/projects/resources/instance/details/sections/metrics/CPUGraph.js
+++ b/troposphere/static/js/components/projects/resources/instance/details/sections/metrics/CPUGraph.js
@@ -1,0 +1,24 @@
+define(function(require) {
+
+  var Graph = require("./Graph");
+
+  var CPUGraph = function(settings) {
+    var defaults = {
+      transform: "derivative"
+    }
+
+    for (prop in defaults) {
+      if (settings[prop] == undefined) {
+        settings[prop] = defaults[prop];
+      }
+    }
+
+    Graph.call(this, settings);
+  };
+
+  CPUGraph.prototype = Object.create(Graph.prototype);
+  CPUGraph.prototype.constructor = CPUGraph;
+
+  return CPUGraph;
+
+})

--- a/troposphere/static/js/components/projects/resources/instance/details/sections/metrics/Graph.js
+++ b/troposphere/static/js/components/projects/resources/instance/details/sections/metrics/Graph.js
@@ -1,0 +1,290 @@
+define(function(require) {
+
+  var d3 = require("d3");
+  var Utils = require("./Utils");
+
+  var Graph = function(config) {
+    config = config || {};
+
+    switch (config.timeframe) {
+      // this.points * this.resolution == 60
+      case "1 hour":
+        this.points = 60;
+        this.resolution = 1;
+        break;
+      // this.points * this.resolution == 60 * 24
+      case "1 day":
+        this.points = 6 * 24;
+        this.resolution = 10;
+        break;
+      // this.points * this.resolution == 60 * 24 * 7
+      case "1 week":
+        this.points = 24 * 7;
+        this.resolution = 60;
+        break;
+    }
+
+    var defaults = {
+      width: 600,
+      height: 100
+    }
+
+    for (prop in defaults) {
+      this[prop] = defaults[prop];
+    }
+    for (prop in config) {
+      this[prop] = config[prop];
+    }
+
+    this.element = document.createElement("div");
+    this.element.style.display = "none";
+    this.container.appendChild(this.element);
+  }
+
+  Graph.prototype = {};
+
+  Graph.prototype.create = function(onSuccess, onError) {
+    var me = this;
+    this.fetch(function(){
+      me.make()
+      onSuccess && onSuccess();
+    }, onError);
+  }
+  Graph.prototype.hide = function() {
+    this.element.style.display = "none";
+  }
+  Graph.prototype.show = function() {
+    this.element.style.display = "inline";
+  }
+  Graph.prototype.clear = function() {
+    var g = this.element;
+    while (g.lastChild) {
+      g.removeChild(g.lastChild);
+    }
+  }
+  Graph.prototype.fetch = function(onSuccess, onError) {
+    var me = this;
+    var urlParams =  {
+      field: this.type,
+      res: this.resolution,
+      size: this.points,
+    }
+
+    if (this.transform == "derivative") {
+      urlParams.fun = "perSecond";
+    }
+
+    Utils.fetch(this.uuid, urlParams, function(data) {
+      me.timestamp = Date.now();
+      me.data = data;
+      onSuccess();
+    }, onError);
+  }
+
+  Graph.prototype.make = function() {
+    var me = this;
+    var data = this.data
+      var graphDom = this.element;
+
+    var yAxisWidth = 60,
+      margin = {top: 10, right: 20, bottom: 5, left: yAxisWidth},
+      width = this.width - margin.left - margin.right,
+      height = this.height - margin.top - margin.bottom;
+
+    getX = Utils.get("x");
+    getY = Utils.get("y");
+
+    var yMax = d3.max(data, getY);
+    var yMean = d3.mean(data, getY) || 0;
+    var xMax = d3.max(data, getX);
+    var xMin = d3.min(data, getX);
+
+    var showRelative = false;
+
+    var x = d3.scale.linear()
+      .range([0, width])
+      .domain(d3.extent(data, getX));
+
+    var y = d3.scale.linear()
+      .range([height, 0])
+      .domain([0, (showRelative ? 1.2 * yMax : 1)]);
+
+    var line = d3.svg.line()
+      .x(function(d) { return x(d.x); })
+      .y(function(d) { return y(d.y); });
+
+    var area = d3.svg.area()
+      .x(function(d) { return x(d.x); })
+      .y0(height)
+      .y1(function(d) { return y(d.y); });
+
+    var svg = d3.select(graphDom).append("svg")
+      .attr("width", me.width)
+      .attr("height", me.height)
+      .append("g")
+      .attr("transform", "translate(" + margin.left + "," + margin.top + ")");
+
+    var delta = 0.2;
+    var showMax = yMax > delta &&
+      yMax < 1 - delta;
+
+    var showMean =
+      // if mean-label enough below max label
+      yMean < yMax - delta * yMax &&
+      // if mean-label enough above 0
+      yMean > (showRelative ? delta * yMax : delta)
+
+      if (showMean) {
+        svg.append("path")
+          .datum([
+              { x: xMin, y: yMean },
+              { x: xMax, y: yMean }
+              ])
+          .style("stroke-dasharray", ("3, 3"))
+          .attr("class", "metrics mean line")
+          .attr("d", line)
+      }
+
+    svg.append("path")
+      .datum(data)
+      .attr("class", "metrics rx area")
+      .attr("d", area)
+
+      var xAxis = d3.svg.line()
+      .x(function(d) { return x(d.x); })
+      .y(function(d) { return y(0); });
+
+    svg.append("path")
+      .datum(data)
+      .attr("class", "metrics x line")
+      .attr("d", xAxis)
+
+      svg.append("path")
+      .datum(data)
+      .attr("class", "metrics rx line")
+      .attr("d", line)
+
+      // Determine what ticks to display on y axis
+      var ticks = [0];
+    if (showMean) ticks.push(yMean);
+    if (showMax) ticks.push(yMax);
+    if (showRelative)
+      ticks.push(yMax);
+    else
+      ticks.push(1);
+
+    var yAxis = d3.svg.axis()
+      .tickFormat(d3.format(showRelative ? ".1%" : ".0%"))
+      .tickValues(ticks)
+      .scale(y)
+      .orient("left");
+
+    svg.append("g")
+      .attr("class", "metrics y axis")
+      .call(yAxis)
+
+      svg.append("text")
+      .attr("class", "metrics x axis")
+      .attr("style", "text-anchor:end")
+      .attr("x", width)
+      .attr("y", 0)
+      .attr("dy", ".32em")
+      .text( me.type == "cpu" ? "cpu usage": "memory usage")
+  };
+
+  // Horizontal labeled x axis
+  Graph.prototype.makeAxis = function() {
+
+    // Cpu/Mem Graph data || Network Graph data
+    var data = this.data || this.lower.data;
+
+    var graphDom = this.element;
+
+    // Height of this axis container
+    var metricsAxisHeight = 30;
+
+    // Define container margins
+    var yAxisWidth = 60,
+      margin = {top: 5, right: 20, bottom: 5, left: yAxisWidth};
+
+    // Width/height of axis
+    var width = this.width - margin.left - margin.right,
+      height = metricsAxisHeight - margin.top - margin.bottom;
+
+    var svg = d3.select(graphDom).append("svg")
+      .attr("id", "labeledXAxis")
+      .attr("class", "axis path")
+      .attr("width", this.width)
+      .attr("height", metricsAxisHeight)
+      .append("g")
+      .attr("transform",
+          "translate(" + margin.left + "," + margin.top + ")");
+
+    var x = d3.time.scale()
+      .range([0, width])
+      .domain(d3.extent(data, getX));
+
+    var xAxis = d3.svg.axis()
+      .scale(x)
+      .orient("bottom")
+
+    var total_mins = this.resolution * this.points;
+    if (total_mins == 60) {
+      xAxis.ticks(6).tickFormat(function(){
+        return d3.time.format("%_I:%M%p")
+        .apply(d3.time, arguments)
+        .toLowerCase()
+      })
+    } else if (total_mins ==  60 * 24) {
+      xAxis.ticks(12).tickFormat(function(){
+        return d3.time.format("%_I%p")
+        .apply(d3.time, arguments)
+        .toLowerCase()
+      })
+    } else if (total_mins == 60 * 24 * 7) {
+      xAxis.ticks(7).tickFormat(d3.time.format("%a"));
+    }
+
+    svg.append("g")
+      .call(xAxis)
+
+  };
+  Graph.prototype.makeTimestamp = function() {
+
+    var timestamp = this.timestamp;
+
+    var graphDom = this.element;
+
+    // Height of the timestamp container
+    var tsContainerHeight = 30;
+
+    // Define container margins
+    var yAxisWidth = 50,
+      margin = {top: 0, right: 20, bottom: 0, left: yAxisWidth};
+
+    // Width/height of axis
+    var width = this.width - margin.left - margin.right,
+      height = tsContainerHeight - margin.top - margin.bottom;
+
+    var svg = d3.select(graphDom).append("svg")
+      .attr("id", "updateTimestamp")
+      .attr("width", this.width)
+      .attr("height", tsContainerHeight)
+      .append("g")
+      .attr("transform",
+          "translate(" + margin.left + "," + margin.top + ")");
+
+    svg.append("text")
+      .attr("class", "metrics x axis")
+      .attr("style", "text-anchor:end")
+      .attr("width", this.width)
+      .attr("height", height)
+      .attr("x", width)
+      .attr("dy", (height / 2) + "px")
+      .text("Updated: " + timestamp)
+
+  };
+
+  return Graph;
+
+})

--- a/troposphere/static/js/components/projects/resources/instance/details/sections/metrics/GraphController.js
+++ b/troposphere/static/js/components/projects/resources/instance/details/sections/metrics/GraphController.js
@@ -1,0 +1,79 @@
+define(function(require) {
+
+  // Metrics utils
+  var Store = require('./Store'),
+    CPUGraph = require('./CPUGraph'),
+    MemoryGraph = require('./MemoryGraph'),
+    NetworkGraph = require('./NetworkGraph');
+
+  var GraphController = function(config) {
+    this.container = config.container;
+    this.width = config.width;
+    this.store = new Store();
+    this.graphs = [];
+  }
+
+  GraphController.prototype.switch = function(settings, onSuccess, onError) {
+    var me = this;
+
+    // Forcing a refresh is equivalent to emptying the store so that data
+    // must be fetched
+    if (settings.refresh)
+      this.store.removeAll();
+
+    var key = {
+      uuid: settings.uuid,
+      timeframe: settings.timeframe
+    }
+
+    var graphs = this.store.get(key);
+
+    // Fetch data/build graphs for a timeframe
+    if (graphs == undefined) {
+
+      var graphs = [["cpu", CPUGraph], ["mem", MemoryGraph], ["net", NetworkGraph]];
+      graphs = graphs.map(function(data) {
+        return new data[1]({
+          type: data[0],
+          uuid: settings.uuid,
+          container: me.container,
+          width: me.width,
+          timeframe: settings.timeframe
+        })
+      });
+
+      me.store.set(key, graphs)
+
+      // Hide current graphs
+      me.graphs.forEach(function(g){ g.hide(); })
+
+      // Show spinning loader
+      document.querySelector("#container.metrics .loading").style.display = "inherit";
+
+      // Exit here to debug css spinning loader
+      // return;
+
+      graphs[0].create(function(){
+        graphs[1].create(function() {
+          graphs[2].create(function() {
+
+            // Hide spinning loader
+            document.querySelector("#container.metrics .loading").style.display = "none";
+            graphs[2].makeAxis();
+            graphs.forEach(function(g){ g.show(); })
+            me.graphs = graphs;
+            onSuccess && onSuccess();
+          }, onError)
+        }, onError)
+      }, onError)
+
+    } else {
+      me.graphs.forEach(function(g){ g.hide(); })
+      graphs.forEach(function(g){ g.show(); })
+      me.graphs = graphs;
+      onSuccess && onSuccess();
+    }
+  }
+
+  return GraphController;
+});

--- a/troposphere/static/js/components/projects/resources/instance/details/sections/metrics/InstanceMetrics.react.js
+++ b/troposphere/static/js/components/projects/resources/instance/details/sections/metrics/InstanceMetrics.react.js
@@ -1,0 +1,130 @@
+define(function(require) {
+  var React = require('react'),
+    GraphController = require('./GraphController'),
+    TimeframeBreadcrumb = require('./TimeframeBreadcrumb.react'),
+    RefreshComponent = require('./RefreshComponent.react');
+
+  return React.createClass({
+
+    getInitialState: function() {
+      var me = this;
+
+      return {
+        controller: null,
+        uuid: this.props.instance.get("uuid"),
+        timeframe: "1 hour",
+        timestamp: new Date(),
+
+        // Individual graph widths
+        graphWidth: 550,
+
+        // Determine if service is available
+        //   null: service has no status (loading)
+        //   false: metrics api failed
+        //   true: metrics api success
+        available: null,
+
+        // Restrict refreshing
+        canRefresh: false,
+
+        // Set refresh interval to 1 minute
+        refreshDelay: 60 * 1000,
+      };
+    },
+    onSuccess: function() {
+
+      // Conviluted way to fetch timestamp from store, off first graph
+      var timestamp = this.state.controller.store.get({
+        uuid: this.state.uuid,
+        timeframe: this.state.timeframe
+      })[0].timestamp;
+
+      // Called after successfully fetching data
+      this.setState({
+        available: true,
+        timestamp: timestamp,
+      });
+    },
+
+    onError: function() {
+      // Called after failing to fetch data
+      //throw new Error("metrics could not be fetched");
+      this.setState({ available: false });
+    },
+    componentDidMount: function() {
+      // Kickstart graphs since d3 needs a finished dom
+      this.setState({
+        controller: new GraphController({
+          container: document.querySelector("#graphs"),
+          width: this.state.graphWidth,
+        }),
+      }, this.refresh)
+    },
+
+    refresh: function() {
+      var me = this;
+
+      // Disable refresh button
+      me.setState({
+        canRefresh: false,
+      }, function() {
+        this.state.controller.switch({
+          uuid: this.state.uuid,
+          timeframe: this.state.timeframe,
+          refresh: true,
+        }, this.onSuccess, this.onError);
+      })
+    },
+
+    onTimeFrameClick : function(e) {
+      this.setState({
+        timeframe: e.target.innerHTML
+      }, function(){
+        this.state.controller.switch({
+          uuid: this.state.uuid,
+          timeframe: this.state.timeframe
+        }, this.onSuccess, this.onError);
+      });
+    },
+
+    onRefreshClick: function() {
+      if (this.state.canRefresh)
+        this.refresh();
+    },
+
+    render: function() {
+     // available is true or still waiting for network request
+     if (this.state.available || this.state.available === null) {
+
+       return (
+         <div id="InstanceMetrics">
+           <div
+            id="controls"
+            style={{
+              display : this.state.available ? "inherit" : "none"
+            }}>
+            <TimeframeBreadcrumb
+               timeframe={ this.state.timeframe }
+               onTimeFrameClick={ this.onTimeFrameClick }
+            />
+            <RefreshComponent
+              delay={ this.state.refreshDelay }
+              timestamp={ this.state.timestamp }
+              onRefreshClick={ this.refresh }
+            />
+          </div>
+          <div id="container" className="metrics">
+             <div className="loading"></div>
+             <div id="graphs"></div>
+          </div>
+        </div>
+      )
+     }
+
+     // available is explicitly false
+     return (<div id="not-available">Instance metrics not available</div>)
+     }
+
+  });
+
+});

--- a/troposphere/static/js/components/projects/resources/instance/details/sections/metrics/MemoryGraph.js
+++ b/troposphere/static/js/components/projects/resources/instance/details/sections/metrics/MemoryGraph.js
@@ -1,0 +1,23 @@
+define(function(require) {
+
+  var Graph = require("./Graph");
+
+  var MemoryGraph = function(settings) {
+    var defaults = {
+      transform: "total"
+    }
+
+    for (prop in defaults) {
+      if (settings[prop] == undefined) {
+        settings[prop] = defaults[prop];
+      }
+    }
+
+    Graph.call(this, settings);
+  };
+
+  MemoryGraph.prototype = Object.create(Graph.prototype);
+  MemoryGraph.prototype.constructor = MemoryGraph;
+
+  return MemoryGraph;
+})

--- a/troposphere/static/js/components/projects/resources/instance/details/sections/metrics/NetworkGraph.js
+++ b/troposphere/static/js/components/projects/resources/instance/details/sections/metrics/NetworkGraph.js
@@ -1,0 +1,208 @@
+define(function(require) {
+
+   var d3 = require("d3");
+   var Graph = require("./Graph");
+   var Utils = require("./Utils");
+
+  var NetworkGraph = function(settings) {
+    var defaults = {
+      type : "net",
+      upper : {
+      query: "*.*." + settings.uuid + ".rx",
+      type: "rx",
+      data: [],
+      transform: "derivative",
+      },
+      lower : {
+      query: "*.*." + settings.uuid + ".tx",
+      type: "tx",
+      data: [],
+      transform: "derivative",
+      }
+    }
+
+    for (prop in defaults) {
+      this[prop] = defaults[prop];
+    }
+
+    for (prop in settings) {
+      this[prop] = settings[prop];
+    }
+
+    Graph.call(this, settings);
+  };
+
+  NetworkGraph.prototype = Object.create(Graph.prototype);
+  NetworkGraph.prototype.constructor = NetworkGraph;
+
+  NetworkGraph.prototype.fetch = function(onSuccess, onError) {
+    var me = this;
+    var series = [ this.upper, this.lower ];
+
+    series.forEach(function(s) {
+      s.urlParams = {
+        field: s.type,
+        res: me.resolution,
+        size: me.points,
+      };
+
+      if (s.transform == "derivative")
+        s.urlParams.fun = "perSecond";
+      else
+        s.urlParams.fun = "";
+    });
+
+    Utils.fetch(me.uuid, series[0].urlParams, function(data) {
+      series[0].data = data;
+      Utils.fetch(me.uuid, series[1].urlParams, function(data) {
+        series[1].data = data;
+        me.timestamp = Date.now();
+        onSuccess.call(me);
+      }, onError)
+    }, onError)
+  }
+
+  NetworkGraph.prototype.make = function() {
+      var me = this;
+      var graphDom = me.element;
+      var data = me.lower.data;
+      var rxData = me.upper.data;
+      var txData = me.lower.data;
+
+      var metricsAxisHeight = 20,
+        yAxisWidth = 60,
+        margin = {top: 10, right: 20, bottom: 5, left: yAxisWidth},
+        width = this.width - margin.left - margin.right,
+        height = this.height - margin.top - margin.bottom;
+
+      var yMax = d3.max([ d3.max(rxData, getY)
+              , d3.max(txData, getY)
+               , 1.2 * 1024]) || 0;
+      var yMeanUpper = d3.max([ d3.mean(rxData, getY)
+               , d3.mean(rxData, getY)]) || 0;
+      var yMeanLower = d3.max([ d3.mean(txData, getY)
+               , d3.mean(txData, getY)]) || 0;
+
+
+      var xMax = d3.max(data, getX);
+      var xMin = d3.min(data, getX);
+
+      var x = d3.time.scale()
+        .range([0, width])
+        .domain(d3.extent(data, getX));
+
+      var y = d3.scale.linear()
+        .range([height, 0])
+        .domain([-1.2 * yMax,  1.2 * yMax]);
+
+      var line = d3.svg.line()
+        .x(function(d) { return x(d.x); })
+        .y(function(d) { return y(d.y); });
+
+      var area = d3.svg.area()
+      .x(function(d) { return x(d.x); })
+      .y0(height/2)
+      .y1(function(d) { return y(d.y); });
+
+      var lineReflect = d3.svg.line()
+        .x(function(d) { return x(d.x); })
+        .y(function(d) { return - y(d.y); });
+
+      var areaReflect = d3.svg.area()
+      .x(function(d) { return x(d.x); })
+      .y0(height/2)
+      .y1(function(d) { return -y(d.y) + height; })
+
+      var svg = d3.select(graphDom).append("svg")
+        .attr("width", me.width)
+        .attr("height", me.height)
+        .append("g")
+        .attr("transform", "translate(" + margin.left + "," + margin.top + ")")
+
+
+      var delta = 0.2;
+      var showMeanUpper =
+         yMeanUpper < yMax - delta * yMax &&
+         yMeanUpper > delta * yMax;
+
+      var showMeanLower =
+         yMeanLower < yMax - delta * yMax &&
+         yMeanLower > delta * yMax;
+
+      if (showMeanUpper && showMeanLower) {
+        svg.append("path")
+        .datum([
+          { x: xMin, y: yMeanUpper },
+          { x: xMax, y: yMeanUpper }
+        ])
+        .style("stroke-dasharray", ("3, 3"))
+        .attr("class", "metrics mean line")
+        .attr("d", line)
+
+        svg.append("path")
+        .datum([
+          { x: xMin, y: -yMeanLower },
+          { x: xMax, y: -yMeanLower }
+        ])
+        .style("stroke-dasharray", ("3, 3"))
+        .attr("class", "metrics mean line")
+        .attr("d", line)
+      }
+
+      var middleAxis = d3.svg.line()
+        .x(function(d) { return x(d.x); })
+        .y(function(d) { return y(0); });
+
+      svg.append("path")
+      .datum(rxData)
+      .attr("class", "metrics rx area")
+      .attr("d", area);
+
+      svg.append("path")
+      .datum(txData)
+      .attr("class", "metrics tx area")
+      .attr("d", areaReflect);
+
+      svg.append("path")
+      .datum(txData)
+      .attr("class", "metrics tx line")
+      .attr("d", lineReflect)
+      .attr("transform", "translate(0," + height + ")")
+
+      svg.append("path")
+      .datum(rxData)
+      .attr("class", "metrics rx line")
+      .attr("d", line);
+
+      var yTick = Math.max(1024, yMax)
+      var yAxis = d3.svg.axis()
+        .tickFormat(function(d){
+          return Utils.bytesToString(Math.abs(d));
+        })
+        .tickValues([ -yTick, yTick, 0 /*yMeanUpper, -yMeanLower*/])
+        .scale(y)
+        .orient("left");
+
+      svg.append("g")
+      .attr("class", "metrics y axis")
+      .call(yAxis)
+
+      svg.append("text")
+      .attr("class", "metrics x axis")
+      .attr("style", "text-anchor:end")
+      .attr("x", width)
+      .attr("y", 0)
+      .attr("dy", ".32em")
+      .text("data in")
+
+      svg.append("text")
+      .attr("class", "metrics x axis")
+      .attr("style", "text-anchor:end")
+      .attr("x", width)
+      .attr("y", height)
+      .attr("dy", ".32em")
+      .text("data out")
+  }
+
+  return NetworkGraph;
+})

--- a/troposphere/static/js/components/projects/resources/instance/details/sections/metrics/RefreshComponent.react.js
+++ b/troposphere/static/js/components/projects/resources/instance/details/sections/metrics/RefreshComponent.react.js
@@ -1,0 +1,60 @@
+define(function(require) {
+  var React = require('react'),
+    moment = require('moment');
+
+  return React.createClass({
+
+    componentDidMount: function() {
+       var me = this;
+
+       // Refresh the timestamp, update whether refresh is active, every
+       // updateInterval
+       var updateInterval = 3 * 1000;
+
+       var id = setInterval(function() {
+         if (!me.isMounted()) {
+           window.clearInterval(id);
+        } else {
+           me.forceUpdate();
+        }
+       }, updateInterval);
+    },
+
+    getTimeMessage: function() {
+      var a = moment(this.props.timestamp);
+      var b = moment(Date.now());
+      var diff = b.diff(a, "seconds");
+
+      // momentjs js is eager in saying a minute ago, this way when a
+      // minute has passed getTimeMessage emits 'Updated a minute ago' in
+      // sync with the refresh being available. (also in sync with fresh
+      // metrics being available
+      if (diff > 44 && diff < 60) {
+        return "Updated a few seconds ago"
+      }
+      return "Updated " + a.fromNow();
+    },
+
+    render: function() {
+
+     var canRefresh =
+       (Date.now() - this.props.timestamp) > this.props.delay;
+
+     var controlsClass =
+       "glyphicon glyphicon-refresh" + (canRefresh ? "" : " disabled");
+
+     return (
+         <div>
+           <span
+             id="refresh"
+             className={ controlsClass }
+             onClick={ canRefresh ? this.props.onRefreshClick : "" }>
+           </span>
+           <div id="timestamp">{ this.getTimeMessage() }</div>
+         </div>
+     )
+     }
+
+  });
+
+})

--- a/troposphere/static/js/components/projects/resources/instance/details/sections/metrics/Store.js
+++ b/troposphere/static/js/components/projects/resources/instance/details/sections/metrics/Store.js
@@ -1,0 +1,28 @@
+define(function(require) {
+
+  // Never return the inner datastruct data. This module depends on that assumption.
+  var Store = function() {
+    var data = {};
+    glob = data;
+
+    this.has = function(key) {
+      return data[JSON.stringify(key)] != undefined;
+    }
+    this.get = function(key) {
+      return data[JSON.stringify(key)];
+    }
+    this.set = function(key, obj) {
+      data[JSON.stringify(key)] = obj;
+    }
+    this.remove = function(key) {
+      delete data[JSON.stringify(key)];
+    }
+    this.removeAll = function(key) {
+      data = {};
+    }
+
+  }
+
+  return Store;
+
+});

--- a/troposphere/static/js/components/projects/resources/instance/details/sections/metrics/TimeframeBreadcrumb.react.js
+++ b/troposphere/static/js/components/projects/resources/instance/details/sections/metrics/TimeframeBreadcrumb.react.js
@@ -1,0 +1,31 @@
+define(function(require) {
+  var React = require('react');
+
+  return React.createClass({
+    render: function() {
+      var me = this;
+
+      var breadcrumbs = ["1 hour", "1 day", "1 week"].map(function(content) {
+        var selectableElement = React.DOM.li({}, React.DOM.a({
+          href: "javascript:void(0);",
+          onClick: me.props.onTimeFrameClick,
+          ref: "selectedAnchorContent"
+        }, content));
+
+        var selectedElement = React.DOM.li({
+          id: content,
+          className: "active metrics"
+        }, content)
+
+        if (content == me.props.timeframe) {
+          return selectedElement
+        }
+        return selectableElement
+      });
+
+      return (
+          <div className="metrics breadcrumb">{ breadcrumbs }</div>
+           )
+    }
+  });
+})

--- a/troposphere/static/js/components/projects/resources/instance/details/sections/metrics/Utils.js
+++ b/troposphere/static/js/components/projects/resources/instance/details/sections/metrics/Utils.js
@@ -1,0 +1,67 @@
+define(function(require) {
+
+  var fetch = function(uuid, urlParams, onSuccess, onError) {
+    var api = API_V2_ROOT + "/metrics";
+
+    // Request extra datapoints to account for occasional null data at
+    // front/end
+    var extra = 2;
+
+    var req = api + "/" + uuid + ".json" +
+      "?field=" + urlParams.field +
+      "&res="   + urlParams.res   +
+      "&size="  + (urlParams.size + extra);
+
+    if (urlParams.fun)
+      req += "&fun=" + urlParams.fun;
+
+    d3.json(req)
+      .header("Authorization", "Token " + access_token)
+      .get(function(error, json) {
+
+        if (!json) return onError && onError();
+        var data = json[0].datapoints
+
+        // Trim initial/final null values
+        if (data[0][0] == null)
+          data.splice(0, 1);
+        data.length = urlParams.size;
+
+        onSuccess(data.map(function(arr) {
+          return { x: arr[1] * 1000, y: arr[0] };
+        }));
+
+      })
+  }
+
+
+  var bytesToString = function (bytes) {
+    var fmt = d3.format('.0f'),
+      isNegative = bytes < 0,
+      output = "";
+
+    bytes = Math.abs(bytes);
+    if (bytes < 1024) {
+      output = fmt(bytes) + 'B';
+    } else if (bytes < 1024 * 1024) {
+      output = fmt(bytes / 1024) + 'kB';
+    } else if (bytes < 1024 * 1024 * 1024) {
+      output = fmt(bytes / 1024 / 1024) + 'MB';
+    } else {
+      output = fmt(bytes / 1024 / 1024 / 1024) + 'GB';
+    }
+    return isNegative ? "-" + output : output;
+  }
+
+  var get = function(name) {
+    return function(obj) {
+      return obj[name];
+    };
+  };
+
+  return {
+    get: get,
+    fetch: fetch,
+    bytesToString: bytesToString
+  }
+})

--- a/troposphere/templates/index.html
+++ b/troposphere/templates/index.html
@@ -75,7 +75,6 @@
 
         {% if show_instance_metrics %}
             var show_instance_metrics = true;
-            var hyper_stats_url = "{{ hyper_stats_url }}";
         {%  else %}
             var show_instance_metrics = false;
         {% endif %}

--- a/troposphere/templates/index.html
+++ b/troposphere/templates/index.html
@@ -72,6 +72,14 @@
         {%  else %}
             var show_troposphere_only = false;
         {% endif %}
+
+        {% if show_instance_metrics %}
+            var show_instance_metrics = true;
+            var hyper_stats_url = "{{ hyper_stats_url }}";
+        {%  else %}
+            var show_instance_metrics = false;
+        {% endif %}
+
     </script>
 
     <!-- Application dependencies -->

--- a/troposphere/views/app.py
+++ b/troposphere/views/app.py
@@ -1,4 +1,5 @@
 import json
+import logging
 
 from django.conf import settings
 from django.http import HttpResponse
@@ -95,6 +96,15 @@ def _handle_authenticated_application_request(request, maintenance_records):
 
     if hasattr(settings, "API_V2_ROOT"):
         template_params['API_V2_ROOT'] = settings.API_V2_ROOT
+
+    template_params["show_instance_metrics"] = getattr(settings, "SHOW_INSTANCE_METRICS", False)
+
+    if settings.SHOW_INSTANCE_METRICS:
+        try: 
+            template_params["hyper_stats_url"] = settings.HYPER_STATS_URL
+        except AttributeError:
+            logger.warn("SHOW_INSTANCE_METRICS disabled: requires HYPER_STATS_URL to be set")
+            template_params["show_instance_metrics"] = False
 
     user_preferences, created = UserPreferences.objects.get_or_create(user=request.user)
 

--- a/troposphere/views/app.py
+++ b/troposphere/views/app.py
@@ -69,14 +69,16 @@ def _handle_public_application_request(request, maintenance_records, disabled_lo
 
 
 def _handle_authenticated_application_request(request, maintenance_records):
-    show_troposphere_only = hasattr(settings, "SHOW_TROPOSPHERE_ONLY") and settings.SHOW_TROPOSPHERE_ONLY is True
+    show_troposphere_only = getattr(settings, "SHOW_TROPOSPHERE_ONLY", False)
+    show_instance_metrics = getattr(settings, "SHOW_INSTANCE_METRICS", False)
 
     template_params = {
         'access_token': request.session.get('access_token'),
         'emulator_token': request.session.get('emulator_token'),
         'emulated_by': request.session.get('emulated_by'),
         'records': maintenance_records,
-        'show_troposphere_only': show_troposphere_only
+        'show_troposphere_only': show_troposphere_only,
+        'show_instance_metrics': show_instance_metrics
     }
 
     template_params['THEME_HEADER_TEXT'] = settings.THEME_HEADER_TEXT
@@ -96,15 +98,6 @@ def _handle_authenticated_application_request(request, maintenance_records):
 
     if hasattr(settings, "API_V2_ROOT"):
         template_params['API_V2_ROOT'] = settings.API_V2_ROOT
-
-    template_params["show_instance_metrics"] = getattr(settings, "SHOW_INSTANCE_METRICS", False)
-
-    if settings.SHOW_INSTANCE_METRICS:
-        try: 
-            template_params["hyper_stats_url"] = settings.HYPER_STATS_URL
-        except AttributeError:
-            logger.warn("SHOW_INSTANCE_METRICS disabled: requires HYPER_STATS_URL to be set")
-            template_params["show_instance_metrics"] = False
 
     user_preferences, created = UserPreferences.objects.get_or_create(user=request.user)
 

--- a/troposphere/views/auth.py
+++ b/troposphere/views/auth.py
@@ -89,6 +89,9 @@ def cas_oauth_service(request):
     code_service_ticket = request.GET['code']
     access_token, expiry_date = cas_oauth_client.get_access_token(code_service_ticket)
 
+    if hasattr(settings, "CAS_DEV_TOKEN"):
+        access_token = settings.CAS_DEV_TOKEN
+
     if not access_token:
         #code_service_ticket has expired (They don't last very long...)
         #Lets try again (Redirect to OAuth-wrapped CAS login)


### PR DESCRIPTION
This is the initial release of instance metrics using hyper-stats. It display three graphs (cpu,mem, network) on the instance details pages. It requires the following setting in local.py:
```
SHOW_INSTANCE_METRICS = True
```
It will default to false, otherwise.

If requests to atmo's metrics api fail while the above setting is true, then the instance details page will report that instance metrics are unavailable.
