### PR TITLE
Add change log to version card ATMO 986

### DIFF
--- a/troposphere/static/js/components/images/detail/versions/Version.react.js
+++ b/troposphere/static/js/components/images/detail/versions/Version.react.js
@@ -88,8 +88,8 @@ define(function (require) {
           versionHash = CryptoJS.MD5(version.id.toString()).toString(),
           iconSize = 63,
           type = stores.ProfileStore.get().get('icon_set'),
-          owner = image.get('created_by').username;
-
+          owner = image.get('created_by').username,
+          changeLog = this.props.version.attributes.change_log;
       return (
         <li className="app-card">
           <div>
@@ -104,6 +104,7 @@ define(function (require) {
                 {isRecommended ? <span className="recommended-tag">Recommended</span> : null}
 
                 {this.renderDateString(version)} by {owner} <br />
+                <p>{changeLog}</p>
               </div>
                 {this.renderEditLink()}
                 {this.renderAvailability()}


### PR DESCRIPTION
There is now a change log displayed on the version card when viewing an image's details just below the author and date created. See below:

![chang-log](https://cloud.githubusercontent.com/assets/7366338/10587711/4004922e-7657-11e5-92a7-f4e9548cb901.png)

**We still need to make some style improvements**
The left side padding of the change log is inappropriate. See below:

![change-log_pad-issue](https://cloud.githubusercontent.com/assets/7366338/10587758/8f7fef9c-7657-11e5-9cda-3456b60771eb.png)

The problem here is with the css on the 'app-card' class itself so a small refactor should be done as a separate issue as it effects several components.
