### PR TITLE
Trim values of fields in image request modal before moving to next step

### DIFF
--- a/troposphere/static/js/components/modals/instance/image/steps/ImageInfoStep.react.js
+++ b/troposphere/static/js/components/modals/instance/image/steps/ImageInfoStep.react.js
@@ -49,7 +49,7 @@ define(function (require) {
     onNext: function () {
       this.props.onNext({
         name: $.trim(this.state.name),
-        description: this.state.description,
+        description: $.trim(this.state.description),
         imageTags: this.state.imageTags,
         newImage: this.state.newImage
       });

--- a/troposphere/static/js/components/modals/instance/image/steps/ImageInfoStep.react.js
+++ b/troposphere/static/js/components/modals/instance/image/steps/ImageInfoStep.react.js
@@ -41,8 +41,8 @@ define(function (require) {
     },
 
     isSubmittable: function () {
-      var hasName = !!this.state.name;
-      var hasDescription = !!this.state.description;
+      var hasName = !!($.trim(this.state.name));
+      var hasDescription = !!($.trim(this.state.description));
       return hasName && hasDescription;
     },
 

--- a/troposphere/static/js/components/modals/instance/image/steps/VersionInfoStep.react.js
+++ b/troposphere/static/js/components/modals/instance/image/steps/VersionInfoStep.react.js
@@ -3,6 +3,7 @@ define(function(require) {
   var React = require('react/addons'),
       Backbone = require('backbone'),
       VersionName = require('../components/VersionName.react'),
+      $ = require('jquery'),
       VersionChanges = require('../components/VersionChangeLog.react'),
       stores = require('stores');
 
@@ -32,10 +33,11 @@ define(function(require) {
     },
 
     isSubmittable: function(){
-      var hasName        = !!this.state.versionName;
-      var hasVersionChanges = !!this.state.versionChanges;
+      var hasName        = !!($.trim(this.state.versionName));
+      var hasVersionChanges = !!($.trim(this.state.versionChanges));
       return hasName && hasVersionChanges;
     },
+
     onPrevious: function(){
       this.props.onPrevious({
         versionName: this.state.versionName,
@@ -49,6 +51,7 @@ define(function(require) {
         versionChanges: this.state.versionChanges,
       });
     },
+
     onVersionNameChange: function(newName){
       this.setState({versionName: newName});
     },

--- a/troposphere/static/js/components/modals/instance/image/steps/VersionInfoStep.react.js
+++ b/troposphere/static/js/components/modals/instance/image/steps/VersionInfoStep.react.js
@@ -47,8 +47,8 @@ define(function(require) {
 
     onNext: function(){
       this.props.onNext({
-        versionName: this.state.versionName,
-        versionChanges: this.state.versionChanges,
+        versionName: $.trim(this.state.versionName),
+        versionChanges: $.trim(this.state.versionChanges),
       });
     },
 


### PR DESCRIPTION
Addresses the cause of separate issue reported in [ATMO-1083](https://pods.iplantcollaborative.org/jira/browse/ATMO-1083).
Trim text fields using jQuery 's trim() function when checking the current step's isSubmittable() and send the trimmed values to the component's onNext().