### PR TITLE
Include d3, bootstrap-sass master

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,9 @@
   "dependencies": {
     "babel-runtime": "^5.8.12",
     "backbone": "^1.2.1",
-    "bootstrap-sass": "^3.3.5",
+    "bootstrap-sass": "https://github.com/twbs/bootstrap-sass.git",
     "crypto-js": "^3.1.5",
+    "d3": "^3.5.6",
     "highcharts-commonjs": "^4.1.7-1",
     "jquery": "^2.1.3",
     "moment": "^2.10.6",


### PR DESCRIPTION
imports necessary for instance metrics that were forgotten (:.|)

bootstrap-sass is pointing to github while we are awaiting a fix to a
sass bug (https://github.com/twbs/bootstrap-sass/issues/919)