### PR TITLE
Provide the originating user-interface for user feedback & issue reporting

### DIFF
--- a/troposphere/static/js/actions/HelpActions.js
+++ b/troposphere/static/js/actions/HelpActions.js
@@ -16,18 +16,18 @@ define(function (require) {
       data["message"] = feedback;
 
       // Size information for the user's browser and monitor
-      data['resolution'] = {
-        'viewport': {
-          'width': $(window).width(),
-          'height': $(window).height()
+      data["resolution"] = {
+        "viewport": {
+          "width": $(window).width(),
+          "height": $(window).height()
         },
-        'screen': {
-          'width': screen.width,
-          'height': screen.height
+        "screen": {
+          "width": screen.width,
+          "height": screen.height
         }
       };
 
-      data['user-interface'] = 'troposphere';
+      data["user-interface"] = 'troposphere';
 
       var feedbackUrl = globals.API_ROOT + '/email/feedback';
 

--- a/troposphere/static/js/actions/instance/report.js
+++ b/troposphere/static/js/actions/instance/report.js
@@ -30,14 +30,15 @@ define(function (require) {
       reportData = {
         username: username,
         message: "Instance IP: " + instance.get('ip_address') + "\n" +
-        "Instance ID: " + instance.id + "\n" +
-        "Provider ID: " + instance.get('provider').id + "\n" +
-        "\n" +
-        "Problems" + "\n" +
-        problemText + "\n" +
-        "Details \n" +
-        reportInfo.details + "\n",
-        subject: "Atmosphere Instance Report from " + username
+                 "Instance ID: " + instance.id + "\n" +
+                 "Provider ID: " + instance.get('provider').id + "\n" +
+                 "\n" +
+                 "Problems" + "\n" +
+                 problemText + "\n" +
+                 "Details \n" +
+                 reportInfo.details + "\n",
+        subject: "Atmosphere Instance Report from " + username,
+        "user-interface": 'troposphere'
       };
 
       $.ajax({

--- a/troposphere/static/js/actions/instance/report.js
+++ b/troposphere/static/js/actions/instance/report.js
@@ -4,6 +4,7 @@ define(function (require) {
   var stores = require('stores'),
     globals = require('globals'),
     $ = require('jquery'),
+    _ = require('underscore'),
     Utils = require('../Utils');
 
   return {

--- a/troposphere/static/js/actions/volume/report.js
+++ b/troposphere/static/js/actions/volume/report.js
@@ -29,13 +29,14 @@ define(function (require) {
       reportData = {
         username: username,
         message: "Volume ID: " + volume.id + "\n" +
-        "Provider ID: " + volume.get('identity').provider + "\n" +
-        "\n" +
-        "Problems" + "\n" +
-        problemText + "\n" +
-        "Details \n" +
-        reportInfo.details + "\n",
-        subject: "Atmosphere Volume Report from " + username
+                 "Provider ID: " + volume.get('identity').provider + "\n" +
+                 "\n" +
+                 "Problems" + "\n" +
+                 problemText + "\n" +
+                 "Details \n" +
+                 reportInfo.details + "\n",
+        subject: "Atmosphere Volume Report from " + username,
+        "user-interface": 'troposphere'
       };
 
       $.ajax({

--- a/troposphere/static/js/actions/volume/report.js
+++ b/troposphere/static/js/actions/volume/report.js
@@ -4,6 +4,7 @@ define(function (require) {
   var stores = require('stores'),
     globals = require('globals'),
     $ = require('jquery'),
+    _ = require('underscore'),
     Utils = require('../Utils');
 
   return {

--- a/troposphere/static/resources/js/cf2/views/instance_screen/report_instance_form.js
+++ b/troposphere/static/resources/js/cf2/views/instance_screen/report_instance_form.js
@@ -94,6 +94,8 @@ Atmo.Views.ReportInstanceForm = Backbone.View.extend({
 				}
 			};
 
+            data["user-interface"] = 'airport';
+
             var btn = self.$el.find('.report_instance_submit');
 
             btn.val("Submitting Report...")

--- a/troposphere/static/resources/js/cf2/views/instance_screen/report_instance_form.js
+++ b/troposphere/static/resources/js/cf2/views/instance_screen/report_instance_form.js
@@ -82,15 +82,15 @@ Atmo.Views.ReportInstanceForm = Backbone.View.extend({
 			}
 			data["message"] += '\n\n';
 
-			data['location'] = window.location.href,
-			data['resolution'] = {
-				'viewport': {
-					'width': $(window).width(),
-					'height': $(window).height()
+			data["location"] = window.location.href,
+			data["resolution"] = {
+				"viewport": {
+					"width": $(window).width(),
+					"height": $(window).height()
 				},
-				'screen': {
-					'width':  screen.width,
-					'height': screen.height
+				"screen": {
+					"width":  screen.width,
+					"height": screen.height
 				}
 			};
 

--- a/troposphere/static/resources/js/cf2/views/volume_screen/report_volume_modal.js
+++ b/troposphere/static/resources/js/cf2/views/volume_screen/report_volume_modal.js
@@ -159,15 +159,15 @@ Atmo.Views.ReportVolumeModal = Backbone.View.extend({
 			}
 			data["message"] += '\n\n';
 
-			data['location'] = window.location.href,
-			data['resolution'] = {
-				'viewport': {
-					'width': $(window).width(),
-					'height': $(window).height()
+			data["location"] = window.location.href,
+			data["resolution"] = {
+				"viewport": {
+					"width": $(window).width(),
+					"height": $(window).height()
 				},
-				'screen': {
-					'width':  screen.width,
-					'height': screen.height
+				"screen": {
+					"width":  screen.width,
+					"height": screen.height
 				}
 			};
 

--- a/troposphere/static/resources/js/cf2/views/volume_screen/report_volume_modal.js
+++ b/troposphere/static/resources/js/cf2/views/volume_screen/report_volume_modal.js
@@ -171,6 +171,8 @@ Atmo.Views.ReportVolumeModal = Backbone.View.extend({
 				}
 			};
 
+			data["user-interface"] = 'airport';
+
 			var succeeded = true;
 
 			$.ajax({


### PR DESCRIPTION
This provides a simple *data-key* indicating if the originating user-interface was `airport` (aka cloudfront2) or `troposphere`. 

Any reported issue regarding *instances* or *volumes* will include `{"user-interface": '(airport | troposphere'}`. 

This work related to the sub-task [ATMO-1004](https://pods.iplantcollaborative.org/jira/browse/ATMO-1004) for [ATMO-990](https://pods.iplantcollaborative.org/jira/browse/ATMO-990).

## Example from local Cloudfront2 (airport)
![screen shot 2015-10-01 at 3 24 03 pm](https://cloud.githubusercontent.com/assets/5923/10235363/97d59382-6850-11e5-88e9-cd381c17460f.png)

## Example from local Troposphere
![screen shot 2015-10-01 at 3 23 24 pm](https://cloud.githubusercontent.com/assets/5923/10235364/97e41c54-6850-11e5-94c0-c1fe834026b2.png)

- - - -

Also, I included some consistency with the keys for data objects that are defined via object laterals to use double quotes since that adheres with the JSON specification ([see *string* type in grammar](http://www.json.org/)). :neckbeard: 

To my knowledge, their is no performance benefit with using single versus double quotes (if there is some compelling reason for one over the other, please let me know). 
