### PR TITLE
ATMO-1010 launch modal padding

### DIFF
--- a/troposphere/static/js/components/modals/instance/InstanceLaunchWizardModal.react.js
+++ b/troposphere/static/js/components/modals/instance/InstanceLaunchWizardModal.react.js
@@ -217,7 +217,7 @@ define(function(require) {
                 <strong>Instance Launch Wizard- {this.state.title}</strong>
               </div>
               <div className="modal-body">
-                <div className="clearfix">
+                <div className="clearfix modal-section">
                     {this.renderBreadCrumbTrail()}
                 </div>
                 {this.renderBody()}

--- a/troposphere/static/js/components/modals/instance/InstanceLaunchWizardModal.react.js
+++ b/troposphere/static/js/components/modals/instance/InstanceLaunchWizardModal.react.js
@@ -216,10 +216,10 @@ define(function(require) {
                 {this.renderCloseButton()}
                 <strong>Instance Launch Wizard- {this.state.title}</strong>
               </div>
-              <div className="modal-section">
-                {this.renderBreadCrumbTrail()}
-              </div>
               <div className="modal-body">
+                <div className="clearfix">
+                    {this.renderBreadCrumbTrail()}
+                </div>
                 {this.renderBody()}
               </div>
             </div>

--- a/troposphere/static/js/components/modals/instance/launch/steps/NameIdentityVersionStep.react.js
+++ b/troposphere/static/js/components/modals/instance/launch/steps/NameIdentityVersionStep.react.js
@@ -232,12 +232,13 @@ define(function (require) {
                                 />
                             </div>
                         </div>
-                        <div className="form-group">
+                        <div className="modal-section">
                             <h4>Project Allocation Usage</h4>
-                            {this.renderAllocationConsumption(this.state.identity)}
+                            <div className="form-group">
+                                {this.renderAllocationConsumption(this.state.identity)}
+                            </div>
+                            <a href="#" onClick={this.props.onRequestResources}>Need more resources?</a>
                         </div>
-                        <a href="#" onClick={this.props.onRequestResources}>Need more resources?</a>
-
                     </div>
                 </div>
             );

--- a/troposphere/static/js/components/modals/instance/launch/steps/SizeSelectStep.react.js
+++ b/troposphere/static/js/components/modals/instance/launch/steps/SizeSelectStep.react.js
@@ -257,11 +257,12 @@ define(function (require) {
                     />
                 </div>
               </div>
-
-              <div className="form-group modal-section">
+              <div className="modal-section">
                 <h4>Projected Resource Usage</h4>
-                {this.renderCpuConsumption(selectedIdentity, size, sizes, instances)}
-                {this.renderMemoryConsumption(selectedIdentity, size, sizes, instances)}
+                <div className="form-group">
+                    {this.renderCpuConsumption(selectedIdentity, size, sizes, instances)}
+                    {this.renderMemoryConsumption(selectedIdentity, size, sizes, instances)}
+                </div>
               </div>
               <a href="#" onClick={this.props.onRequestResources}>Need more resources?</a>
 


### PR DESCRIPTION
The issue was with the `form-horizontal` class applying negative margins to nested `form-group` classes. This is to compensate for the padding added columns, the same issue will occur with the misuse of the `row` class. 

![launch-modal-before](https://cloud.githubusercontent.com/assets/7366338/10613693/169d619a-770b-11e5-89cf-16e237122931.png)

It was fixed by pulling the headings out of the `form-group` classes. Also, the breadcrumb was not nested within the modal body so it just wasn't contained by the body padding. 

![launch-modal-after](https://cloud.githubusercontent.com/assets/7366338/10613710/2f7c6468-770b-11e5-9aa4-f8d96717ec10.png)

