### PR TITLE
Resource Request Admin Cleanup

### DIFF
--- a/troposphere/static/css/app/admin.scss
+++ b/troposphere/static/css/app/admin.scss
@@ -1,28 +1,5 @@
-.admin-detail textarea, .admin-detail select{
-	width: 95%;
-}
-
-.admin-table{
-    background:#F2F2F2;
-}
-
-.admin-detail{
-	width: 48%;
-	float: right;
-	padding: 1%;
-	position: relative;
-	border: 5px solid;
-    border-color: $brand-primary;
-
-    .radio-buttons{
-    	input[type="radio"]{
-    		margin: 1%;
-    	}
-    }
-}
-
 .admin-detail button{
-	margin: 2%;
+	margin-right: 2%;
 }
 
 .admin-detail div{
@@ -44,4 +21,57 @@
 
 .inline div, .inline p{
 	display: inline-block;
+}
+
+.requests{
+	padding: 0;
+
+	li{
+		list-style-type: none;
+	}
+
+	h3{
+		width: 33%;
+		display: inline-block;
+	}
+}
+
+.request{
+	width: 100%;
+	margin-bottom: 1%;
+	border-bottom: 2px solid;
+	padding: 1%;
+	padding-left: 0;
+
+	.request-info, .request-actions{
+		width: 50%;
+	}
+
+	.buttons{
+		text-align: center;
+	}
+
+	.inline-block{
+		display: inline-block;
+	}
+
+	input[type="radio"]{
+    	margin: 4px 5px 0;
+	}
+
+	textarea{
+		width: 100%;
+		height: 100px;
+	}
+
+	>a{
+		width: 100%;
+		height: 100%;
+	}
+
+	a>div{
+		display: inline-block;
+		width: 32%;
+		margin-right: 1%;
+	}
 }

--- a/troposphere/static/css/app/admin.scss
+++ b/troposphere/static/css/app/admin.scss
@@ -39,7 +39,6 @@
 .request{
 	width: 100%;
 	margin-bottom: 1%;
-	border-bottom: 2px solid;
 	padding: 1%;
 	padding-left: 0;
 

--- a/troposphere/static/js/components/admin/ResourceMaster.react.js
+++ b/troposphere/static/js/components/admin/ResourceMaster.react.js
@@ -40,22 +40,14 @@ define(function (require) {
       return (
         <div className="resource-master">
           <h1>Resource Requests</h1>
-            <table className="admin-table table table-hover table-striped col-md-6">
-              <tbody>
-                <tr className="admin-row">
-                  <th>
-                      <h4>User</h4>
-                  </th>
-                  <th>
-                      <h4>Request</h4>
-                  </th>
-                  <th>
-                      <h4>Description</h4>
-                  </th>
-                </tr>
-                {resourceRequestRows}
-              </tbody>
-            </table>
+            <ul className="requests">
+              <li>
+                <h3>User</h3>
+                <h3>Request</h3>
+                <h3>Description</h3>
+              </li>
+              {resourceRequestRows}
+            </ul>
             <RouteHandler />
         </div>
       );

--- a/troposphere/static/js/components/admin/ResourceRequest.react.js
+++ b/troposphere/static/js/components/admin/ResourceRequest.react.js
@@ -48,7 +48,7 @@ define(function (require) {
 
     handleApproval: function(e){
         e.preventDefault();
-        var resourceRequest = stores.ResourceRequestStore.get(this.getParams().resourceRequestId),
+        var resourceRequest = this.props.request,
           quotaToSend = parseInt(this.state.quota) || parseInt(resourceRequest.get('current_quota')),
           allocationToSend = stores.AllocationStore.findWhere({"threshold": parseInt(this.state.AUSearch) * 60, "delta": this.state.delta}).models[0].get('id');
           status = stores.StatusStore.findOne({name: "approved"});
@@ -64,7 +64,7 @@ define(function (require) {
 
     handleDenial: function(e){
       e.preventDefault();
-      var resourceRequest = stores.ResourceRequestStore.get(this.getParams().resourceRequestId),
+      var resourceRequest = this.props.request,
         status = stores.StatusStore.findOne({name: "rejected"});
       
       ResourceActions.update({

--- a/troposphere/static/js/components/admin/ResourceRequest.react.js
+++ b/troposphere/static/js/components/admin/ResourceRequest.react.js
@@ -4,7 +4,10 @@ define(function (require) {
   var React = require('react/addons'),
     Backbone = require('backbone'),
     Router = require('react-router'),
-    stores = require('stores');
+    stores = require('stores'),
+    Glyphicon = require('components/common/Glyphicon.react'),
+    actions = require('actions'),
+    ResourceActions = require('actions/ResourceActions');
 
   return React.createClass({
 
@@ -12,18 +15,202 @@ define(function (require) {
       request: React.PropTypes.instanceOf(Backbone.Model).isRequired
     },
 
+    getInitialState: function(){
+      return {
+        AUSearch: "",
+        delta: 525600,
+        expire: true,
+        response: "",
+        canSubmit: false,
+        newAllocationId: null,
+        displayAdmin: false
+      };
+    },
+
+    handleDisplayChange: function (event){
+      this.setState({displayAdmin: !this.state.displayAdmin});
+    },
+
+    handleResponseChange: function (event) {
+      var response = event.target.value;
+      if (response) this.setState({response: response});
+    },
+
+    handleQuotaChange: function (event) {
+      var quota = event.target.value;
+      if (quota) this.setState({quota: quota});
+    },
+
+    handleAllocationChange: function (event) {
+      var allocation = event.target.value;
+      if (allocation) this.setState({allocation: allocation});
+    },
+
+    handleApproval: function(e){
+        e.preventDefault();
+        var resourceRequest = stores.ResourceRequestStore.get(this.getParams().resourceRequestId),
+          quotaToSend = parseInt(this.state.quota) || parseInt(resourceRequest.get('current_quota')),
+          allocationToSend = stores.AllocationStore.findWhere({"threshold": parseInt(this.state.AUSearch) * 60, "delta": this.state.delta}).models[0].get('id');
+          status = stores.StatusStore.findOne({name: "approved"});
+
+        ResourceActions.update({
+          request: resourceRequest,
+          response: this.state.response,
+          quota: quotaToSend,
+          allocation: allocationToSend,
+          status: status.id
+        });
+    },
+
+    handleDenial: function(e){
+      e.preventDefault();
+      var resourceRequest = stores.ResourceRequestStore.get(this.getParams().resourceRequestId),
+        status = stores.StatusStore.findOne({name: "rejected"});
+      
+      ResourceActions.update({
+        request: resourceRequest,
+        response: this.state.response,
+        status: status.id
+      });
+    },
+
+    handleThresholdSearchChange: function(e){
+      this.setState({
+        AUSearch: e.target.value
+      });
+    },
+
+    makeNewAllocation: function(){
+      actions.AllocationActions.create({"threshold": this.state.AUSearch * 60, "delta": this.state.delta});
+    }, 
+
+    onExpireChange: function(e){
+      // If expire is currently true, we want it to be false. Set delta to -1 for non expiring AU, standard 525600 for expiring.
+      this.state.expire ? this.setState({delta: -1}) : this.setState({delta: 525600});
+      this.setState({expire: !this.state.expire});
+    },    
+
+    renderAllocationStatus: function(){
+      if(stores.AllocationStore.findWhere({"threshold": parseInt(this.state.AUSearch) * 60, "delta": this.state.delta}).length < 1){
+        return(
+          <div>
+            <p>Allocation with {this.state.AUSearch} AU expiring: {this.state.expire ? "true":"false"} does not exist. Click <a href="#" onClick={this.makeNewAllocation}>here</a> to create it.</p>
+          </div>
+        ); 
+      }
+      else{
+        return(
+          <div>
+            <Glyphicon name="ok" /> Allocation exists
+          </div>
+        );
+      }
+    },
+
+    renderAdminDetails: function(){
+      var quotas = stores.QuotaStore.getAll(),
+          allocations = stores.AllocationStore.fetchWhere({"page_size": 100}),
+          statuses = stores.StatusStore.getAll(),
+          request = this.props.request,
+          currentQuotaString = 'N/A',
+          currentAllocationString = 'N/A';
+
+      if (!quotas || !allocations || !statuses) return <div className="loading"/>;
+
+      if (request.get('current_quota') && request.get('current_allocation')) {
+
+        var currentQuota = stores.QuotaStore.get(request.get('current_quota')),
+            currentAllocation = stores.AllocationStore.get(request.get('current_allocation'));
+
+        if (!currentQuota || !currentAllocation) return <div className="loading"/>;
+
+        var currentCPU = "  CPU: " + currentQuota.get('cpu'),
+          currentMemory = "  Memory: " + currentQuota.get('memory'),
+          currentStorage = "  Storage: " + currentQuota.get('storage'),
+          currentStorageCount = "  Storage Count: " + currentQuota.get('storage_count'),
+          currentSuspendedCount = "  Suspended: " + currentQuota.get('suspended_count'),
+          currentThreshold = "  Threshold: " + currentAllocation.get('threshold') + " (" + (currentAllocation.get('threshold') / 60) + " AU)",
+          currentDelta = "  Delta: " + currentAllocation.get('delta'),
+          currentQuotaString = currentCPU + currentMemory + currentStorage + currentStorageCount + currentSuspendedCount,
+          currentAllocationString = currentThreshold + currentDelta;
+      }
+
+      var canSubmit = (parseInt(this.state.quota) || parseInt(request.get('current_quota'))) && (stores.AllocationStore.findWhere({"threshold": parseInt(this.state.AUSearch) * 60, "delta": this.state.delta}).length == 1) && this.state.response;
+
+      return(
+          <div className="admin-detail">
+            <div className="request-info pull-left">
+              <div><strong>User: </strong> {request.get('user').username}</div>
+              <div><strong>Created by: </strong> {request.get('created_by').username}</div>
+              <div><strong>Admin message: </strong> {request.get('admin_message')}</div>
+              <div><strong>Request: </strong> {request.get('request')}</div>
+              <div><strong>Description: </strong> {request.get('description')}</div>
+              <div><strong>Current quota: </strong>{currentQuotaString}</div>
+              <div><strong>Current allocation: </strong>{currentAllocationString}</div>
+            </div>
+            <div className="request-actions pull-right">
+              <div>
+                <label>New quota: </label>
+                <select value={this.state.quota} onChange={this.handleQuotaChange}
+                  ref="selectedQuota">{quotas.map(function (quota) {
+                  return (
+                    <option value={quota.id} key={quota.id}>
+                      CPU: {quota.get('cpu')}&nbsp;
+                      Memory: {quota.get('memory')}&nbsp;
+                      Storage: {quota.get('storage')}&nbsp;
+                      Storage Count: {quota.get('storage_count')}&nbsp;
+                      Suspended: {quota.get('suspended_count')}&nbsp;
+                    </option>
+                  );
+                })}
+                </select>
+              </div>
+              <div>
+                <div className="inline">
+                  <label>New allocation: </label>
+                  <div>
+                    <input type="text" value={this.state.AUSearch} onChange={this.handleThresholdSearchChange} />AU
+                  </div>
+                </div>
+                <div className="radio-buttons">
+                  <strong>Expiring allocation? </strong>
+                  <input type="radio" name="expire" checked={this.state.expire === true} onChange={this.onExpireChange}>Yes</input>
+                  <input type="radio" name="expire" checked={this.state.expire === false} onChange={this.onExpireChange}>No</input>
+                </div>
+                {this.renderAllocationStatus()}
+              </div>
+              <div className="form-group">
+                <strong>Response:</strong>
+                <br />
+                <textarea type="text" form="admin" value={this.state.value} onChange={this.handleResponseChange}/>
+              </div>
+              <div className="buttons">
+                <button disabled={!canSubmit} onClick={this.handleApproval} type="button" className="btn btn-default btn-sm">Approve</button>
+                <button onClick={this.handleDenial} type="button" className="btn btn-default btn-sm">Deny</button>
+              </div>
+            </div>
+          </div>
+        );
+    },
+
     render: function () {
-      var request = this.props.request;
+      var request = this.props.request,
+          adminDisplay;
+
+      if(this.state.displayAdmin){
+        adminDisplay = this.renderAdminDetails();
+      }
+
       return (
-        <tr>
-          <td className="user-name">
-            <Router.Link to="resource-request" params={{resourceRequestId: request.id}}>
-              {request.get('user').username}
-            </Router.Link>
-          </td>
-          <td className="request">{request.get('request')}</td>
-          <td className="description">{request.get('description')}</td>
-        </tr>
+        <li className="request clearfix">
+          <a onClick={this.handleDisplayChange}>
+            <div>{request.get('user').username}</div> 
+            <div>{request.get('request')} </div>
+            <div>{request.get('description')}</div>
+          </a>
+
+          {adminDisplay}
+        </li>
       );
     }
 


### PR DESCRIPTION
Clean up the awkward blockiness of a separate admin component taking up half the screen when dealing with resource requests.

Now, requests show as list elements as opposed to table rows, and the admin details and actions vertically expand out when the request is clicked.
<img width="1280" alt="adminexpand1" src="https://cloud.githubusercontent.com/assets/11079642/11410323/ca28ecfe-9383-11e5-8449-173f58021133.png">
![adminexpand2](https://cloud.githubusercontent.com/assets/11079642/11410339/e8e47726-9383-11e5-9358-28688cf79aa7.png)


