### PR TITLE
Add minimum requirements step

### DIFF
--- a/troposphere/static/css/app/modal.scss
+++ b/troposphere/static/css/app/modal.scss
@@ -148,6 +148,9 @@ $breadcrumb-bk-inactive:lightgrey;
     background:none !important;
   }
 
+  .breadcrumb{
+    padding: 0;
+  }
   .breadcrumb div {
     width:50%;
     text-decoration: none;

--- a/troposphere/static/css/app/request_image_form.scss
+++ b/troposphere/static/css/app/request_image_form.scss
@@ -20,3 +20,9 @@
     }
   }
 }
+
+#min-requirements{
+  div{
+    margin: 3%;
+  }
+}

--- a/troposphere/static/js/actions/instance/requestImage.js
+++ b/troposphere/static/js/actions/instance/requestImage.js
@@ -30,7 +30,7 @@ define(function (require) {
           name = params.name,
           description = params.description,
           minMem = params.minMem,
-          minStorage = params.minStorage,
+          minCPU = params.minCPU,
           providerId = params.providerId,
           identity = params.identity,
           software = params.software || "[no files specified]",
@@ -64,7 +64,7 @@ define(function (require) {
         new_application_description: description,
         new_application_name: name,
         new_version_memory_min: minMem,
-        new_version_storage_min: minStorage,
+        new_version_cpu_min: minCPU,
         new_application_visibility: visibility,
         new_machine_owner: newMachineOwner,
         new_machine_provider: providerId,
@@ -74,6 +74,7 @@ define(function (require) {
         new_version_name: versionName,
         tags: tagNames
       };
+
 
       var requestUrl = (
         globals.API_V2_ROOT + "/machine_requests" 

--- a/troposphere/static/js/actions/instance/requestImage.js
+++ b/troposphere/static/js/actions/instance/requestImage.js
@@ -26,14 +26,18 @@ define(function (require) {
       if(!params.imageUsers) throw new Error("Missing imageUsers");
 
 
-      var instance = params.instance,
+      var instance = params.instance.get('id'),
           name = params.name,
           description = params.description,
+          minMem = params.minMem,
+          minStorage = params.minStorage,
           providerId = params.providerId,
-          software = params.software,
-          filesToExclude = params.filesToExclude,
+          identity = params.identity,
+          software = params.software || "[no files specified]",
+          filesToExclude = params.filesToExclude || "[no files specified]",
           fork = params.versionFork,
           versionName = params.versionName,
+          newMachineOwner = params.newMachineOwner,
           versionChanges = params.versionChanges,
           systemFiles = params.systemFiles || "[no files specified]",
           visibility = params.visibility,
@@ -49,30 +53,30 @@ define(function (require) {
           }),
           provider = stores.ProviderStore.get(providerId);
 
+
       var requestData = {
-        fork: fork,
-        name: name,
-        description: description,
-        tags: tagNames,
-        instance: instance.get('uuid'),
-        ip_address: instance.get("ip_address"),
-        provider: provider.get('uuid'),
-        version_name: versionName,
-        version_changes: versionChanges,
-        vis: visibility,
-        shared_with: userNames,
-        exclude: filesToExclude || "[no files specified]",
-        software: software || "[no software specified]",
-        sys: systemFiles || "[no files specified]",
-        licenses: licenses,
-        scripts: scripts
+        access_list: userNames,
+        exclude_files: filesToExclude,
+        installed_software: software,
+        instance: instance,
+        identity: identity,
+        iplant_sys_files: systemFiles,
+        new_application_description: description,
+        new_application_name: name,
+        new_version_memory_min: minMem,
+        new_version_storage_min: minStorage,
+        new_application_visibility: visibility,
+        new_machine_owner: newMachineOwner,
+        new_machine_provider: providerId,
+        new_version_allow_imaging: true,
+        new_version_change_log: versionChanges,
+        new_version_forked: fork,
+        new_version_name: versionName,
+        tags: tagNames
       };
 
       var requestUrl = (
-        globals.API_ROOT +
-        "/provider/" + instance.get('provider').uuid +
-        "/identity/" + instance.get('identity').uuid +
-        "/request_image"
+        globals.API_V2_ROOT + "/machine_requests" 
       );
 
       $.ajax({

--- a/troposphere/static/js/components/modals/instance/InstanceImageWizardModal.react.js
+++ b/troposphere/static/js/components/modals/instance/InstanceImageWizardModal.react.js
@@ -16,12 +16,11 @@ define(function (require) {
 
   var IMAGE_INFO_STEP = 1,
       VERSION_INFO_STEP = 2,
-      MINIMUM_REQUIREMENTS_STEP = 3,
-      PROVIDER_STEP = 4,
-      VISIBILITY_STEP = 5,
-      EXCLUDE_FILES_STEP = 6,
-      SCRIPTS_LICENSE_STEP = 7,
-      REVIEW_STEP = 8;
+      PROVIDER_STEP = 3,
+      VISIBILITY_STEP = 4,
+      EXCLUDE_FILES_STEP = 5,
+      SCRIPTS_LICENSE_STEP = 6,
+      REVIEW_STEP = 7;
 
   return React.createClass({
     displayName: "InstanceImageWizardModal",
@@ -49,7 +48,7 @@ define(function (require) {
         imageTags: null,
         providerId: null,
         visibility: "public",
-        minStorage: "0",
+        minCPU: "0",
         minMem: "0",
         imageUsers: new Backbone.Collection(),
         activeScripts: new Backbone.Collection(),
@@ -58,7 +57,6 @@ define(function (require) {
         breadcrumbs: [
           {name:"Image Info",step:IMAGE_INFO_STEP},
           {name:"Version Info",step:VERSION_INFO_STEP},
-          {name:"Minimum Requirements",step:MINIMUM_REQUIREMENTS_STEP},
           {name:"Provider",step:PROVIDER_STEP},
           {name:"Privacy",step:VISIBILITY_STEP},
           {name:"Exclude Files",step:EXCLUDE_FILES_STEP},
@@ -122,7 +120,7 @@ define(function (require) {
         name: this.state.name,
         description: this.state.description,
         minMem: this.state.minMem,
-        minStorage: this.state.minStorage,
+        minCPU: this.state.minCPU,
         tags: this.state.imageTags,
         versionName: this.state.versionName,
         versionChanges: this.state.versionChanges,
@@ -204,6 +202,8 @@ define(function (require) {
             <ProviderStep
               instance={instance}
               providerId={this.state.providerId}
+              minMem={this.state.minMem}
+              minCPU={this.state.minCPU}
               onPrevious={this.onPrevious}
               onNext={this.onNext}
               />
@@ -219,16 +219,6 @@ define(function (require) {
               onNext={this.onNext}
               onSubmit={this.onReviewImage}
               />
-          );
-
-        case MINIMUM_REQUIREMENTS_STEP:
-          return (
-            <MinimumRequirementsStep
-            minMem={this.state.minMem}
-            minStorage={this.state.minStorage}
-            onPrevious={this.onPrevious}
-            onNext={this.onNext}
-            />
           );
 
         case EXCLUDE_FILES_STEP:

--- a/troposphere/static/js/components/modals/instance/InstanceImageWizardModal.react.js
+++ b/troposphere/static/js/components/modals/instance/InstanceImageWizardModal.react.js
@@ -154,7 +154,6 @@ define(function (require) {
     },
 
     onNext: function (data) {
-      console.log(data);
         // Similar logic to onPrevious. this.state.step == breadcrumbs + 1 
         var nextStep = this.state.breadcrumbs[this.state.step],
             data = data || {},

--- a/troposphere/static/js/components/modals/instance/InstanceImageWizardModal.react.js
+++ b/troposphere/static/js/components/modals/instance/InstanceImageWizardModal.react.js
@@ -8,6 +8,7 @@ define(function (require) {
       ImageInfoStep = require('./image/steps/ImageInfoStep.react'),
       VersionInfoStep = require('./image/steps/VersionInfoStep.react'),
       ProviderStep = require('./image/steps/ProviderStep.react'),
+      MinimumRequirementsStep = require('./image/steps/MinimumRequirementsStep.react'),
       VisibilityStep = require('./image/steps/VisibilityStep.react'),
       FilesToExcludeStep = require('./image/steps/FilesToExcludeStep.react'),
       BootScriptsAndLicenseStep = require('./image/steps/BootScriptsLicensingStep.react'),
@@ -15,11 +16,12 @@ define(function (require) {
 
   var IMAGE_INFO_STEP = 1,
       VERSION_INFO_STEP = 2,
-      PROVIDER_STEP = 3,
-      VISIBILITY_STEP = 4,
-      EXCLUDE_FILES_STEP = 5,
-      SCRIPTS_LICENSE_STEP = 6,
-      REVIEW_STEP = 7;
+      MINIMUM_REQUIREMENTS_STEP = 3,
+      PROVIDER_STEP = 4,
+      VISIBILITY_STEP = 5,
+      EXCLUDE_FILES_STEP = 6,
+      SCRIPTS_LICENSE_STEP = 7,
+      REVIEW_STEP = 8;
 
   return React.createClass({
     displayName: "InstanceImageWizardModal",
@@ -47,6 +49,8 @@ define(function (require) {
         imageTags: null,
         providerId: null,
         visibility: "public",
+        minStorage: "0",
+        minMem: "0",
         imageUsers: new Backbone.Collection(),
         activeScripts: new Backbone.Collection(),
         activeLicenses: new Backbone.Collection(),
@@ -54,6 +58,7 @@ define(function (require) {
         breadcrumbs: [
           {name:"Image Info",step:IMAGE_INFO_STEP},
           {name:"Version Info",step:VERSION_INFO_STEP},
+          {name:"Minimum Requirements",step:MINIMUM_REQUIREMENTS_STEP},
           {name:"Provider",step:PROVIDER_STEP},
           {name:"Privacy",step:VISIBILITY_STEP},
           {name:"Exclude Files",step:EXCLUDE_FILES_STEP},
@@ -97,7 +102,7 @@ define(function (require) {
       this.hide();
     },
 
-    onReviewImage: function() {
+    onReviewImage: function(data) {
       var step = REVIEW_STEP,
         data = data || {},
         state = _.extend({step: step}, data);
@@ -116,6 +121,8 @@ define(function (require) {
         newImage: this.state.newImage,
         name: this.state.name,
         description: this.state.description,
+        minMem: this.state.minMem,
+        minStorage: this.state.minStorage,
         tags: this.state.imageTags,
         versionName: this.state.versionName,
         versionChanges: this.state.versionChanges,
@@ -147,6 +154,7 @@ define(function (require) {
     },
 
     onNext: function (data) {
+      console.log(data);
         // Similar logic to onPrevious. this.state.step == breadcrumbs + 1 
         var nextStep = this.state.breadcrumbs[this.state.step],
             data = data || {},
@@ -212,6 +220,16 @@ define(function (require) {
               onNext={this.onNext}
               onSubmit={this.onReviewImage}
               />
+          );
+
+        case MINIMUM_REQUIREMENTS_STEP:
+          return (
+            <MinimumRequirementsStep
+            minMem={this.state.minMem}
+            minStorage={this.state.minStorage}
+            onPrevious={this.onPrevious}
+            onNext={this.onNext}
+            />
           );
 
         case EXCLUDE_FILES_STEP:
@@ -283,7 +301,7 @@ define(function (require) {
     },
 
     changeTitleBack: function(){
-      var breadcrumb = this.state.breadcrumbs[this.state.step];
+      var breadcrumb = this.state.breadcrumbs[this.state.step - 1];
       this.setState({title: breadcrumb.name});
     },
 

--- a/troposphere/static/js/components/modals/instance/image/steps/MinimumRequirementsStep.react.js
+++ b/troposphere/static/js/components/modals/instance/image/steps/MinimumRequirementsStep.react.js
@@ -64,7 +64,9 @@ define(function(require) {
                 Let other users know how much memory (RAM) is required to properly run an instance based on this image.
               </div>
               <input type="text" onChange={this.handleMemChange} value={this.state.minMem} />
-              <hr />
+            </div>
+            <hr />
+            <div className="form-group">
               <label htmlFor="name" className="control-label">
                 Minimum storage (GB):
               </label>

--- a/troposphere/static/js/components/modals/instance/image/steps/MinimumRequirementsStep.react.js
+++ b/troposphere/static/js/components/modals/instance/image/steps/MinimumRequirementsStep.react.js
@@ -1,0 +1,93 @@
+define(function(require) {
+
+  var React = require('react/addons'),
+      Backbone = require('backbone'),
+      VersionName = require('../components/VersionName.react'),
+      VersionChanges = require('../components/VersionChangeLog.react'),
+      stores = require('stores');
+
+  return React.createClass({
+    displayName: "ImageWizard-VersionInfoStep",
+
+    propTypes: {
+      minMem: React.PropTypes.string.isRequired,
+      minStorage: React.PropTypes.string.isRequired
+    },
+
+    getInitialState: function(){
+      return {
+        minMem: this.props.minMem,
+        minStorage: this.props.minStorage
+      }
+    },
+
+    isSubmittable: function(){
+      return this.state.minMem && this.state.minStorage;
+    },
+
+    onPrevious: function(){
+      this.props.onPrevious({
+        versionName: this.state.versionName,
+        versionChanges: this.state.versionChanges,
+      });
+    },
+
+    handleMemChange: function(e){
+      this.setState({minMem: e.target.value});
+    },
+
+    handleStorageChange: function(e){
+      this.setState({minStorage: e.target.value});
+    },
+
+    onNext: function(){
+      this.props.onNext({
+        minStorage: this.state.minStorage,
+        minMem: this.state.minMem
+      });
+    },
+
+    onDescriptionChange: function(newVersionChanges){
+      this.setState({versionChanges: newVersionChanges});
+    },
+
+    render: function () {
+
+      return (
+        <div>
+          <div className="modal-body">
+            <div className="form-group">
+              <label htmlFor="name" className="control-label">
+                Minimum memory (GB):
+              </label>
+              <div className="help-block">
+                Let other users know how much memory (RAM) is required to properly run an instance based on this image.
+              </div>
+              <input type="text" onChange={this.handleMemChange} value={this.state.minMem} />
+              <hr />
+              <label htmlFor="name" className="control-label">
+                Minimum storage (GB):
+              </label>
+              <div className="help-block">
+                Let other users know how much storage is required to properly run an instance based on this image.
+              </div>
+              <input type="text" onChange={this.handleStorageChange} value={this.state.minStorage} />
+            </div>
+          </div>
+
+          <div className="modal-footer">
+            <button type="button" className="btn btn-default cancel-button pull-left" onClick={this.onPrevious}>
+              <span className="glyphicon glyphicon-chevron-left"></span>
+              Back
+            </button>
+            <button type="button" className="btn btn-primary cancel-button" onClick={this.onNext}>
+              Next
+            </button>
+          </div>
+        </div>
+      );
+    }
+
+  });
+
+});

--- a/troposphere/static/js/components/modals/instance/image/steps/ProviderStep.react.js
+++ b/troposphere/static/js/components/modals/instance/image/steps/ProviderStep.react.js
@@ -15,7 +15,9 @@ define(function (require) {
     getInitialState: function () {
       var instance = this.props.instance;
       return {
-        providerId: this.props.providerId || instance.get('provider').id
+        providerId: this.props.providerId || instance.get('provider').id,
+        minCPU: "0",
+        minMem: "0"
       }
     },
 
@@ -32,6 +34,8 @@ define(function (require) {
 
     onNext: function () {
       this.props.onNext({
+        minCPU: this.state.minCPU,
+        minMem: this.state.minMem,
         providerId: this.state.providerId
       });
     },
@@ -42,13 +46,50 @@ define(function (require) {
       });
     },
 
-    renderBody: function (instance) {
+    handleCPUChange: function(e){
+      this.setState({minCPU: e.target.value});
+    },
+
+    handleMemChange: function(e){
+      this.setState({minMem: e.target.value});
+    },
+
+    renderProvider: function (instance) {
       return (
         <div>
           <Provider
             providerId={this.state.providerId}
-            onChange={this.onProviderChange}
-            />
+            onChange={this.onProviderChange}/>
+        </div>
+      );
+    },
+
+    renderRequirementsStep: function(){
+      return (
+        <div id="min-requirements" className="min-requirements collapse">
+          <div className="min-cpu clearfix">
+            # of CPUs: {this.state.minCPU}
+            <input type = "range" className = "slider"
+              value = {this.state.minCPU}
+              min = "0"
+              max = "16"
+              step = "1"
+              onChange = {this.handleCPUChange} />
+            <span className="pull-left">0</span> 
+            <span className="pull-right">16</span>
+          </div>
+
+          <div className="min-mem">
+            Memory: {this.state.minMem} GB
+            <input type = "range" className = "slider"
+              value = {this.state.minMem}
+              min = "0"
+              max = "16"
+              step = "2"
+              onChange = {this.handleMemChange} />
+            <span className="pull-left">0</span> 
+            <span className="pull-right">16</span>
+          </div>
         </div>
       );
     },
@@ -59,7 +100,11 @@ define(function (require) {
       return (
         <div>
           <div className="modal-body">
-            {this.renderBody(instance)}
+            {this.renderProvider(instance)}
+            <a role="button" data-toggle="collapse" href="#min-requirements" aria-expanded="true">
+              Minimum Requirements (optional)
+            </a>  
+            {this.renderRequirementsStep()}
           </div>
           <div className="modal-footer">
             <button type="button" className="btn btn-default cancel-button pull-left" onClick={this.onPrevious}>

--- a/troposphere/static/js/modals/instance/requestImage.js
+++ b/troposphere/static/js/modals/instance/requestImage.js
@@ -20,11 +20,15 @@ define(function (require) {
       ModalHelpers.renderModal(InstanceImageWizardModal, props, function (params) {
         actions.InstanceActions.requestImage({
           instance: instance,
+          identity: instance.get('identity').id,
           name: params.name,
           description: params.description,
           tags: params.tags,
           versionName: params.versionName,
+          minMem: params.minMem,
+          minStorage: params.minStorage,
           versionChanges: params.versionChanges,
+          newMachineOwner: instance.get('user').id,
           versionFork: params.newImage,
           providerId: params.providerId,
           visibility: params.visibility,

--- a/troposphere/static/js/modals/instance/requestImage.js
+++ b/troposphere/static/js/modals/instance/requestImage.js
@@ -26,7 +26,7 @@ define(function (require) {
           tags: params.tags,
           versionName: params.versionName,
           minMem: params.minMem,
-          minStorage: params.minStorage,
+          minCPU: params.minCPU,
           versionChanges: params.versionChanges,
           newMachineOwner: instance.get('user').id,
           versionFork: params.newImage,

--- a/troposphere/static/js/stores/BaseStore.js
+++ b/troposphere/static/js/stores/BaseStore.js
@@ -159,9 +159,6 @@ define(function (require) {
         }).done(function () {
             this.isFetching = false;
             this.models = models;
-            if (this.pollingEnabled) {
-              this.models.each(this.pollNowUntilBuildIsFinished.bind(this));
-            }
             this.emitChange();
           }.bind(this));
       }


### PR DESCRIPTION
This PR adds a new step in the image launch modal for users to specify minimum requirements for their images. It also addresses a bug where the step displayed by the modal was incorrectly showing the next step's name when the mouse was hovered on to the breadcrumb and then hovered off.