### PR TITLE
Show more helpful end date when an image request hasn't been completed

### DIFF
--- a/troposphere/static/js/components/images/MyImageRequestsPage.react.js
+++ b/troposphere/static/js/components/images/MyImageRequestsPage.react.js
@@ -70,7 +70,7 @@ define(function(require) {
       var displayRequests = requests.map(function(request){
         
         // set the color of the row based on the status of the request
-        var trClass;
+        var trClass, endDateText = "N/A";
         switch(request.get('status').name){
           case "approved":
             trClass = "success";
@@ -86,12 +86,15 @@ define(function(require) {
         if(stores.ProfileStore.get().get('is_staff')){
           machineStateData = <td>{request.get('old_status')}</td>;
         }
+				if (request.get('end_date')) {
+					endDateText = moment(request.get('end_date')).format("MMM D, YYYY h:mm:ss a");
+				}
 
         var newMachineId = !!request.get('new_machine') ? request.get('new_machine').id : "N/A";
 
         return <tr className={trClass}>
                     <td>{moment(request.get('start_date')).format("MMM D, YYYY h:mm:ss a")}</td>
-                    <td>{moment(request.get('end_date')).format("MMM D, YYYY h:mm:ss a")}</td>
+                    <td>{endDateText}</td>
                     <td>#{request.get('instance').id} - {request.get('instance').name}</td>
                     <td>{request.get('status').name}</td>
                     {machineStateData}


### PR DESCRIPTION
The end date field currently shows the "Invalid Date" text returned by moment.js when trying to parse the "null" returned by the API. In the case of a null end date, display "N/A" which feels a lot better than "Invalid Date."