### PR TITLE
Corrected instance size order comparison.

### DIFF
--- a/troposphere/static/js/collections/SizeCollection.js
+++ b/troposphere/static/js/collections/SizeCollection.js
@@ -22,8 +22,8 @@ define(function (require) {
     },
 
     comparator: function (sizeA, sizeB) {
-      var aliasA = sizeA.get('alias').toLowerCase();
-      var aliasB = sizeB.get('alias').toLowerCase();
+      var aliasA = parseInt(sizeA.get('alias'));
+      var aliasB = parseInt(sizeB.get('alias'));
 
       if (aliasA === aliasB) return 0;
       return aliasA < aliasB ? -1 : 1;


### PR DESCRIPTION
Currently, the instance sizes are shown in an unexpected order. [ATMO-1060](https://pods.iplantcollaborative.org/jira/browse/ATMO-1060). This change altered the instance size comparator to marshal `alias` attribute as an `int` for proper comparison (and not lexical/alpha comparison).

Fix will be available in beta environment. 

A screenshot from the local development environment shows the new ordering:
<img width="463" alt="screen shot 2015-11-04 at 4 24 04 pm" src="https://cloud.githubusercontent.com/assets/5923/10955404/c0523920-8310-11e5-8127-c2420dced6c2.png">