### PR TITLE
Fix alignment and keeping break in overflow within own col.

### DIFF
--- a/troposphere/static/css/app/layout.scss
+++ b/troposphere/static/css/app/layout.scss
@@ -310,21 +310,27 @@
   }
 
   ul {
-    padding-left: 0;
+    padding-left: 10px;
   }
 
   li {
     list-style: none;
-    line-height: 30px;
+    line-height: 120%;
+    padding-bottom: 10px;
 
-    > span:first-of-type {
-      width: 60px;
-      margin-right: 20px;
-      display: inline-block;
-      text-align: right;
+    .detail-label {
+      width: 20%;
+      margin-right: 10%;
+      display: block;
       color: #5A5A5A;
+      float:left;
     }
-
+    
+    .detail-value {
+      width:70%;
+      display: block;
+      float:left;
+    }
     span {
       font-size: 13px;
     }
@@ -337,14 +343,15 @@
     padding: 10px 0px;
 
     i {
-      font-size: 20px;
+      display: inline-block;
+      font-size: 25px;
       margin-right: 10px;
     }
 
-   .title-3, h2 {
+  .title-3,  h2 {
       display: inline-block;
       vertical-align: bottom;
-      font-size: 20px;
+      font-size: 27px;
       margin-top: 0px;
       margin-bottom: 3px;
     }

--- a/troposphere/static/js/components/projects/common/ResourceDetail.react.js
+++ b/troposphere/static/js/components/projects/common/ResourceDetail.react.js
@@ -6,6 +6,7 @@ define(
   function (React) {
 
     return React.createClass({
+      displayName: 'ResourceDetail',
 
       propTypes: {
         label: React.PropTypes.string.isRequired,
@@ -14,9 +15,9 @@ define(
 
       render: function () {
         return (
-          <li>
-            <span>{this.props.label}</span>
-            <span>{this.props.children}</span>
+          <li className="clearfix">
+            <span className="detail-label">{this.props.label}</span>
+            <span className="detail-value" >{this.props.children}</span>
           </li>
         );
       }


### PR DESCRIPTION
remove tight aligned labels, two columns, added class selectors to markup.

![resource-detail-after](https://cloud.githubusercontent.com/assets/7366338/10180626/9c31c2d6-66c3-11e5-9073-ef0f0b5ec3f4.png)
![resource-detail-before](https://cloud.githubusercontent.com/assets/7366338/10180627/9c324a58-66c3-11e5-8d49-16019c9a8221.png)
