### PR TITLE
Added the time (hours:minutes) to dates occurrences.

### DIFF
--- a/troposphere/static/js/components/common/project/Project.react.js
+++ b/troposphere/static/js/components/common/project/Project.react.js
@@ -72,7 +72,7 @@ define(function (require) {
         descriptionHtml = converter.makeHtml(description),
         projectInstances = stores.ProjectInstanceStore.getInstancesFor(project),
         projectVolumes = stores.ProjectVolumeStore.getVolumesFor(project),
-        projectCreationDate = moment(project.get('start_date')).format("MMM D, YYYY");
+        projectCreationDate = moment(project.get('start_date')).format("MMM D, YYYY hh:mm a");
 
       return (
         <div>

--- a/troposphere/static/js/components/dashboard/ImageCreatedMessage.react.js
+++ b/troposphere/static/js/components/dashboard/ImageCreatedMessage.react.js
@@ -25,7 +25,7 @@ define(function (require) {
             </div>
             <div className="details">
               <div><strong>{user.username}</strong> created an image</div>
-              <div>{startDate.format("MMM DD, YYYY")}</div>
+              <div>{startDate.format("MMM DD, YYYY hh:mm a")}</div>
               <div>
                 <Router.Link to="image-details" params={{imageId: image.id}}>
                   {image.get('name')}

--- a/troposphere/static/js/components/dashboard/InstanceHistoryList.react.js
+++ b/troposphere/static/js/components/dashboard/InstanceHistoryList.react.js
@@ -104,8 +104,8 @@ define(function(require) {
 
         var startDate = instance.get('start_date'),
             endDate = instance.get('end_date'),
-            formattedStartDate = startDate.format("MMM DD, YYYY"),
-            formattedEndDate = endDate.format("MMM DD, YYYY"),
+            formattedStartDate = startDate.format("MMM DD, YYYY hh:mm a"),
+            formattedEndDate = endDate.format("MMM DD, YYYY hh:mm a"),
             now = moment(),
             timeSpan = now.diff(startDate, "days"),
             instanceHistoryHash = CryptoJS.MD5((instance.id || instance.cid).toString()).toString(),

--- a/troposphere/static/js/components/images/detail/created/CreatedView.react.js
+++ b/troposphere/static/js/components/images/detail/created/CreatedView.react.js
@@ -15,7 +15,7 @@ define(
 
       render: function () {
         var image = this.props.image,
-          startDate = moment(image.get('start_date')).format("MMM D, YYYY");
+          startDate = moment(image.get('start_date')).format("MMM D, YYYY hh:mm a");
 
         return (
           <div className="image-info-segment row">

--- a/troposphere/static/js/components/images/detail/removed/RemovedView.react.js
+++ b/troposphere/static/js/components/images/detail/removed/RemovedView.react.js
@@ -15,7 +15,7 @@ define(
 
       render: function () {
         var image = this.props.image,
-          startDate = moment(image.get('start_date')).format("MMM D, YYYY");
+          startDate = moment(image.get('start_date')).format("MMM D, YYYY hh:mm a");
 
         return (
           <div className="image-info-segment row">

--- a/troposphere/static/js/components/images/detail/versions/Version.react.js
+++ b/troposphere/static/js/components/images/detail/versions/Version.react.js
@@ -64,12 +64,12 @@ define(function (require) {
       var date_str;
 
       if(version.get('end_date')) {
-        var dateCreated = moment(version.get('start_date')).format("M/DD/YYYY"),
-          dateArchived = moment(version.get('end_date')).format("M/DD/YYYY");
+        var dateCreated = moment(version.get('start_date')).format("M/DD/YYYY hh:mm a"),
+          dateArchived = moment(version.get('end_date')).format("M/DD/YYYY hh:mm a");
 
           date_str = dateCreated + " - " + dateArchived;
       } else {
-        var dateCreated = moment(version.get('start_date')).format("M/DD/YYYY");
+        var dateCreated = moment(version.get('start_date')).format("M/DD/YYYY hh:mm a");
 
           date_str = dateCreated;
       }
@@ -81,7 +81,7 @@ define(function (require) {
       var version = this.props.version,
           image = this.props.image,
           isRecommended = false,
-          dateCreated = moment(version.start_date).format("M/DD/YYYY"),
+          dateCreated = moment(version.start_date).format("M/DD/YYYY hh:mm a"),
           versionHash = CryptoJS.MD5(version.id.toString()).toString(),
           iconSize = 63,
           type = stores.ProfileStore.get().get('icon_set'),

--- a/troposphere/static/js/components/images/list/common/ImageCard.react.js
+++ b/troposphere/static/js/components/images/list/common/ImageCard.react.js
@@ -22,7 +22,7 @@ define(function (require) {
       var image = this.props.image,
         type = stores.ProfileStore.get().get('icon_set'),
         imageTags = stores.TagStore.getImageTags(image),
-        imageCreationDate = moment(image.get('start_date')).format("MMM D, YYYY"),
+        imageCreationDate = moment(image.get('start_date')).format("MMM D, YYYY hh:mm a"),
         iconSize = 145,
         icon;
 

--- a/troposphere/static/js/components/images/list/common/ImageListCard.react.js
+++ b/troposphere/static/js/components/images/list/common/ImageListCard.react.js
@@ -22,7 +22,7 @@ define(function (require) {
       var image = this.props.image,
         type = stores.ProfileStore.get().get('icon_set'),
         imageTags = stores.TagStore.getImageTags(image),
-        imageCreationDate = moment(image.get('start_date')).format("MMM D, YYYY"),
+        imageCreationDate = moment(image.get('start_date')).format("MMM D, YYYY hh:mm a"),
         converter = new Showdown.Converter(),
         description = image.get('description');
       if(!description) {

--- a/troposphere/static/js/components/modals/VersionInformationModal.react.js
+++ b/troposphere/static/js/components/modals/VersionInformationModal.react.js
@@ -66,15 +66,15 @@ define(function (require) {
       if (this.state.version) {
         var client = this.state.version.client;
         var clientVersion = client.get("git_branch") + " " + client.get("git_sha_abbrev");
-        var clientLastUpdated = moment(client.get('commit_date')).format("MMM Do YYYY");
+        var clientLastUpdated = moment(client.get('commit_date')).format("MMM Do YYYY hh:mm a");
 
         var serverDeploy = this.state.version.deploy;
         var serverDeployVersion = serverDeploy.get("git_branch") + " " + serverDeploy.get("git_sha_abbrev");
-        var serverDeployLastUpdated = moment(serverDeploy.get('commit_date')).format("MMM Do YYYY");
+        var serverDeployLastUpdated = moment(serverDeploy.get('commit_date')).format("MMM Do YYYY hh:mm a");
 
         var server = this.state.version.server;
         var serverVersion = server.get("git_branch") + " " + server.get("git_sha_abbrev");
-        var serverLastUpdated = moment(server.get('commit_date')).format("MMM Do YYYY");
+        var serverLastUpdated = moment(server.get('commit_date')).format("MMM Do YYYY hh:mm a");
 
         content = (
           <div role='form'>

--- a/troposphere/static/js/components/modals/image_version/availability/ProviderMachineEditItem.react.js
+++ b/troposphere/static/js/components/modals/image_version/availability/ProviderMachineEditItem.react.js
@@ -62,7 +62,7 @@ define(function (require) {
             if(! provider_machine.end_date.isValid()) {
               availableText = "Archiving ..."
             } else {
-              availableText = "Archived as of " + provider_machine.end_date.format("MMM D, YYYY hh:mma");
+              availableText = "Archived as of " + provider_machine.end_date.format("MMM D, YYYY hh:mm a");
             }
             classes = "list-group-item list-group-item-danger"
             activateText = "Re-Enable Provider";

--- a/troposphere/static/js/components/projects/detail/details/EditDetails.react.js
+++ b/troposphere/static/js/components/projects/detail/details/EditDetails.react.js
@@ -71,7 +71,7 @@ define(
             <div className="project-info-segment row">
               <h4 className="col-md-3">Created</h4>
 
-              <p className="col-md-9">{project.get('start_date').format("MMMM Do, YYYY")}</p>
+              <p className="col-md-9">{project.get('start_date').format("MMMM Do, YYYY hh:mm a")}</p>
             </div>
 
             <div className="project-info-segment row">

--- a/troposphere/static/js/components/projects/detail/details/ViewDetails.react.js
+++ b/troposphere/static/js/components/projects/detail/details/ViewDetails.react.js
@@ -33,7 +33,7 @@ define(
           <div className="project-info-segment row">
             <h4 className="col-md-3">Created</h4>
 
-            <p className="col-md-9">{project.get('start_date').format("MMMM Do, YYYY")}</p>
+            <p className="col-md-9">{project.get('start_date').format("MMMM Do, YYYY hh:mm a")}</p>
           </div>
         );
       },

--- a/troposphere/static/js/components/projects/list/Project.react.js
+++ b/troposphere/static/js/components/projects/list/Project.react.js
@@ -71,7 +71,7 @@ define(function (require) {
         descriptionHtml = converter.makeHtml(description),
         projectInstances = stores.ProjectInstanceStore.getInstancesFor(project),
         projectVolumes = stores.ProjectVolumeStore.getVolumesFor(project),
-        projectCreationDate = moment(project.get('start_date')).format("MMM D, YYYY");
+        projectCreationDate = moment(project.get('start_date')).format("MMM D, YYYY hh:mm a");
 
       return (
         <div style={{"position": "relative"}}>


### PR DESCRIPTION
This PR simply added the `` ... hh:mm a`` to ``format()`` get the hours, minutes, & am/pm for occurrences where time is currently used. (Resolution for [ATMO-985](https://pods.iplantcollaborative.org/jira/browse/ATMO-985))

Each occurrence does *not* appear to impact the layout of the UI element (see below). 

Examples from local testing are shown below:
---- 

![screen shot 2015-09-21 at 2 00 09 pm](https://cloud.githubusercontent.com/assets/5923/10005151/80ec8506-606a-11e5-8fb7-0a577f336e99.png)
![screen shot 2015-09-21 at 2 00 02 pm](https://cloud.githubusercontent.com/assets/5923/10005152/80ee67c2-606a-11e5-9c6d-4df47da7500c.png)
![screen shot 2015-09-21 at 1 58 56 pm](https://cloud.githubusercontent.com/assets/5923/10005154/80f77eca-606a-11e5-9cf6-7ba4c8e9465f.png)
![screen shot 2015-09-21 at 1 58 42 pm](https://cloud.githubusercontent.com/assets/5923/10005149/80e9d82e-606a-11e5-9877-018ff45196e4.png)
![screen shot 2015-09-21 at 1 57 57 pm](https://cloud.githubusercontent.com/assets/5923/10005148/80e8e7f2-606a-11e5-8450-9aa22c7b5e94.png)
![screen shot 2015-09-21 at 1 57 50 pm](https://cloud.githubusercontent.com/assets/5923/10005150/80ebda98-606a-11e5-8f36-b8b5aa74f8c7.png)
![screen shot 2015-09-21 at 1 57 20 pm](https://cloud.githubusercontent.com/assets/5923/10005153/80f4d5b2-606a-11e5-838f-98b03c89b402.png)
![screen shot 2015-09-21 at 1 57 13 pm](https://cloud.githubusercontent.com/assets/5923/10005155/80fa3cf0-606a-11e5-938e-c6caa3e7ae29.png)
![screen shot 2015-09-21 at 1 57 04 pm](https://cloud.githubusercontent.com/assets/5923/10005156/80fe817a-606a-11e5-9fe2-fca7c5dc5945.png)
![screen shot 2015-09-21 at 1 57 01 pm](https://cloud.githubusercontent.com/assets/5923/10005157/80feb0be-606a-11e5-9caa-548466df8dc3.png)
