### PR TITLE
Moved Secondary Navigation above Title 

### DIFF
--- a/troposphere/static/css/app/layout.scss
+++ b/troposphere/static/css/app/layout.scss
@@ -32,7 +32,7 @@
 .secondary-nav {
   background: white;
   border-bottom: 1px solid #EEEEEE;
-  margin-bottom: 35px;
+  margin-bottom: 20px;
 
   .project-name i {
     display: none;
@@ -394,10 +394,6 @@
       background-color: #eee;
     }
   }
-}
-
-.project-details > div.container {
-  margin-top: -35px;
 }
 
 // Table styles

--- a/troposphere/static/js/components/projects/common/SecondaryProjectNavigation.react.js
+++ b/troposphere/static/js/components/projects/common/SecondaryProjectNavigation.react.js
@@ -48,11 +48,6 @@ define(function (require) {
           <div className="secondary-nav">
             <div className="container">
 
-              <div className="project-name">
-                <h1>
-                  {project.get('name')}
-                </h1>
-              </div>
 
               <ul className="secondary-nav-links">
                 {this.renderRoute("Resources", "project-resources", "th", {projectId: project.id})}
@@ -79,6 +74,11 @@ define(function (require) {
 
             </div>
           </div>
+              <div className="project-name container">
+                <h1>
+                  {project.get('name')}
+                </h1>
+              </div>
         </div>
       );
     }


### PR DESCRIPTION
# Move Secondary Navigation Above Title on Projects Page

**Purpose**
* Reduce clutter around options and actions
* Places navigation concerns together above location concerns 
* Is consistent with Images section

**Changes:**
* Moved Project Title block out of secondary nav block and gave it it's own container class
* Removed negative margins from the resource list
* Reduced the bottom margin on Secondary Navigation to 20px

![move-secondary-nav](https://cloud.githubusercontent.com/assets/7366338/10890292/7b97d618-8154-11e5-9fd1-81d45481eaf3.png)

