### PR TITLE
Bug fix ATMO-680: missing hover information on bar-graph

### DIFF
--- a/troposphere/static/js/components/dashboard/plots/ProviderSummaryLinePlot.react.js
+++ b/troposphere/static/js/components/dashboard/plots/ProviderSummaryLinePlot.react.js
@@ -122,23 +122,23 @@ define(function (require) {
 
         // CPU Usage
         var cpuUsageStats = this.calculateCpuUsage(providerInstances, quota, sizes),
-          cpuUsage = cpuUsageStats.percentUsed * 100;
+          cpuUsage = (cpuUsageStats.percentUsed * 100 > 100) ? 100 : cpuUsageStats.percentUsed * 100;
 
         // Memory Usage
         var memoryUsageStats = this.calculateMemoryUsage(providerInstances, quota, sizes),
-          memoryUsage = memoryUsageStats.percentUsed * 100;
+          memoryUsage = (memoryUsageStats.percentUsed * 100 > 100) ? 100 : memoryUsageStats.percentUsed * 100;
 
         // Storage Usage
         var storageUsageStats = this.calculateStorageUsage(providerVolumes, quota),
-          storageUsage = storageUsageStats.percentUsed * 100;
+          storageUsage = (storageUsageStats.percentUsed * 100 > 100) ? 100 : storageUsageStats.percentUsed * 100;
 
         // Volume Usage
         var volumeUsageStats = this.calculateStorageCountUsage(providerVolumes, quota),
-          volumeUsage = volumeUsageStats.percentUsed * 100;
+          volumeUsage = (volumeUsageStats.percentUsed * 100 > 100) ? 100 : volumeUsageStats.percentUsed * 100;
 
         // Allocation Usage
         var allocationUsageStats = this.calculateAllocationUsage(allocation),
-          allocationUsage = allocationUsageStats.percentUsed * 100;
+          allocationUsage = (allocationUsageStats.percentUsed * 100 > 100) ? 100 : allocationUsageStats.percentUsed * 100;
 
         var seriesData = {
           name: provider.get('name'),


### PR DESCRIPTION
Bug: On dashboard, bar-graph hover information doesn't show when bar value is over 100.

Fix: Set value of bar to never exceed 100. 