### PR TITLE
Fix API_ROOT vars now get local not default SERVER_URL

### DIFF
--- a/scripts/generate_configs.py
+++ b/scripts/generate_configs.py
@@ -171,6 +171,7 @@ def generate_configs(configs, backup):
     success, messages = _handle_preconditions(configs)
     print_messages(messages)
     if not success:
+        print 'Config not generated.\n'
         exit(1)
     print 'Generating configs...\n'
     success, messages = _generate_configs(configs, backup)


### PR DESCRIPTION
`API_ROOT` incorrectly defined with the `defaults.py` `SERVER_URL` not the `local.py` version.
```
API_ROOT    = SERVER_URL + "/api/v1"
API_V2_ROOT = SERVER_URL + "/api/v2"
```

Any variables which depend on other variables must be defined in `troposphere/settings/__init__.py`. Otherwise local.py cannot affect those dependent vars.
