### PR TITLE
Corrected property used from `quota` to calculate memory usage.

### DIFF
--- a/troposphere/static/js/components/dashboard/plots/ProviderSummaryLinePlot.react.js
+++ b/troposphere/static/js/components/dashboard/plots/ProviderSummaryLinePlot.react.js
@@ -196,7 +196,7 @@ define(function (require) {
       },
 
       calculateMemoryUsage: function (instances, quota, sizes) {
-        var maxMemory = quota.mem;
+        var maxMemory = quota.memory;
 
         var currentMemory = instances.reduce(function (memo, instance) {
           var size = sizes.get(instance.get('size').id);


### PR DESCRIPTION
The `quota` object is exposing the memory as `quota.memory` now;
not `quota.mem`.

This is a fix for [ATMO-1042](https://pods.iplantcollaborative.org/jira/browse/ATMO-1042). 