### PR TITLE
Added tooltip hide option to button onClick event

### DIFF
--- a/troposphere/static/js/components/projects/detail/resources/Button.react.js
+++ b/troposphere/static/js/components/projects/detail/resources/Button.react.js
@@ -32,11 +32,18 @@ define(function (require) {
       });
     },
 
+    onClick: function(){
+      var el = this.getDOMNode();
+      var $el = $(el);
+      $el.tooltip('hide');
+      this.props.onClick();
+    },
+
     render: function () {
       var style = this.props.style || {};
       if (this.props.isVisible) {
         return (
-          <button className="btn btn-default" style={style} onClick={this.props.onClick}>
+          <button className="btn btn-default" style={style} onClick={this.onClick}>
             <i className={"glyphicon glyphicon-" + this.props.icon}/>
           </button>
         );

--- a/troposphere/static/js/components/projects/detail/resources/Button.react.js
+++ b/troposphere/static/js/components/projects/detail/resources/Button.react.js
@@ -35,6 +35,8 @@ define(function (require) {
     onClick: function(){
       var el = this.getDOMNode();
       var $el = $(el);
+      //Manually hides tooltip to fix a bug using modals 
+      //See: https://github.com/iPlantCollaborativeOpenSource/troposphere/pull/201
       $el.tooltip('hide');
       this.props.onClick();
     },

--- a/troposphere/static/js/components/projects/detail/resources/Button.react.js
+++ b/troposphere/static/js/components/projects/detail/resources/Button.react.js
@@ -35,7 +35,7 @@ define(function (require) {
     onClick: function(){
       var el = this.getDOMNode();
       var $el = $(el);
-      //Manually hides tooltip to fix a bug using modals 
+      //Manually hides tooltip to fix a bug when using modals 
       //See: https://github.com/iPlantCollaborativeOpenSource/troposphere/pull/201
       $el.tooltip('hide');
       this.props.onClick();

--- a/troposphere/static/js/components/projects/detail/resources/ProjectDetails.react.js
+++ b/troposphere/static/js/components/projects/detail/resources/ProjectDetails.react.js
@@ -104,7 +104,7 @@ define(function (require) {
     onMoveSelectedResources: function () {
         var match = false,
             attachedResources = stores.VolumeStore.getAttachedResources();
-        
+
         this.state.selectedResources.forEach(function(sel) {
             if (attachedResources.indexOf(sel.get('uuid')) !== -1) {
                 match = true;

--- a/troposphere/static/js/components/projects/detail/resources/ProjectDetails.react.js
+++ b/troposphere/static/js/components/projects/detail/resources/ProjectDetails.react.js
@@ -104,7 +104,7 @@ define(function (require) {
     onMoveSelectedResources: function () {
         var match = false,
             attachedResources = stores.VolumeStore.getAttachedResources();
-
+        
         this.state.selectedResources.forEach(function(sel) {
             if (attachedResources.indexOf(sel.get('uuid')) !== -1) {
                 match = true;


### PR DESCRIPTION
This fixes a bug where the tooltip on a button that fires a modal gets stuck open in front of said modal. 
This might be a bug in the browser or a bug with the way the modal and tooltip play with React. 

The easiest solution was to manually hide the tooltip when clicked. 

The onClick event was refactored so that the hiding could happen on the Button component level for reusability without affecting the parents that use it. 

**With Bug**
![tooltip-bug](https://cloud.githubusercontent.com/assets/7366338/11048794/2132f84e-86f7-11e5-9a00-2491fc119f3b.png)

**Without Bug**
![fixed-tooltip-bug](https://cloud.githubusercontent.com/assets/7366338/11048793/212f50cc-86f7-11e5-