### PR TITLE
Filter instances from different providers when attaching volume

### DIFF
--- a/troposphere/static/js/components/modals/ModalHelpers.js
+++ b/troposphere/static/js/components/modals/ModalHelpers.js
@@ -1,8 +1,9 @@
 define(
   [
-    'react'
+    'react',
+    'underscore'
   ],
-  function (React) {
+  function (React, _) {
 
     function onCancel(){
       // Important! We need to un-mount the component so it un-registers from Stores and
@@ -13,12 +14,13 @@ define(
     return {
 
       renderModal: function(ModalComponent, props, cb){
-        props = props || {};
-        var modal = React.createFactory(ModalComponent)(props);
-        modal.props.onConfirm = cb;
-        modal.props.onCancel = onCancel;
-        modal.props.handleHidden = onCancel;
+        props = _.extend(props || {}, {
+          onConfirm: cb,
+          onCancel: onCancel,
+          handleHidden: onCancel,
+        });
 
+        var modal = React.createElement(ModalComponent, props);
         React.render(modal, document.getElementById('modal'));
       }
 

--- a/troposphere/static/js/components/modals/volume/VolumeAttachModal.react.js
+++ b/troposphere/static/js/components/modals/volume/VolumeAttachModal.react.js
@@ -53,12 +53,17 @@ define(
       // ----------------
       //
 
-      getState: function(project) {
-        var project = this.props.project,
-            state = {
-              instances: stores.ProjectInstanceStore.getInstancesFor(project),
-              instanceId: null
-            };
+      getState: function() {
+        if (this.props.project === undefined)
+            throw new Error("Volume attach modal lacks a project");
+
+        var project = this.props.project;
+
+        // TODO: remove ambiguity between state/this.state
+        var state = {
+            instances: stores.ProjectInstanceStore.getInstancesFor(project),
+            instanceId: null
+        };
 
         this.state = this.state || {};
 
@@ -108,6 +113,7 @@ define(
       confirm: function () {
         this.hide();
         var instance = this.state.instances.get(this.state.instanceId);
+        if (instance === undefined) throw new Error("Instance not found in modal's instances store");
         this.props.onConfirm(instance);
       },
 
@@ -153,11 +159,10 @@ define(
                 <div className='form-group'>
                   <p>
                     <strong>Uh oh! </strong>
-                    {
-                      "It looks like you don't have any instances in this project that you can attach the volume " +
-                      "to. Volumes can only be attached to instances that are in the same project and on the same " +
-                      "provider as the volume."
-                    }
+                    It looks like you don't have any instances in this project
+                    that you can attach the volume to. Volumes can only be
+                    attached to instances that are in the <strong>same project</strong> and
+                    on the <strong>same provider</strong> as the volume.
                   </p>
                   <p>
                     {
@@ -216,14 +221,14 @@ define(
 
       render: function () {
         var project = this.props.project,
-            instances = stores.ProjectInstanceStore.getInstancesFor(project),
+            instances = this.state.instances,
             content;
 
-        if(!instances) {
+        if (!instances) {
           content = this.renderLoadingContent();
-        }else if(instances.length <= 0){
+        } else if (instances.length <= 0) {
           content = this.renderAttachRulesContent();
-        }else{
+        } else {
           content = this.renderAttachVolumeContent(instances);
         }
 

--- a/troposphere/static/js/modals/instanceVolume/attach.js
+++ b/troposphere/static/js/modals/instanceVolume/attach.js
@@ -7,21 +7,27 @@ define(function (require) {
 
   return {
 
-    attach: function(volume, project){
-      var props = {
-        volume: volume,
-        project: project
-      };
+    attach: function(volume, project) {
+      ModalHelpers.renderModal(
+          // Modal to create
+          VolumeAttachModal, 
 
-      ModalHelpers.renderModal(VolumeAttachModal, props, function (instance, mountLocation) {
-        actions.InstanceVolumeActions.attach({
-          instance: instance,
-          volume: volume,
-          project: project,
-          mountLocation: mountLocation
-        })
-      })
+          // Modal properties
+          {
+              volume: volume,
+              project: project
+          }, 
 
+          // This callback is the action fired in the modal
+          function (instance, mountLocation) {
+            actions.InstanceVolumeActions.attach({
+              instance: instance,
+              volume: volume,
+              project: project,
+              mountLocation: mountLocation
+            })
+          }
+      )
     }
 
   };


### PR DESCRIPTION
- Filter instances so that, user cannot attach volumes to instances where the provider doesn't match
- Add bold font, to explain why volumes and instances must have **same provider** and **same project**
- Refactor render modal