### PR TITLE
Defined foreign key relation in User to include preferences.  

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -2,6 +2,14 @@ from rest_framework import serializers
 from django.contrib.auth.models import User
 from api.models import UserPreferences
 
+class UserPreferencesSummarySerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = UserPreferences
+        fields = (
+            'id',
+            'url'
+        )
+
 
 class UserRelatedField(serializers.PrimaryKeyRelatedField):
 
@@ -14,6 +22,10 @@ class UserRelatedField(serializers.PrimaryKeyRelatedField):
 
 
 class UserSerializer(serializers.HyperlinkedModelSerializer):
+    user_pref = UserPreferencesSummarySerializer(
+        source='userpreferences_set',
+        many=True)
+
     class Meta:
         model = User
         fields = (
@@ -25,7 +37,8 @@ class UserSerializer(serializers.HyperlinkedModelSerializer):
             'email',
             'is_staff',
             'is_superuser',
-            'date_joined'
+            'date_joined',
+            'user_pref'
         )
 
 


### PR DESCRIPTION
This provides a true relationship between a troposhere User and their preferences, it address the ticket [ATMO-1052](https://pods.iplantcollaborative.org/jira/browse/ATMO-1052). 

A response to a `GET tropo-api/users/<user-id>` now includes a hyperlink to the `UserPreferences` resource associated with the User. 

```bash
$  curl --insecure -H 'Authorization: Token <TGToken>' \ 
https://ui.atmo.dev/tropo-api/users/1 | python -mjson.tool

{
    "date_joined": "2015-09-10T17:29:19.661509Z",
    "email": "lenards@iplantcollaborative.org",
    "first_name": "Andrew Lenards",
    "id": 1,
    "is_staff": false,
    "is_superuser": false,
    "last_name": "Mock Lenards, just try",
    "url": "https://ui.atmo.dev/tropo-api/users/1",
    "user_pref": [
        {
            "id": 1,
            "url": "https://ui.atmo.dev/tropo-api/user_preferences/1"
        }
    ],
    "username": "lenards"
}
```

Using this response, `this.user_pref[0].url` can be used to send a `PATCH tropo-api/user_preferences/<user-pref-id>` to modify any mutable preference. 

