### PR TITLE
Included date/time w/ each image in list when launching from project 

### DIFF
--- a/troposphere/static/js/components/modals/instance/launch/components/Image.react.js
+++ b/troposphere/static/js/components/modals/instance/launch/components/Image.react.js
@@ -4,10 +4,11 @@ define(
     'react',
     'backbone',
     'stores',
+    'moment',
     'components/common/tags/ViewTags.react',
     'components/common/Gravatar.react'
   ],
-  function (React, Backbone, stores, Tags, Gravatar) {
+  function (React, Backbone, stores, moment, Tags, Gravatar) {
 
     return React.createClass({
 
@@ -32,6 +33,7 @@ define(
       render: function () {
         var image = this.props.image,
           type = stores.ProfileStore.get().get('icon_set'),
+          imageCreationDate = moment(image.get('start_date')).format("MMM D, YYYY hh:mm a"),
           iconSize = 67,
           icon;
 
@@ -55,8 +57,7 @@ define(
                 <span className="app-name">
                   <h4 className="name">{image.get('name')}</h4>
                   <div>
-                    <span>by </span>
-                    <strong>{image.get('created_by').username}</strong>
+                    <time>{imageCreationDate}</time> by <strong>{image.get('created_by').username}</strong>
                   </div>
                   {this.renderTags()}
                 </span>


### PR DESCRIPTION
The modal for launching a new instance from a project does not include date/time of an image. This provides a resolution for that ([ATMO-984](https://pods.iplantcollaborative.org/jira/browse/ATMO-984)).

---- 

![screen_shot_2015-09-21_at_3_13_50_pm](https://cloud.githubusercontent.com/assets/5923/10006676/183b1a72-6074-11e5-905b-30491ed9aa1f.png)