### PR TITLE
Stop user from moving attached resources ATMO-747

### DIFF
--- a/troposphere/static/js/components/modals/project/CantMoveAttachedModal.react.js
+++ b/troposphere/static/js/components/modals/project/CantMoveAttachedModal.react.js
@@ -1,0 +1,43 @@
+define(function (require) {
+    var React = require('react/addons'),
+    BootstrapModalMixin = require('components/mixins/BootstrapModalMixin.react');
+    
+    return React.createClass({
+    displayName: "CantMoveAttached",
+    
+     mixins: [BootstrapModalMixin],
+     
+     confirm: function () {
+         this.hide();
+     },
+
+     render: function () {
+
+     var content = (
+        <div>
+            <h4>You are trying to move attached resources</h4>
+            <p>An instance or volume can not be moved while attached. To move these resources, please dettach them by first selecting the attached volume and then selecting the dettach option top right.</p>
+        </div>
+       );
+
+        return (
+          <div className="modal fade">
+            <div className="modal-dialog">
+              <div className="modal-content">
+                <div className="modal-header">
+                  <h3>Resources Still Attached</h3>
+                </div>
+                <div className="modal-body">
+                {content}
+                </div>
+                <div className="modal-footer">
+                <button className="btn btn-primary" onClick={this.confirm} >OK</button>
+                </div>
+              </div>
+            </div>
+          </div>
+        );
+      }
+
+    });
+});

--- a/troposphere/static/js/components/projects/detail/resources/ProjectDetails.react.js
+++ b/troposphere/static/js/components/projects/detail/resources/ProjectDetails.react.js
@@ -101,10 +101,18 @@ define(function (require) {
     },
 
     onMoveSelectedResources: function () {
-      modals.ProjectModals.moveResources(
-        this.state.selectedResources,
-        this.props.project
-      );
+        var match = false;
+        this.state.selectedResources.forEach(function(sel){
+            if (stores.VolumeStore.getAttachedResources().indexOf(sel.get('uuid')) !== -1) {
+                match = true;
+            }
+        });
+        if (match) modals.ProjectModals.cantMoveAttached();
+        else
+        modals.ProjectModals.moveResources(
+            this.state.selectedResources,
+            this.props.project
+        );
     },
 
     onDeleteSelectedResources: function () {

--- a/troposphere/static/js/modals/ProjectModals.js
+++ b/troposphere/static/js/modals/ProjectModals.js
@@ -4,6 +4,7 @@ define(function (require) {
     create: require('./project/create').create,
     destroy: require('./project/destroy').destroy,
     explainProjectDeleteConditions: require('./project/explainProjectDeleteConditions').explainProjectDeleteConditions,
+    cantMoveAttached: require('./project/cantMoveAttached').cantMoveAttached,
     moveResources: require('./project/moveResources').moveResources,
     removeResources: require('./project/removeResources').removeResources
   };

--- a/troposphere/static/js/modals/project/cantMoveAttached.js
+++ b/troposphere/static/js/modals/project/cantMoveAttached.js
@@ -1,0 +1,14 @@
+define(function (require) {
+
+  var actions = require('actions'),
+    ModalHelpers = require('components/modals/ModalHelpers'),
+    CantMoveAttachedModal = require('components/modals/project/CantMoveAttachedModal.react');
+
+  return {
+    cantMoveAttached: function () {
+      ModalHelpers.renderModal(CantMoveAttachedModal, null, function () {
+      });
+    }
+  }
+
+});

--- a/troposphere/static/js/stores/VolumeStore.js
+++ b/troposphere/static/js/stores/VolumeStore.js
@@ -44,12 +44,10 @@ define(function (require) {
         var attachedResources = [];
         this.models.each(function (volume) {
             var attachData = volume.get('attach_data');
-            if (attachData.instance_id !== null)
-                var attached = {
-                    volumeID: volume.get('uuid'),
-                    instanceID: attachData.instance_id
-                };
-                attachedResources.push(attached);
+            if (attachData.instance_id !== null) {
+                attachedResources.push(volume.get('uuid'));
+                attachedResources.push(attachData.instance_id);
+            }
         });
         return attachedResources;
     },

--- a/troposphere/static/js/stores/VolumeStore.js
+++ b/troposphere/static/js/stores/VolumeStore.js
@@ -38,6 +38,23 @@ define(function (require) {
       return attachedVolumes;
     },
 
+// Makes a clean list of attached resources from volume information for easy reference
+    getAttachedResources: function () {
+        if (!this.models) return this.fetchModels();
+        var attachedResources = [];
+        this.models.each(function (volume) {
+            var attachData = volume.get('attach_data');
+            if (attachData.instance_id !== null)
+                var attached = {
+                    volumeID: volume.get('uuid'),
+                    instanceID: attachData.instance_id
+                };
+                attachedResources.push(attached);
+        });
+        return attachedResources;
+    },
+
+
     getVolumesNotInAProject: function () {
       if (!this.models) return this.fetchModels();
 


### PR DESCRIPTION
When user tries to move a a batch of selected resources, if any resources are attached a modal alerting the user to first detach the resources stops the user from putting the resource into an inconsistent state. 

![cant-move-resource](https://cloud.githubusercontent.com/assets/7366338/10530713/477ee2e8-735f-11e5-8145-979128d2f656.png)

**This is a minimum viable solution**

We should display which resources are attached and allow the user to detach from modal. Also, a redesign would help prevent this form happening. I would also suggest letting the user move both resources leaving them attached. 