### PR TITLE
Only show image request machine state if user is staff

### DIFF
--- a/troposphere/static/js/components/images/MyImageRequestsPage.react.js
+++ b/troposphere/static/js/components/images/MyImageRequestsPage.react.js
@@ -41,6 +41,15 @@ define(function(require) {
 
       var requests = stores.ImageRequestStore.getAll();
 
+      var machineStateColumn, machineStateData;
+
+      if(stores.ProfileStore.get().get('is_staff')){
+        machineStateColumn = (
+          <th>
+            <h3>Machine State</h3>
+          </th>
+        );
+      }
       
       if(requests == null){
         return <div className = "loading"></div>;
@@ -74,6 +83,10 @@ define(function(require) {
             break;
         }
 
+        if(stores.ProfileStore.get().get('is_staff')){
+          machineStateData = <td>{request.get('old_status')}</td>;
+        }
+
         var newMachineId = !!request.get('new_machine') ? request.get('new_machine').id : "N/A";
 
         return <tr className={trClass}>
@@ -81,7 +94,7 @@ define(function(require) {
                     <td>{moment(request.get('end_date')).format("MMM D, YYYY h:mm:ss a")}</td>
                     <td>#{request.get('instance').id} - {request.get('instance').name}</td>
                     <td>{request.get('status').name}</td>
-                    <td>{request.get('old_status')}</td>
+                    {machineStateData}
                     <td>{newMachineId}</td>
                 </tr>
       }.bind(this));
@@ -110,9 +123,7 @@ define(function(require) {
                 <th>
                   <h3>Status</h3>
                 </th>
-                <th>
-                  <h3>Machine State</h3>
-                </th>
+                {machineStateColumn}
                 <th>
                   <h3>New Machine ID</h3>
                 </th>


### PR DESCRIPTION
The machine state column currently shows too much information for the average user. Addresses ATMO-1083.

Non staff user:
<img width="1280" alt="non-staff-user" src="https://cloud.githubusercontent.com/assets/11079642/11692496/f2a6237a-9e5c-11e5-9891-b18b184074f2.png">
Staff user:
![staff_user](https://cloud.githubusercontent.com/assets/11079642/11692500/fa4a5966-9e5c-11e5-8645-28768bdac362.png)


