### PR TITLE
[ATMO-987] Include ability to end date entire image

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "scripts": {
     "dev" : "webpack -d --progress --profile --colors --bail --",
     "build": "webpack --progress --profile --colors --bail --",
+    "watch": "webpack -d --progress --profile --colors --watch",
     "jenkins": "webpack --profile --colors --",
     "test": "echo \"Error: no test specified\" && exit 1",
     "lint": "eslint"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "dev" : "webpack -d --progress --profile --colors --bail --",
     "build": "webpack --progress --profile --colors --bail --",
-    "watch": "webpack -d --progress --profile --colors --watch",
+    "watch": "webpack --progress --profile --colors --watch",
     "jenkins": "webpack --profile --colors --",
     "test": "echo \"Error: no test specified\" && exit 1",
     "lint": "eslint"

--- a/troposphere/static/js/actions/ImageActions.js
+++ b/troposphere/static/js/actions/ImageActions.js
@@ -9,7 +9,7 @@ define(function (require) {
     updateImageAttributes: function (image, newAttributes) {
       if(newAttributes.end_date != null) {
         var end_date;
-        if (typeof newAttributesend_date == "object") {
+        if (typeof newAttributes.end_date === "object") {
             end_date = newAttributes.end_date
         } else {
             end_date = moment(newAttributes.end_date);

--- a/troposphere/static/js/actions/ImageActions.js
+++ b/troposphere/static/js/actions/ImageActions.js
@@ -1,14 +1,25 @@
 define(function (require) {
 
-  var AppDispatcher = require('dispatchers/AppDispatcher'),
+  var moment = require('moment'),
+      AppDispatcher = require('dispatchers/AppDispatcher'),
       ImageConstants = require('constants/ImageConstants');
 
   return {
 
     updateImageAttributes: function (image, newAttributes) {
+      if(newAttributes.end_date != null) {
+        var end_date;
+        if (typeof newAttributesend_date == "object") {
+            end_date = newAttributes.end_date
+        } else {
+            end_date = moment(newAttributes.end_date);
+        }
+        newAttributes.end_date = end_date;
+      }
       image.set({
         name: newAttributes.name,
         description: newAttributes.description,
+        end_date: newAttributes.end_date,
         tags: newAttributes.tags
       });
       AppDispatcher.handleRouteAction({

--- a/troposphere/static/js/components/images/detail/EditImageDetails.react.js
+++ b/troposphere/static/js/components/images/detail/EditImageDetails.react.js
@@ -12,8 +12,8 @@ define(function (require) {
     AuthorView = require('./author/AuthorView.react'),
     actions = require('actions'),
     globals = require('globals'),
-    //moment = require('moment'),
-    //momentTZ = require('moment-timezone'),
+    moment = require('moment'),
+    momentTZ = require('moment-timezone'),
     stores = require('stores');
 
   return React.createClass({

--- a/troposphere/static/js/components/images/detail/EditImageDetails.react.js
+++ b/troposphere/static/js/components/images/detail/EditImageDetails.react.js
@@ -11,6 +11,9 @@ define(function (require) {
     EditRemovedView = require('./removed/EditRemovedView.react'),
     AuthorView = require('./author/AuthorView.react'),
     actions = require('actions'),
+    globals = require('globals'),
+    //moment = require('moment'),
+    //momentTZ = require('moment-timezone'),
     stores = require('stores');
 
   return React.createClass({
@@ -31,6 +34,7 @@ define(function (require) {
       return {
         name: image.get('name'),
         description: image.get('description'),
+        endDate: image.get('end_date').tz(globals.TZ_REGION).format("M/DD/YYYY hh:mm a z"),
         tags: imageTags
       }
     },
@@ -93,7 +97,7 @@ define(function (require) {
             />
             <CreatedView image={image}/>
             <InteractiveDateField
-              value={this.state.end_date}
+              value={this.state.endDate}
               onChange={this.handleEndDateChange}
               />
             <AuthorView image={image}/>

--- a/troposphere/static/js/components/images/detail/EditImageDetails.react.js
+++ b/troposphere/static/js/components/images/detail/EditImageDetails.react.js
@@ -6,7 +6,9 @@ define(function (require) {
     ImageLaunchCard = require('./launch/ImageLaunchCard.react'),
     EditNameView = require('./name/EditNameView.react'),
     EditDescriptionView = require('./description/EditDescriptionView.react'),
+    InteractiveDateField = require('components/common/InteractiveDateField.react'),
     CreatedView = require('./created/CreatedView.react'),
+    EditRemovedView = require('./removed/EditRemovedView.react'),
     AuthorView = require('./author/AuthorView.react'),
     actions = require('actions'),
     stores = require('stores');
@@ -37,10 +39,16 @@ define(function (require) {
       var updatedAttributes = {
         name: this.state.name,
         description: this.state.description,
+        end_date: this.state.endDate,
         tags: this.state.tags
       };
 
       this.props.onSave(updatedAttributes);
+    },
+
+    handleEndDateChange: function (value) {
+      var endDate = value;
+      this.setState({endDate: endDate});
     },
 
     handleNameChange: function (e) {
@@ -84,6 +92,10 @@ define(function (require) {
               onChange={this.handleNameChange}
             />
             <CreatedView image={image}/>
+            <InteractiveDateField
+              value={this.state.end_date}
+              onChange={this.handleEndDateChange}
+              />
             <AuthorView image={image}/>
             <EditDescriptionView
               titleClassName="title col-md-2"

--- a/troposphere/static/js/components/images/detail/ViewImageDetails.react.js
+++ b/troposphere/static/js/components/images/detail/ViewImageDetails.react.js
@@ -6,13 +6,14 @@ define(
     './launch/ImageLaunchCard.react',
     './name/NameView.react',
     './created/CreatedView.react',
+    './removed/RemovedView.react',
     './author/AuthorView.react',
     './description/DescriptionView.react',
     './versions/VersionsView.react',
     'actions',
     'stores'
   ],
-  function (React, HeaderView, TagsView, ImageLaunchCard, NameView, CreatedView, AuthorView, DescriptionView, VersionsView, actions, stores) {
+  function (React, HeaderView, TagsView, ImageLaunchCard, NameView, CreatedView, RemovedView, AuthorView, DescriptionView, VersionsView, actions, stores) {
 
     return React.createClass({
 
@@ -52,6 +53,7 @@ define(
             <div>
               <NameView image={this.props.image}/>
               <CreatedView image={this.props.image}/>
+              <RemovedView image={this.props.image}/>
               <AuthorView image={this.props.image}/>
               <DescriptionView image={this.props.image}/>
               {tagsView}

--- a/troposphere/static/js/components/images/detail/removed/RemovedView.react.js
+++ b/troposphere/static/js/components/images/detail/removed/RemovedView.react.js
@@ -15,13 +15,23 @@ define(
 
       render: function () {
         var image = this.props.image,
-          startDate = moment(image.get('start_date')).format("MMM D, YYYY hh:mm a");
+            endDate = moment(image.get('end_date'));
+        if (endDate.isValid()) {
+            endDate = endDate.format("MMM D, YYYY hh:mm a");
+        } else {
+            //Hide this from view when end date isn't available
+            // Based on API permissions, this means only STAFF
+            // and ImageOwners will see this view.
+            return (
+                <div className="hidden">
+                </div>);
+        }
 
         return (
           <div className="image-info-segment row">
-            <h4 className="title col-md-2">Created</h4>
+            <h4 className="title col-md-2">Removed from Image List</h4>
 
-            <p className="content col-md-10">{startDate}</p>
+            <p className="content col-md-10">{endDate}</p>
           </div>
         );
       }

--- a/troposphere/static/js/components/images/detail/removed/RemovedView.react.js
+++ b/troposphere/static/js/components/images/detail/removed/RemovedView.react.js
@@ -1,43 +1,41 @@
+define(function (require) {
+  var React = require('react'),
+    Backbone = require('backbone'),
+    globals = require('globals'),
+    moment = require('moment'),
+    // implicit include within context for `.tz()`
+    momentTZ = require('moment-timezone');
 
-define(
-  [
-    'react',
-    'backbone',
-    'globals',
-    'moment'
-  ],
-  function (React, Backbone, globals, moment) {
+  return React.createClass({
 
-    return React.createClass({
+    propTypes: {
+      image: React.PropTypes.instanceOf(Backbone.Model).isRequired
+    },
 
-      propTypes: {
-        image: React.PropTypes.instanceOf(Backbone.Model).isRequired
-      },
-
-      render: function () {
-        var image = this.props.image,
-            endDate = moment(image.get('end_date'));
-        if (endDate.isValid()) {
-            formatDate = endDate.tz(globals.TZ_REGION).format("M/DD/YYYY hh:mm a z");
-            endDate = formatDate;
-        } else {
-            //Hide this from view when end date isn't available
-            // Based on API permissions, this means only STAFF
-            // and ImageOwners will see this view.
-            return (
-                <div className="hidden">
-                </div>);
-        }
-
-        return (
-          <div className="image-info-segment row">
-            <h4 className="title col-md-2">Removed from Image List</h4>
-
-            <p className="content col-md-10">{endDate}</p>
-          </div>
-        );
+    render: function () {
+      var image = this.props.image,
+          endDate = moment(image.get('end_date'));
+      if (endDate.isValid()) {
+          formatDate = endDate.tz(globals.TZ_REGION).format("M/DD/YYYY hh:mm a z");
+          endDate = formatDate;
+      } else {
+          // Hide this from view when end date isn't available
+          // Based on API permissions, this means only STAFF
+          // and ImageOwners will see this view.
+          return (
+              <div className="hidden">
+              </div>);
       }
 
-    });
+      return (
+        <div className="image-info-segment row">
+          <h4 className="title col-md-2">Removed from Image List</h4>
+
+          <p className="content col-md-10">{endDate}</p>
+        </div>
+      );
+    }
 
   });
+
+});

--- a/troposphere/static/js/components/images/detail/removed/RemovedView.react.js
+++ b/troposphere/static/js/components/images/detail/removed/RemovedView.react.js
@@ -3,9 +3,10 @@ define(
   [
     'react',
     'backbone',
+    'globals',
     'moment'
   ],
-  function (React, Backbone, moment) {
+  function (React, Backbone, globals, moment) {
 
     return React.createClass({
 
@@ -17,7 +18,8 @@ define(
         var image = this.props.image,
             endDate = moment(image.get('end_date'));
         if (endDate.isValid()) {
-            endDate = endDate.format("MMM D, YYYY hh:mm a");
+            formatDate = endDate.tz(globals.TZ_REGION).format("M/DD/YYYY hh:mm a z");
+            endDate = formatDate;
         } else {
             //Hide this from view when end date isn't available
             // Based on API permissions, this means only STAFF

--- a/troposphere/static/js/components/modals/image_version/ImageVersionEditModal.react.js
+++ b/troposphere/static/js/components/modals/image_version/ImageVersionEditModal.react.js
@@ -9,6 +9,7 @@ define(function (require) {
       VersionChanges = require('../instance/image/components/VersionChangeLog.react'),
       EditAvailabilityView = require('./availability/EditAvailabilityView.react'),
       EditDescriptionView = require('components/images/detail/description/EditDescriptionView.react'),
+      InteractiveDateField = require('components/common/InteractiveDateField.react'),
       EditMembershipView = require('./membership/EditMembershipView.react'),
       EditLicensesView = require('./licenses/EditLicensesView.react'),
       EditScriptsView = require('./scripts/EditScriptsView.react'),
@@ -125,18 +126,9 @@ define(function (require) {
       this.setState({versionName: e.target.value});
     },
 
-    onEndDateChange: function (e) {
-      this.setState({versionEndDate: e.target.value});
+    onEndDateChange: function (value) {
+      this.setState({versionEndDate: value});
     },
-    setEndDateNow: function (e) {
-      var now_time = moment(new Date());
-      this.setState({versionEndDate: now_time.format("MMM D, YYYY hh:mm a")});
-    },
-
-    unsetEndDateNow: function (e) {
-      this.setState({versionEndDate: ""});
-    },
-
     onUncopyableSelected: function (e) {
       var uncopyable = (e.target.checked);
       this.setState({versionCanImage: uncopyable});
@@ -310,14 +302,10 @@ define(function (require) {
         </div>
       );
       //FUTURE_keyTODO: Pull this functionality out if you use it anywhere else..
-      endDateView = (<div className='form-group'>
-        <label htmlFor='version-end-date'>Date to hide image from public view</label>
-        <div className="input-group">
-          <input type='text' className='form-control' value={ended} onChange={this.onEndDateChange}/>
-          <span className="input-group-addon" id="enddate-set-addon" onClick={this.setEndDateNow}>Set</span>
-          <span className="input-group-addon" id="enddate-clear-addon" onClick={this.unsetEndDateNow}>Clear</span>
-        </div>
-      </div>);
+      endDateView = (<InteractiveDateField
+              value={ended}
+              onChange={this.onEndDateChange}
+              />);
       startDateView = (<div className='form-group'>
           <label htmlFor='version-version'>Version Created On</label>
           <input type='text' className='form-control' value={created} readOnly={true} editable={false}/>

--- a/troposphere/static/js/stores/ImageStore.js
+++ b/troposphere/static/js/stores/ImageStore.js
@@ -1,6 +1,7 @@
 define(function (require) {
 
-  var ImageCollection = require('collections/ImageCollection'),
+  var moment = require('moment'),
+      ImageCollection = require('collections/ImageCollection'),
       ProviderCollection = require('collections/ProviderCollection'),
       Dispatcher = require('dispatchers/Dispatcher'),
       BaseStore = require('stores/BaseStore'),
@@ -16,11 +17,29 @@ define(function (require) {
       var tagIds = tags.map(function(tag){
           return tag.id;
       });
-      image.save({
+      var updateAttrs = {
         name: image.get('name'),
         description: image.get('description'),
         tags: tagIds
-      }, {
+      }
+      if(image.get('end_date')) {
+        var end_date;
+        if (typeof image.get('end_date') == "object") {
+            end_date = image.get('end_date')
+        } else {
+            //NOTE: This may never happen..
+            end_date = moment(image.get('end_date'));
+        }
+        //Test validity if the date
+        if(end_date.isValid()) {
+            end_date = end_date.toISOString();
+        } else {
+            end_date = null;
+        }
+        //Add new date (or non-date) to the update list
+        updateAttrs.end_date = end_date
+      }
+      image.save(updateAttrs, {
         patch: true
       }).done(function(){
         image.set({tags:tags});


### PR DESCRIPTION
*(Summary pulled from #160)*
---- 
Example of the "Input box" users see when they edit their image.
![screen shot 2015-10-05 at 11 48 19 am](https://cloud.githubusercontent.com/assets/2889930/10290115/1a4ece60-6b57-11e5-9918-3a0b27e07877.png)

Example of the interface when an object has been end-dated (As seen by image creator or Staff users... "Normal" users will not see the image at all!)
![screen shot 2015-10-05 at 11 48 05 am](https://cloud.githubusercontent.com/assets/2889930/10290150/4e1e9a9a-6b57-11e5-9121-b7707c89fdde.png)
