### PR TITLE
Prevent polling of deleted instances

### DIFF
--- a/troposphere/static/js/actions/instance/destroy.js
+++ b/troposphere/static/js/actions/instance/destroy.js
@@ -39,7 +39,7 @@ define(function (require) {
         });
         // todo: the proper thing to do is to poll until the instance is actually destroyed
         // and THEN remove it from the project. Need to find a way to support that.
-        Utils.dispatch(InstanceConstants.REMOVE_INSTANCE, {instance: instance});
+        Utils.dispatch(InstanceConstants.REMOVE_INSTANCE, {instance: instance}, options);
         Utils.dispatch(ProjectInstanceConstants.REMOVE_PROJECT_INSTANCE, {projectInstance: projectInstance}, options);
       }).fail(function (response) {
         instance.set({state: originalState});

--- a/troposphere/static/js/stores/InstanceStore.js
+++ b/troposphere/static/js/stores/InstanceStore.js
@@ -35,11 +35,11 @@ define(function (require) {
     // Polling functions
     // -----------------
 
-    isInFinalState: function(instance){
-        if(instance.get('state').get('status') == 'active' && instance.get('ip_address').charAt(0) == '0'){
+    isInFinalState: function(instance) {
+        if (instance.get('state').get('status') == 'active' && instance.get('ip_address').charAt(0) == '0') {
             return false;
         }
-    
+
         return instance.get('state').isInFinalState();
     }
 
@@ -67,6 +67,7 @@ define(function (require) {
         break;
 
       case InstanceConstants.POLL_INSTANCE:
+        // This happens whether or not polling is enabled in basestore (seems unintuitive)
         store.pollNowUntilBuildIsFinished(payload.instance);
         break;
 


### PR DESCRIPTION
This fixes an error that is thrown when an instance.update is called on a nonexistent instance. This happens because instances that are polled, are not removed from polling when they are deleted. See this [chunk](https://github.com/cdosborn/troposphere/blob/02fdeb9dc826537524f95960dd7aca15cb728045/troposphere/static/js/stores/BaseStore.js#L91-L95).

To trigger the bug, you have to delete an instance while it's state is still being polled. Normally this doesn't happen, because the polling process doesn't take much time.

There are several stylistic changes. I renamed modelsBuilding to modelsPolling, since that is what it actually represents. We will need to poll for things other than a building instance. Other changes are just whitespace.
