### PR TITLE
Be explicit when config is NOT generated

### DIFF
--- a/scripts/generate_configs.py
+++ b/scripts/generate_configs.py
@@ -171,6 +171,7 @@ def generate_configs(configs, backup):
     success, messages = _handle_preconditions(configs)
     print_messages(messages)
     if not success:
+        print 'Config not generated.\n'
         exit(1)
     print 'Generating configs...\n'
     success, messages = _generate_configs(configs, backup)


### PR DESCRIPTION
If the config fails, say that the config was not generated.