### PR TITLE
Changed the default UI preference for new users.

### DIFF
--- a/api/migrations/0002_alter_ui_pref_default.py
+++ b/api/migrations/0002_alter_ui_pref_default.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('api', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='userpreferences',
+            name='show_beta_interface',
+            field=models.BooleanField(default=True),
+            preserve_default=True,
+        ),
+    ]

--- a/api/models.py
+++ b/api/models.py
@@ -56,7 +56,7 @@ class UserToken(models.Model):
 
 class UserPreferences(models.Model):
     user = models.ForeignKey(User)
-    show_beta_interface = models.BooleanField(default=False)
+    show_beta_interface = models.BooleanField(default=True)
     created_date = models.DateTimeField(auto_now_add=True)
     modified_date = models.DateTimeField(auto_now=True)
 


### PR DESCRIPTION
We want to begin phasing out the previous user interface, *Airport*, in favor of the current version. This will default new users to the current (aka _beta_) user interface. 

This work is a sub-task ([ATMO-1057](https://pods.iplantcollaborative.org/jira/browse/ATMO-1057)) of [ATMO-1016](https://pods.iplantcollaborative.org/jira/browse/ATMO-1016).