### PR TITLE
Fix tag creation functionality within image modal

### DIFF
--- a/troposphere/static/js/components/modals/instance/image/components/Tags.react.js
+++ b/troposphere/static/js/components/modals/instance/image/components/Tags.react.js
@@ -32,7 +32,7 @@ define(function (require) {
 		},
 
     onQueryChange: function (query) {
-      this.setState({query: query});
+      this.setState({query: query.toLowerCase()});
     },
 
 		onNewTagNameChange: function(name){

--- a/troposphere/static/js/components/modals/instance/image/components/Tags.react.js
+++ b/troposphere/static/js/components/modals/instance/image/components/Tags.react.js
@@ -3,7 +3,8 @@ define(function (require) {
   var React = require('react/addons'),
     Backbone = require('backbone'),
     stores = require('stores'),
-    TagMultiSelect = require('components/common/tags/TagMultiSelect.react');
+    actions = require('actions'),
+		TagMultiSelect = require('components/common/tags/TagMultiSelect.react');
 
   return React.createClass({
     displayName: "Tags",
@@ -17,18 +18,65 @@ define(function (require) {
 
     getInitialState: function () {
       return {
-        query: ""
+        query: "",
+				newTagName: "",
+				newTagDescription: "",
+				showTagCreateForm: false
       }
     },
+
+		createTagAndAddToImage: function(){
+			var newTag = actions.TagActions.create({name: this.state.newTagName, description: this.state.newTagDescription});
+			this.props.onTagAdded(newTag);
+			this.setState({newTagName: "", newTagDescription: "", showTagCreateForm: false});
+		},
 
     onQueryChange: function (query) {
       this.setState({query: query});
     },
 
+		onNewTagNameChange: function(name){
+			this.setState({newTagName: name.target.value});
+		},
+
+		onNewTagDescriptionChange: function(description){
+			this.setState({newTagDescription: description.target.value});
+		},
+
+		isSubmittable: function(){
+			return this.state.newTagName && this.state.newTagDescription;
+		},
+
+		onCreateNewTag: function(tagName) {
+			this.setState({
+				newTagName: tagName,
+				showTagCreateForm: true
+			});
+		},
+
     render: function () {
       var imageTags = this.props.imageTags,
         tags = stores.TagStore.getAll(),
-        query = this.state.query;
+        query = this.state.query,
+				tagCreateForm = null;
+
+			if(this.state.showTagCreateForm){
+				tagCreateForm = (
+					<div className="form-group">
+						<label for="tag-create" className="control-label">Create new tag</label>
+						<form>
+							Name:<br />
+							<input className="form-control" type="text" onChange={this.onNewTagNameChange} value={this.state.newTagName} /><br />
+							Description:<br />
+							<textarea className="form-control" type="text" onChange={this.onNewTagDescriptionChange} value={this.state.newTagDescription} /><br />
+						</form>
+						<button disabled={!this.isSubmittable()} onClick={this.createTagAndAddToImage}
+							className="btn btn-primary btn-sm pull-right">
+							Create and add
+						</button>
+					</div>
+				);
+			}
 
       if (!tags) return <div className="loading"/>;
 
@@ -40,7 +88,7 @@ define(function (require) {
       }
 
       return (
-        <div className="form-group">
+        <div className="form-group" style={{marginBottom:"30px"}}>
           <label htmlFor="tags" className="control-label">Image Tags</label>
 
           <div className="tagger_container">
@@ -56,13 +104,15 @@ define(function (require) {
             <TagMultiSelect
               models={tags}
               activeModels={imageTags}
-              onModelAdded={this.props.onTagAdded}
+              onCreateNewTag={this.onCreateNewTag}
+							onModelAdded={this.props.onTagAdded}
               onModelRemoved={this.props.onTagRemoved}
               onModelCreated={this.props.onTagCreated}
               onQueryChange={this.onQueryChange}
               width={"100%"}
               placeholderText="Search by tag name..."
               />
+						{tagCreateForm}
           </div>
         </div>
       );


### PR DESCRIPTION
Re-add tag creation functionality within the image request modal. 
Addresses ATMO-1108
![tag2](https://cloud.githubusercontent.com/assets/11079642/12130273/54b1e4cc-b3c6-11e5-8ae5-b1237c594a5a.png)
![tag1](https://cloud.githubusercontent.com/assets/11079642/12130276/5acd0562-b3c6-11e5-9d10-49b0adc9c933.png)