### PR TITLE
Add Instance Reboot Button to Project Resources Page

### DIFF
--- a/troposphere/static/js/components/projects/detail/resources/InstanceActionButtons.react.js
+++ b/troposphere/static/js/components/projects/detail/resources/InstanceActionButtons.react.js
@@ -27,6 +27,10 @@ define(function (require) {
       modals.InstanceModals.stop(this.props.instance);
     },
 
+    onReboot: function(){
+      modals.InstanceModals.reboot(this.props.instance);
+    },
+
     onResume: function () {
       modals.InstanceModals.resume(this.props.instance);
     },
@@ -61,6 +65,15 @@ define(function (require) {
               icon="stop"
               tooltip="Stop"
               onClick={this.onStop}
+              isVisible={true}
+              />
+          );
+          linksArray.push(
+            <Button
+              key="Reboot"
+              icon="repeat"
+              tooltip="Rebboot the selected instance"
+              onClick={this.onReboot}
               isVisible={true}
               />
           );


### PR DESCRIPTION
### Instance Reboot Action On Project Resources Page
When an instance is selected on the Project Resources page a reboot button will be available on the top right with the other actions. 

This was taken from the Instance Detail page and calls on the same Model (InstanceModels).

**Note: All of these buttons are calling directly to the backbone models**
This will need to be refactored to use actions as we move to redux. 

