### PR TITLE
Improve admin page

### DIFF
--- a/troposphere/static/css/app/admin.scss
+++ b/troposphere/static/css/app/admin.scss
@@ -14,6 +14,12 @@
 	position: relative;
 	border: 5px solid;
     border-color: $brand-primary;
+
+    .radio-buttons{
+    	input[type="radio"]{
+    		margin: 1%;
+    	}
+    }
 }
 
 .admin-detail button{
@@ -21,7 +27,7 @@
 }
 
 .admin-detail div{
-	margin: 2%;
+	margin-top: 2%;
 }
 
 .admin-row, .quota-inline{

--- a/troposphere/static/js/actions/AllocationActions.js
+++ b/troposphere/static/js/actions/AllocationActions.js
@@ -1,0 +1,27 @@
+define(function (require) {
+
+  var AppDispatcher = require('dispatchers/AppDispatcher'),
+    AllocationConstants = require('constants/AllocationConstants'),
+    Allocation = require('models/Allocation'),
+    Utils = require('./Utils'),
+    stores = require('stores');
+
+  return {
+
+    create: function(params){
+
+      var allocation = new Allocation({
+        threshold: parseInt(params.threshold),
+        delta: parseInt(params.delta)
+      });
+
+      allocation.save().done(function(){
+        Utils.dispatch(AllocationConstants.CREATE_ALLOCATION, {allocation: allocation}, {silent: false});
+      }).fail(function(response){
+        console.log(response);
+      });
+    }
+
+  };
+
+});

--- a/troposphere/static/js/bootstrapper.js
+++ b/troposphere/static/js/bootstrapper.js
@@ -68,6 +68,7 @@ define(function (require) {
   stores.VolumeStore = require('stores/VolumeStore');
 
   var actions = require('actions');
+  actions.AllocationActions = require('actions/AllocationActions');
   actions.BadgeActions = require('actions/BadgeActions');
   actions.HelpActions = require('actions/HelpActions');
   actions.ImageActions = require('actions/ImageActions');

--- a/troposphere/static/js/constants/AllocationConstants.js
+++ b/troposphere/static/js/constants/AllocationConstants.js
@@ -1,0 +1,9 @@
+define(
+  [],
+  function () {
+
+    return {
+      CREATE_ALLOCATION: "CREATE_ALLOCATION"
+    };
+
+  });

--- a/troposphere/static/js/stores/AllocationStore.js
+++ b/troposphere/static/js/stores/AllocationStore.js
@@ -1,56 +1,18 @@
 define(function (require) {
 
   var _ = require('underscore'),
+    BaseStore = require('stores/BaseStore'),
     Dispatcher = require('dispatchers/Dispatcher'),
     Store = require('stores/Store'),
-    Constants = require('constants/ResourceRequestConstants'),
-    Collection = require('collections/AllocationCollection'),
+    AllocationConstants = require('constants/AllocationConstants'),
+    AllocationCollection = require('collections/AllocationCollection'),
     stores = require('stores');
 
-  var _models = null;
-  var _isFetching = false;
+  var  AllocationStore = BaseStore.extend({
+    collection: AllocationCollection
+  }); 
 
-  //
-  // CRUD Operations
-  //
-
-  var fetchModels = function () {
-    if (!_models && !_isFetching) {
-      _isFetching = true;
-      var models = new Collection();
-      models.fetch({
-        url: models.url + "?page_size=100"
-      }).done(function () {
-        _isFetching = false;
-        _models = models;
-        ModelStore.emitChange();
-      });
-    }
-  };
-
-
-  //
-  // Model Store
-  //
-
-  var ModelStore = {
-
-    get: function (modelId) {
-      if (!_models) {
-        fetchModels();
-      } else {
-        return _models.get(modelId);
-      }
-    },
-
-    getAll: function () {
-      if (!_models) {
-        fetchModels()
-      }
-      return _models;
-    }
-
-  };
+  var store = new AllocationStore();
 
   Dispatcher.register(function (dispatch) {
     var actionType = dispatch.action.actionType;
@@ -58,7 +20,8 @@ define(function (require) {
     var options = dispatch.action.options || options;
 
     switch (actionType) {
-      case Constants.EMIT_CHANGE:
+      case AllocationConstants.CREATE_ALLOCATION:
+        store.add(payload.allocation);
         break;
 
       default:
@@ -66,13 +29,11 @@ define(function (require) {
     }
 
     if (!options.silent) {
-      ModelStore.emitChange();
+      store.emitChange();
     }
 
     return true;
   });
 
-  _.extend(ModelStore, Store);
-
-  return ModelStore;
+  return store;
 });


### PR DESCRIPTION
* Allow admins to search for allocations by AU, not have to select from list of threshold/delta values. 
* Abstract delta -1 vs. any other delta value for expiration of allocation to radio buttons.
* Allow creation of new allocation objects from UI, no need to use Django admin for creation
* Don't allow for approval if admin message is empty (updated after screenshot below) or if allocation searched for does not exist
<img width="623" alt="screenshot1" src="https://cloud.githubusercontent.com/assets/11079642/10897247/bdeeb950-817c-11e5-9c31-b6950d1f4ded.png">
<img width="541" alt="screenshot2" src="https://cloud.githubusercontent.com/assets/11079642/10897248/bdef2e62-817c-11e5-91c0-513b430d50b7.png">
