### PR TITLE
Changed to ES6 module syntax for entry points.

### DIFF
--- a/troposphere/static/js/AppRoutes.react.js
+++ b/troposphere/static/js/AppRoutes.react.js
@@ -1,49 +1,48 @@
-define(function (require) {
-  "use strict";
+import React from 'react/addons';
+import Router from 'react-router';
 
-  var React = require('react/addons'),
-    Router = require('react-router'),
-    Route = Router.Route,
+let Route = Router.Route,
     Redirect = Router.Redirect,
     DefaultRoute = Router.DefaultRoute;
 
-  var Master = require('./components/Master.react'),
-    BadgeMaster = require('./components/badges/BadgeMaster.react'),
-    MyBadges = require('./components/badges/MyBadges.react'),
-    AllBadges = require('./components/badges/AllBadges.react'),
-    UnearnedBadges = require('./components/badges/UnearnedBadges.react'),
-    PassThroughHandler = require('./components/PassThroughHandler.react'),
-    RequestHistory = require('./components/requests/ResourceHistoryMaster.react'),
-    RequestMaster = require('./components/requests/RequestMaster.react'),
-    DashboardPage = require('./components/dashboard/DashboardPage.react'),
-    ProjectListPage = require('./components/projects/ProjectListPage.react'),
-    ImageListPage = require('./components/images/ImageListPage.react'),
-    ImageDetailsPage = require('./components/images/ImageDetailsPage.react'),
-    ProvidersMaster = require('./components/providers/ProvidersMaster.react'),
-    ProviderListSection = require('./components/providers/ProviderListSection.react'),
-    ProviderDetail = require('./components/providers/ProviderDetail.react'),
-    HelpPage = require('./components/help/HelpPage.react'),
-    ProjectsMaster = require('./components/projects/ProjectsMaster.react'),
-    ProjectDetailsMaster = require('./components/projects/detail/ProjectDetailsMaster.react'),
-    ProjectDetailsPage = require('./components/projects/ProjectDetailsPage.react'),
-    ProjectResourcesPage = require('./components/projects/ProjectResourcesPage.react'),
-    FavoritedImagesPage = require('./components/images/FavoritedImagesPage.react'),
-    MyImagesPage = require('./components/images/MyImagesPage.react'),
-    MyImageRequestsPage = require('./components/images/MyImageRequestsPage.react'),
-    ImageTagsPage = require('./components/images/ImageTagsPage.react'),
-    ImagesMaster = require('./components/images/ImagesMaster.react'),
-    SettingsPage = require('./components/settings/SettingsPage.react'),
-    ProjectInstancePage = require("./components/projects/InstanceDetailsPage.react"),
-    ProjectVolumePage = require("./components/projects/VolumeDetailsPage.react"),
-    ProjectLinkPage = require("./components/projects/ExternalLinkDetailsPage.react"),
-    AdminMaster = require('./components/admin/AdminMaster.react'),
-    AtmosphereUserMaster = require('./components/admin/AtmosphereUserMaster.react'),
-    ImageMaster = require('./components/admin/ImageMaster.react'),
-    IdentityMembershipMaster = require('./components/admin/IdentityMembershipMaster.react'),
-    ResourceMaster = require('./components/admin/ResourceMaster.react'),
-    ResourceRequest = require('./components/admin/ResourceRequest.react');
+import Master from './components/Master.react';
+import BadgeMaster from './components/badges/BadgeMaster.react';
+import MyBadges from './components/badges/MyBadges.react';
+import AllBadges from './components/badges/AllBadges.react';
+import UnearnedBadges from './components/badges/UnearnedBadges.react';
+import PassThroughHandler from './components/PassThroughHandler.react';
+import RequestHistory from './components/requests/ResourceHistoryMaster.react';
+import RequestMaster from './components/requests/RequestMaster.react';
+import DashboardPage from './components/dashboard/DashboardPage.react';
+import ProjectListPage from './components/projects/ProjectListPage.react';
+import ImageListPage from './components/images/ImageListPage.react';
+import ImageDetailsPage from './components/images/ImageDetailsPage.react';
+import ProvidersMaster from './components/providers/ProvidersMaster.react';
+import ProviderListSection from './components/providers/ProviderListSection.react';
+import ProviderDetail from './components/providers/ProviderDetail.react';
+import HelpPage from './components/help/HelpPage.react';
+import ProjectsMaster from './components/projects/ProjectsMaster.react';
+import ProjectDetailsMaster from './components/projects/detail/ProjectDetailsMaster.react';
+import ProjectDetailsPage from './components/projects/ProjectDetailsPage.react';
+import ProjectResourcesPage from './components/projects/ProjectResourcesPage.react';
+import FavoritedImagesPage from './components/images/FavoritedImagesPage.react';
+import MyImagesPage from './components/images/MyImagesPage.react';
+import MyImageRequestsPage from './components/images/MyImageRequestsPage.react';
+import ImageTagsPage from './components/images/ImageTagsPage.react';
+import ImagesMaster from './components/images/ImagesMaster.react';
+import SettingsPage from './components/settings/SettingsPage.react';
+import ProjectInstancePage from "./components/projects/InstanceDetailsPage.react";
+import ProjectVolumePage from "./components/projects/VolumeDetailsPage.react";
+import ProjectLinkPage from "./components/projects/ExternalLinkDetailsPage.react";
+import AdminMaster from './components/admin/AdminMaster.react';
+import AtmosphereUserMaster from './components/admin/AtmosphereUserMaster.react';
+import ImageMaster from './components/admin/ImageMaster.react';
+import IdentityMembershipMaster from './components/admin/IdentityMembershipMaster.react';
+import ResourceMaster from './components/admin/ResourceMaster.react';
+import ResourceRequest from './components/admin/ResourceRequest.react';
 
-  var AppRoutes = (
+
+let AppRoutes = (
     <Route name="root" path="/application" handler={Master}>
       <Route name="dashboard" handler={DashboardPage}/>
 
@@ -100,7 +99,6 @@ define(function (require) {
       <DefaultRoute handler={DashboardPage}/>
 
     </Route>
-  );
+);
 
-  return AppRoutes;
-});
+export default AppRoutes;

--- a/troposphere/static/js/bootstrapper.js
+++ b/troposphere/static/js/bootstrapper.js
@@ -1,116 +1,111 @@
-define(function (require) {
-  'use strict';
+import $ from 'jquery';
+import _ from 'underscore';
+import Backbone from 'backbone';
+import React from 'react/addons';
+import SplashScreen from 'components/SplashScreen.react';
+import MaintenanceScreen from 'components/MaintenanceScreen.react';
+import modernizr from 'lib/modernizr-latest.js';
 
-  var $ = require('jquery'),
-    _ = require('underscore'),
-    Backbone = require('backbone'),
-    React = require('react/addons'),
-    SplashScreen = require('components/SplashScreen.react'),
-    MaintenanceScreen = require('components/MaintenanceScreen.react'),
-    modernizr = require('lib/modernizr-latest.js');
+// Important:
+//   Disconnect all Backbone Events from Models and Collections
+Object.keys(Backbone.Events).forEach(function(functionName) {
+    Backbone.Model.prototype[functionName] = function() {};
+    Backbone.Collection.prototype[functionName] = function() {};
+});
 
-  // Disconnect all Backbone Events from Models and Collections
-  Object.keys(Backbone.Events).forEach(function (functionName) {
-    Backbone.Model.prototype[functionName] = function () {
-    };
-    Backbone.Collection.prototype[functionName] = function () {
-    };
-  });
 
-  //Backbone.Model.prototype.parse = function(resp, options) {
-  //  if(resp.id) resp.id = String(resp.id);
-  //  return resp;
-  //};
-
-  Backbone.Collection.prototype.get = function (obj) {
+Backbone.Collection.prototype.get = function(obj) {
     if (obj == null) return void 0;
-    return _.find(this.models, function (model) {
-      return model.id == obj || model.id === obj.id || model.cid === obj.cid;
-      //return model.id == String(obj) || model.id === String(obj.id) || model.cid === obj.cid;
+    return _.find(this.models, function(model) {
+        return model.id == obj || model.id === obj.id || model.cid === obj.cid;
     });
-  };
+};
 
-  // Register which stores the image should use
-  var stores = require('stores');
-  stores.AllocationStore = require('stores/AllocationStore');
-  stores.BadgeStore = require('stores/BadgeStore');
-  stores.ExternalLinkStore = require('stores/ExternalLinkStore');
-  stores.ImageStore = require('stores/ImageStore');
-  stores.ImageVersionStore = require('stores/ImageVersionStore');
-  stores.ImageVersionMembershipStore = require('stores/ImageVersionMembershipStore');
-  stores.ImageVersionLicenseStore = require('stores/ImageVersionLicenseStore');
-  stores.ImageVersionScriptStore = require('stores/ImageVersionScriptStore');
-  stores.IdentityStore = require('stores/IdentityStore');
-  stores.ImageBookmarkStore = require('stores/ImageBookmarkStore');
-  stores.InstanceHistoryStore = require('stores/InstanceHistoryStore');
-  stores.ImageRequestStore = require('stores/ImageRequestStore');
-  stores.InstanceStore = require('stores/InstanceStore');
-  stores.InstanceTagStore = require('stores/InstanceTagStore');
-  stores.LicenseStore = require('stores/LicenseStore');
-  stores.ScriptStore = require('stores/ScriptStore');
-  stores.MaintenanceMessageStore = require('stores/MaintenanceMessageStore');
-  stores.MyBadgeStore = require('stores/MyBadgeStore');
-  stores.MembershipStore = require('stores/MembershipStore');
-  stores.ProfileStore = require('stores/ProfileStore');
-  stores.ProjectStore = require('stores/ProjectStore');
-  stores.ProjectExternalLinkStore = require('stores/ProjectExternalLinkStore');
-  stores.ProjectImageStore = require('stores/ProjectImageStore');
-  stores.ProjectInstanceStore = require('stores/ProjectInstanceStore');
-  stores.ProjectVolumeStore = require('stores/ProjectVolumeStore');
-  stores.ProviderMachineStore = require('stores/ProviderMachineStore');
-  stores.ProviderStore = require('stores/ProviderStore');
-  stores.ResourceRequestStore = require('stores/ResourceRequestStore');
-  stores.IdentityMembershipStore = require('stores/IdentityMembershipStore');
-  stores.StatusStore = require('stores/StatusStore');
-  stores.SSHKeyStore = require('stores/SSHKeyStore');
-  stores.QuotaStore = require('stores/QuotaStore');
-  stores.SizeStore = require('stores/SizeStore');
-  stores.TagStore = require('stores/TagStore');
-  stores.UserStore = require('stores/UserStore');
-  stores.VersionStore = require('stores/VersionStore');
-  stores.VolumeStore = require('stores/VolumeStore');
 
-  var actions = require('actions');
-  actions.AllocationActions = require('actions/AllocationActions');
-  actions.BadgeActions = require('actions/BadgeActions');
-  actions.ExternalLinkActions = require('actions/ExternalLinkActions');
-  actions.HelpActions = require('actions/HelpActions');
-  actions.IdentityMembershipActions = require('actions/IdentityMembershipActions');
-  actions.ImageActions = require('actions/ImageActions');
-  actions.ImageVersionActions = require('actions/ImageVersionActions');
-  actions.ImageVersionMembershipActions = require('actions/ImageVersionMembershipActions');
-  actions.ImageVersionLicenseActions = require('actions/ImageVersionLicenseActions');
-  actions.ImageVersionScriptActions = require('actions/ImageVersionScriptActions');
-  actions.ImageBookmarkActions = require('actions/ImageBookmarkActions');
-  actions.InstanceActions = require('actions/InstanceActions');
-  actions.InstanceTagActions = require('actions/InstanceTagActions');
-  actions.InstanceVolumeActions = require('actions/InstanceVolumeActions');
-  actions.LicenseActions = require('actions/LicenseActions');
-  actions.ScriptActions = require('actions/ScriptActions');
-  actions.NullProjectActions = require('actions/NullProjectActions');
-  actions.ProfileActions = require('actions/ProfileActions');
-  actions.ProjectActions = require('actions/ProjectActions');
-  actions.ProviderMachineActions = require('actions/ProviderMachineActions');
-  actions.ProjectExternalLinkActions = require('actions/ProjectExternalLinkActions');
-  actions.ProjectImageActions = require('actions/ProjectImageActions');
-  actions.ProjectInstanceActions = require('actions/ProjectInstanceActions');
-  actions.ProjectVolumeActions = require('actions/ProjectVolumeActions');
-  actions.TagActions = require('actions/TagActions');
-  actions.UserActions = require('actions/UserActions');
-  actions.VolumeActions = require('actions/VolumeActions');
+import stores from 'stores';
 
-  var modals = require('modals');
-  modals.BadgeModals = require('modals/BadgeModals');
-  modals.ExternalLinkModals = require('modals/ExternalLinkModals');
-  modals.HelpModals = require('modals/HelpModals');
-  modals.InstanceModals = require('modals/InstanceModals');
-  modals.InstanceVolumeModals = require('modals/InstanceVolumeModals');
-  modals.ProjectModals = require('modals/ProjectModals');
-  modals.TagModals = require('modals/TagModals');
-  modals.VersionModals = require('modals/VersionModals');
-  modals.VolumeModals = require('modals/VolumeModals');
+stores.AllocationStore = require('stores/AllocationStore');
+stores.BadgeStore = require('stores/BadgeStore');
+stores.ExternalLinkStore = require('stores/ExternalLinkStore');
+stores.ImageStore = require('stores/ImageStore');
+stores.ImageVersionStore = require('stores/ImageVersionStore');
+stores.ImageVersionMembershipStore = require('stores/ImageVersionMembershipStore');
+stores.ImageVersionLicenseStore = require('stores/ImageVersionLicenseStore');
+stores.ImageVersionScriptStore = require('stores/ImageVersionScriptStore');
+stores.IdentityStore = require('stores/IdentityStore');
+stores.ImageBookmarkStore = require('stores/ImageBookmarkStore');
+stores.InstanceHistoryStore = require('stores/InstanceHistoryStore');
+stores.ImageRequestStore = require('stores/ImageRequestStore');
+stores.InstanceStore = require('stores/InstanceStore');
+stores.InstanceTagStore = require('stores/InstanceTagStore');
+stores.LicenseStore = require('stores/LicenseStore');
+stores.ScriptStore = require('stores/ScriptStore');
+stores.MaintenanceMessageStore = require('stores/MaintenanceMessageStore');
+stores.MyBadgeStore = require('stores/MyBadgeStore');
+stores.MembershipStore = require('stores/MembershipStore');
+stores.ProfileStore = require('stores/ProfileStore');
+stores.ProjectStore = require('stores/ProjectStore');
+stores.ProjectExternalLinkStore = require('stores/ProjectExternalLinkStore');
+stores.ProjectImageStore = require('stores/ProjectImageStore');
+stores.ProjectInstanceStore = require('stores/ProjectInstanceStore');
+stores.ProjectVolumeStore = require('stores/ProjectVolumeStore');
+stores.ProviderMachineStore = require('stores/ProviderMachineStore');
+stores.ProviderStore = require('stores/ProviderStore');
+stores.ResourceRequestStore = require('stores/ResourceRequestStore');
+stores.IdentityMembershipStore = require('stores/IdentityMembershipStore');
+stores.StatusStore = require('stores/StatusStore');
+stores.SSHKeyStore = require('stores/SSHKeyStore');
+stores.QuotaStore = require('stores/QuotaStore');
+stores.SizeStore = require('stores/SizeStore');
+stores.TagStore = require('stores/TagStore');
+stores.UserStore = require('stores/UserStore');
+stores.VersionStore = require('stores/VersionStore');
+stores.VolumeStore = require('stores/VolumeStore');
 
-  return {
+import actions from 'actions';
+
+actions.AllocationActions = require('actions/AllocationActions');
+actions.BadgeActions = require('actions/BadgeActions');
+actions.ExternalLinkActions = require('actions/ExternalLinkActions');
+actions.HelpActions = require('actions/HelpActions');
+actions.IdentityMembershipActions = require('actions/IdentityMembershipActions');
+actions.ImageActions = require('actions/ImageActions');
+actions.ImageVersionActions = require('actions/ImageVersionActions');
+actions.ImageVersionMembershipActions = require('actions/ImageVersionMembershipActions');
+actions.ImageVersionLicenseActions = require('actions/ImageVersionLicenseActions');
+actions.ImageVersionScriptActions = require('actions/ImageVersionScriptActions');
+actions.ImageBookmarkActions = require('actions/ImageBookmarkActions');
+actions.InstanceActions = require('actions/InstanceActions');
+actions.InstanceTagActions = require('actions/InstanceTagActions');
+actions.InstanceVolumeActions = require('actions/InstanceVolumeActions');
+actions.LicenseActions = require('actions/LicenseActions');
+actions.ScriptActions = require('actions/ScriptActions');
+actions.NullProjectActions = require('actions/NullProjectActions');
+actions.ProfileActions = require('actions/ProfileActions');
+actions.ProjectActions = require('actions/ProjectActions');
+actions.ProviderMachineActions = require('actions/ProviderMachineActions');
+actions.ProjectExternalLinkActions = require('actions/ProjectExternalLinkActions');
+actions.ProjectImageActions = require('actions/ProjectImageActions');
+actions.ProjectInstanceActions = require('actions/ProjectInstanceActions');
+actions.ProjectVolumeActions = require('actions/ProjectVolumeActions');
+actions.TagActions = require('actions/TagActions');
+actions.UserActions = require('actions/UserActions');
+actions.VolumeActions = require('actions/VolumeActions');
+
+import modals from 'modals';
+
+modals.BadgeModals = require('modals/BadgeModals');
+modals.ExternalLinkModals = require('modals/ExternalLinkModals');
+modals.HelpModals = require('modals/HelpModals');
+modals.InstanceModals = require('modals/InstanceModals');
+modals.InstanceVolumeModals = require('modals/InstanceVolumeModals');
+modals.ProjectModals = require('modals/ProjectModals');
+modals.TagModals = require('modals/TagModals');
+modals.VersionModals = require('modals/VersionModals');
+modals.VolumeModals = require('modals/VolumeModals');
+
+
+export default {
     run: function () {
       let authHeaders = {
           "Content-Type": "application/json"
@@ -173,15 +168,59 @@ define(function (require) {
           }
         });
 
-        return dfd.promise();
-      };
+        // We're wrapping Backbone.sync so that we can observe every AJAX request.
+        // If any request returns a 503 (service unavailable) then we're going to
+        // throw up the maintenance splash page. Otherwise, just pass the response
+        // up to chain.
+        var originalSync = Backbone.sync;
+        Backbone.sync = function(attrs, textStatus, xhr) {
+            // NOTE: a conceptually simpler solution would be to do this:
+            //
+            //    var xhr = originalSync.apply(this, arguments).catch(function(response){
+            //      if(response.status === 503) {
+            //        $('.splash-image').remove();
+            //        var MaintenanceComponent = React.createFactory(MaintenanceScreen);
+            //        React.render(MaintenanceComponent(), document.getElementById('application'));
+            //      }
+            //    });
+            //
+            //    return xhr;
+            //
+            // However, since we're using jQuery deferred objects for the promise chain, and they
+            // don't have a way to cancel promise propagation, we can end up in a scenario where we
+            // display a toast with an error on the maintenance splash screen (because other error
+            // handlers can still get called).  To get around that, we need to create our own promise
+            // and, based on the result of the AJAX request, either manually resolve or reject it.
 
-      // render the splash page which will load the rest of the application
-      $(document).ready(function () {
-        var SplashScreenComponent = React.createFactory(SplashScreen);
-        React.render(SplashScreenComponent(), document.getElementById('application'));
-      });
+
+            var dfd = $.Deferred();
+
+            originalSync.apply(this, arguments).then(function() {
+                dfd.resolve.apply(this, arguments);
+            }).fail(function(response) {
+                if (response.status === 503) {
+                    // need to make sure we remove the splash-image element is included in the HTML
+                    // template by default but re-apply the splash screen-class to body so that the
+                    // splash page displays correctly
+                    $('.splash-image').remove();
+                    $('body').addClass('splash-screen');
+
+                    // replace the current view with the
+                    var MaintenanceComponent = React.createFactory(MaintenanceScreen);
+                    React.render(MaintenanceComponent(), document.getElementById('application'));
+                } else {
+                    dfd.reject.apply(this, arguments);
+                }
+            });
+
+            return dfd.promise();
+        };
+
+        // render the splash page which will load the rest of the application
+        $(document).ready(function() {
+            var SplashScreenComponent = React.createFactory(SplashScreen);
+            React.render(SplashScreenComponent(), document.getElementById('application'));
+        });
+      }
     }
-  }
-
-});
+}

--- a/troposphere/static/js/public_site/bootstrapper.react.js
+++ b/troposphere/static/js/public_site/bootstrapper.react.js
@@ -1,54 +1,55 @@
-define(function (require) {
-    'use strict';
 
-    var React = require('react/addons'),
-        Profile = require('models/Profile'),
-        $ = require('jquery'),
-        Router = require('../Router'),
-        routes = require('./AppRoutes.react');
+import React from 'react/addons';
+import Profile from 'models/Profile';
+import $ from 'jquery';
+import Router from '../Router';
+import routes from './AppRoutes.react';
 
-    // Register which stores the application should use
-    var stores = require('stores');
-    stores.ImageStore = require('stores/ImageStore');
-    stores.ImageBookmarkStore = require('stores/ImageBookmarkStore');
-    stores.ImageVersionStore = require('stores/ImageVersionStore');
-    stores.TagStore         = require('stores/TagStore');
-    // Mock out the profile store with an empty profile
-    stores.ProfileStore = {
-      get: function(){
-        return new Profile({icon_set: "default"})
-      },
-      addChangeListener: function(){},
-      removeChangeListener: function(){}
-    };
-    // Mock out the maintenance message store
-    stores.MaintenanceMessageStore = {
-      getAll: function(){},
-      addChangeListener: function(){},
-      removeChangeListener: function(){}
-    };
+// Register which stores the application should use
+import stores from 'stores';
 
-    function startApplication() {
+stores.ImageStore = require('stores/ImageStore');
+stores.ImageBookmarkStore = require('stores/ImageBookmarkStore');
+stores.ImageVersionStore = require('stores/ImageVersionStore');
+stores.TagStore = require('stores/TagStore');
 
-      $(document).ready(function () {
+// Mock out the profile store with an empty profile
+stores.ProfileStore = {
+    get: function() {
+        return new Profile({
+            icon_set: "default"
+        })
+    },
+    addChangeListener: function() {},
+    removeChangeListener: function() {}
+};
+
+// Mock out the maintenance message store
+stores.MaintenanceMessageStore = {
+    getAll: function() {},
+    addChangeListener: function() {},
+    removeChangeListener: function() {}
+};
+
+function startApplication() {
+
+    $(document).ready(function() {
 
         $('body').removeClass('splash-screen');
 
         // Start the application router
-        Router.getInstance(routes).run(function (Handler, state) {
-          // you might want to push the state of the router to a store for whatever reason
-          // RouterActions.routeChange({routerState: state});
+        Router.getInstance(routes).run(function(Handler, state) {
+            // you might want to push the state of the router to a store for whatever reason
+            // RouterActions.routeChange({routerState: state});
 
-          // whenever the url changes, this callback is called again
-          React.render(<Handler/>, document.getElementById("application"));
+            // whenever the url changes, this callback is called again
+            React.render( < Handler / > , document.getElementById("application"));
         });
-      });
-    }
+    });
+}
 
-  return {
-    run: function () {
-      startApplication();
+export default {
+    run: function() {
+        startApplication();
     }
-  }
-
-});
+}


### PR DESCRIPTION
This is the first step to moving over to [ES6 Modules](https://babeljs.io/docs/learn-es2015/#modules) (notes from a discussion can be found [here](http://bit.ly/tropo-ui-es6)). 

The hardest files to managed & resolve **conflicts** are the 3 involved in this commit:
- bootstrapper.js
- AppRoute.react.js
- public_site/bootstrapper.js

Resources around understanding & using ES6 Modules can be found in the following gist:
- https://gist.github.com/lenards/711efb16001d02152598

The [next step](https://github.com/lenards/troposphere/tree/es6-module-imports/troposphere/static/js) will be to create a pull request for [es6-module-imports](https://github.com/lenards/troposphere/tree/es6-module-imports). 
