### PR TITLE
Delete volume action displays warning modal

### DIFF
--- a/troposphere/static/js/components/projects/resources/volume/details/actions/VolumeActionsAndLinks.react.js
+++ b/troposphere/static/js/components/projects/resources/volume/details/actions/VolumeActionsAndLinks.react.js
@@ -25,11 +25,9 @@ define(function (require) {
       var project = this.props.project,
           volume = this.props.volume;
 
-      actions.VolumeActions.destroy({
-        volume: volume,
-        project: project,
-        linksTo: "project-resources",
-        params: {projectId: project.id}
+      modals.VolumeModals.destroy({
+        volume: this.props.volume,
+        project: this.props.project
       });
     },
 


### PR DESCRIPTION
This restores the correct behavior of displaying a warning modal on delete in the volume details page.