### PR TITLE
[ATMO-1122] Fix store populating models wrong

### DIFF
--- a/troposphere/static/js/components/admin/ResourceMaster.react.js
+++ b/troposphere/static/js/components/admin/ResourceMaster.react.js
@@ -17,9 +17,8 @@ define(function (require) {
         }),
         statuses = stores.StatusStore.getAll();
 
-      if (!requests || !statuses) return <div className="loading"></div>;
-
-      requests = stores.ResourceRequestStore.getAll();
+      if (!requests || !statuses) 
+        return <div className="loading"></div>;
 
       var resourceRequestRows = requests.map(function (request) {
         return (

--- a/troposphere/static/js/stores/BaseStore.js
+++ b/troposphere/static/js/stores/BaseStore.js
@@ -316,8 +316,6 @@ define(function (require) {
           url: models.url + queryString
         }).done(function () {
           this.isFetchingQuery[queryString] = false;
-          if(!this.models) this.models = new this.collection();
-          this.models.add(models.models);
           this.queryModels[queryString] = models;
           this.emitChange();
         }.bind(this));


### PR DESCRIPTION
*Before:*
![screen shot 2016-01-11 at 12 30 50 pm](https://cloud.githubusercontent.com/assets/3847314/12244111/384e32d4-b85f-11e5-85c1-d6ac63f7c26c.png)

*After:*
![screen shot 2016-01-11 at 12 31 53 pm](https://cloud.githubusercontent.com/assets/3847314/12244141/55ee46b2-b85f-11e5-809d-c208925b17e8.png)

This fix is bound to break other behavior. The main assumption our codebase
depends on:

    fetchWhere leaves the stores models unaffected

prosif/cdosborn added these lines, so somewhere I assume we depend on the
behavior. I will investigate and add changes if I find them.