### PR TITLE
Handled when time remaining is infinity for provider stats.

### DIFF
--- a/troposphere/static/js/components/providers/Stats.react.js
+++ b/troposphere/static/js/components/providers/Stats.react.js
@@ -54,12 +54,20 @@ define(function (require) {
       var instancesConsumingAllocation = identity.getInstancesConsumingAllocation(instances);
       var allocationBurnRate = identity.getCpusUsed(instancesConsumingAllocation, sizes);
       var timeRemaining = allocationRemaining / allocationBurnRate;
+      var timeRemainingSubText = "hours";
+
+      if (!isFinite(timeRemaining)) {
+        timeRemaining = "N/A";
+        timeRemainingSubText = "";
+      } else {
+        timeRemaining = Math.round(timeRemaining);
+      }
 
       return (
         <div className="row provider-info-section provider-stats">
           {this.renderAllocationStat(allocationConsumedPercent, allocationConsumed, allocationTotal)}
           {this.renderStat(instancesConsumingAllocation.length, "instances", "Number of instances consuming allocation")}
-          {this.renderStat(Math.round(timeRemaining), "hours", "Time remaining before allocation runs out")}
+          {this.renderStat(timeRemaining, timeRemainingSubText, "Time remaining before allocation runs out")}
           {this.renderStat(allocationBurnRate, "AUs/hour", "Rate at which AUs are being used")}
         </div>
       )


### PR DESCRIPTION
Previously, "time remaining" calculations were done when the number of instances running were 0. This creates a division by zero issue, which ends up be type coerced into `Infinity`. This was displayed to the user as "Infinity hours" remaining.

This address the display of the misleading statistic mentioned in [ATMO-1093](https://pods.iplantcollaborative.org/jira/browse/ATMO-1093) (**it does not address the root issue described, which is the calculation of "instances" as relates to _instance state_) and part of [ATMO-1086](https://pods.iplantcollaborative.org/jira/browse/ATMO-1086). 
