### PR TITLE
Add better error handling for instance metrics

### DIFF
--- a/troposphere/static/js/components/projects/resources/instance/details/sections/metrics/InstanceMetrics.react.js
+++ b/troposphere/static/js/components/projects/resources/instance/details/sections/metrics/InstanceMetrics.react.js
@@ -2,8 +2,7 @@ define(function(require) {
   var React = require('react'),
     GraphController = require('./GraphController'),
     TimeframeBreadcrumb = require('./TimeframeBreadcrumb.react'),
-    RefreshComponent = require('./RefreshComponent.react'),
-    stores = require('stores');
+    RefreshComponent = require('./RefreshComponent.react');
 
 
   return React.createClass({

--- a/troposphere/static/js/components/projects/resources/instance/details/sections/metrics/Utils.js
+++ b/troposphere/static/js/components/projects/resources/instance/details/sections/metrics/Utils.js
@@ -19,7 +19,9 @@ define(function(require) {
       .header("Authorization", "Token " + access_token)
       .get(function(error, json) {
 
-        if (!json) return onError && onError();
+        // The json object should be an array with length >= 1 
+        if (!(json && Array.isArray(json) && json.length)) 
+          return onError && onError();
         var data = json[0].datapoints
 
         // Trim initial/final null values


### PR DESCRIPTION
If the api returned with [], the onError wouldn't fire, because [] is not
falsy in js. Also removed unused import.