### PR TITLE
Fixes ATMO-962 (Clicking on Menu Item not collapsing menu for small screens)

### DIFF
--- a/troposphere/static/js/components/Header.react.js
+++ b/troposphere/static/js/components/Header.react.js
@@ -129,7 +129,7 @@ define(function (require) {
     },
     
     // We need the screen size for handling the opening and closing of our menu on small screens
-    //See the menu item render for implementation
+    //See navLinks below for implementation.
 
     getInitialState: function() {
     return {windowWidth: window.innerWidth};

--- a/troposphere/static/js/components/Header.react.js
+++ b/troposphere/static/js/components/Header.react.js
@@ -184,7 +184,7 @@ define(function (require) {
         var isCurrentRoute = (link.name.toLowerCase() === this.props.currentRoute[0]);
         var className = isCurrentRoute ? "active" : null;
         
-        //We need to only trigger the toggle menu on small screen sizes to avoid buggy behaviour when selecting menu items on larger screens
+        //We need to only trigger the toggle menu on small screen sizes to avoid buggy behavior when selecting menu items on larger screens
         var smScreen = (this.state.windowWidth < 768);
         var toggleMenu = smScreen ? {toggle: 'collapse',target:'.navbar-collapse'} : {toggle: null, target: null};
 

--- a/troposphere/static/js/components/Header.react.js
+++ b/troposphere/static/js/components/Header.react.js
@@ -127,6 +127,9 @@ define(function (require) {
       profile: React.PropTypes.instanceOf(Backbone.Model),
       currentRoute: React.PropTypes.array.isRequired
     },
+    
+    // We need the screen size for handling the opening and closing of our menu on small screens
+    //See the menu item render for implementation
 
     getInitialState: function() {
     return {windowWidth: window.innerWidth};
@@ -180,6 +183,8 @@ define(function (require) {
       var navLinks = links.map(function (link) {
         var isCurrentRoute = (link.name.toLowerCase() === this.props.currentRoute[0]);
         var className = isCurrentRoute ? "active" : null;
+        
+        //We need to only trigger the toggle menu on small screen sizes to avoid buggy behaviour when selecting menu items on larger screens
         var smScreen = (this.state.windowWidth < 768);
         var toggleMenu = smScreen ? {toggle: 'collapse',target:'.navbar-collapse'} : {toggle: null, target: null};
 

--- a/troposphere/static/js/components/Header.react.js
+++ b/troposphere/static/js/components/Header.react.js
@@ -128,6 +128,22 @@ define(function (require) {
       currentRoute: React.PropTypes.array.isRequired
     },
 
+    getInitialState: function() {
+    return {windowWidth: window.innerWidth};
+    },
+
+    handleResize: function(e) {
+        this.setState({windowWidth: window.innerWidth});
+    },
+
+    componentDidMount: function() {
+        window.addEventListener('resize', this.handleResize);
+    },
+
+    componentWillUnmount: function() {
+        window.removeEventListener('resize', this.handleResize);
+    },
+
     renderBetaToggle: function () {
       if (!window.show_troposphere_only) {
         return (
@@ -164,8 +180,11 @@ define(function (require) {
       var navLinks = links.map(function (link) {
         var isCurrentRoute = (link.name.toLowerCase() === this.props.currentRoute[0]);
         var className = isCurrentRoute ? "active" : null;
+        var smScreen = (this.state.windowWidth < 768);
+        var toggleMenu = smScreen ? {toggle: 'collapse',target:'.navbar-collapse'} : {toggle: null, target: null};
+
         return (
-          <li key={link.name}>
+          <li key={link.name} data-toggle={toggleMenu.toggle} data-target={toggleMenu.target} >
             <Link to={link.linksTo}>
               <i className={"glyphicon glyphicon-" + link.icon}></i>
               {link.name}


### PR DESCRIPTION
Added attributes, data-toggle and data-target, to menu items on small screen sizes that trigger bootstrap's mobile menu functionality. 

Because Bootstrap is using jQuery to manipulate the DOM we need to use data-target to tell Bootstrap where to apply the animation. For this reason, we also need the screen size because trying to animate the menu collapse while it is hidden on larger screen sizes causes buggy looking behavior as it tries to show and hide it. 

