### PR TITLE
Ensure only 'active' instances are included as "consuming allocation".

### DIFF
--- a/troposphere/static/js/components/providers/Instances.react.js
+++ b/troposphere/static/js/components/providers/Instances.react.js
@@ -34,7 +34,10 @@ define(function (require) {
 
     render: function () {
       var provider = this.props.provider,
-        instances = stores.InstanceStore.findWhere({'provider.id': provider.id}),
+        instances = stores.InstanceStore.findWhere({
+            'provider.id': provider.id,
+            'status': 'active'
+        }),
         sizes = stores.SizeStore.fetchWhere({
           provider__id: provider.id,
           page_size: 100

--- a/troposphere/static/js/models/Identity.js
+++ b/troposphere/static/js/models/Identity.js
@@ -36,7 +36,7 @@ define(function (require) {
 
       return instances.filter(function (instance) {
         if (isRelevant(instance, identityId)) {
-          return instance.get('status') !== "suspended";
+          return instance.get('status') === "active";
         } else {
           return false;
         }


### PR DESCRIPTION
[ATMO-1086](https://pods.iplantcollaborative.org/jira/browse/ATMO-1086) generally describes that _Troposphere UI_ is not displaying instance statistics accurately within the Providers view. This related to work done in #232 yet not limited to that. This pull request specifically addresses how we display the number of "instances consuming allocation" and a table with each allocation consuming instance. 

Previously, any instance that was *not* suspended was being treated as "consuming allocation":
```javascript
    getInstancesConsumingAllocation: function (instances) {
      var identityId = this.id;

      return instances.filter(function (instance) {
        if (isRelevant(instance, identityId)) {
          return instance.get('status') !== "suspended";
        } else {
          return false;
        }
      });
    }
```
source: [troposphere/static/js/models/Identity.js](https://github.com/iPlantCollaborativeOpenSource/troposphere/blob/jamming-junglefowl/troposphere/static/js/models/Identity.js#L34-L44)

I have found *no* documentation nor a member of the team that can defend this definition of "filtering". 

This PR changes to what as been communicated to me: _"only 'active' instances should be considered as consuming allocation"_

```diff
       return instances.filter(function (instance) {
         if (isRelevant(instance, identityId)) {
-          return instance.get('status') !== "suspended";
+          return instance.get('status') === "active";
         } else {
           return false;
         }
```

The second commit here addresses the criteria used in how we "find" instances _"consuming allocation"_. It simply adds to `findWhere({ ... })` the additional criteria of instances with `'status'==='active'` be returned.

Release target: `larping-loon`; Requesting approval to bring over to `kicking-kestrel` as with #232

Reviewer: @steve-gregory 

Relates to:
- [ATMO-1086](https://pods.iplantcollaborative.org/jira/browse/ATMO-1086)
- [ATMO-1093](https://pods.iplantcollaborative.org/jira/browse/ATMO-1093)
