### PR TITLE
Added _expected_ label text for end-date field when editing image version information.

### DIFF
--- a/troposphere/static/js/components/common/InteractiveDateField.react.js
+++ b/troposphere/static/js/components/common/InteractiveDateField.react.js
@@ -12,6 +12,7 @@ define(function (require) {
 
     propTypes: {
       value: React.PropTypes.string,
+      labelText: React.PropTypes.string,
       onChange: React.PropTypes.func.isRequired,
     },
 
@@ -46,9 +47,10 @@ define(function (require) {
     },
 
     render: function () {
-
+      var labelEl = this.props.labelText ? (<label>{this.props.labelText}</label>) : "";
       return (
         <div className="form-group">
+          {labelEl}
           <input type='text' className='form-control' value={this.state.value} onChange={this.onValueChanged}/>
           <span className="input-group-addon" id="enddate-set-addon" onClick={this.setEndDateNow}>Today</span>
           <span className="input-group-addon" id="enddate-clear-addon" onClick={this.unsetDate}>Clear</span>

--- a/troposphere/static/js/components/modals/image_version/ImageVersionEditModal.react.js
+++ b/troposphere/static/js/components/modals/image_version/ImageVersionEditModal.react.js
@@ -304,6 +304,7 @@ define(function (require) {
       //FUTURE_keyTODO: Pull this functionality out if you use it anywhere else..
       endDateView = (<InteractiveDateField
               value={ended}
+              labelText={"Version End-dated On"}
               onChange={this.onEndDateChange}
               />);
       startDateView = (<div className='form-group'>


### PR DESCRIPTION
The "Edit Image Version" modal was missing label text for the field that sets an "end-date" for the version (described in [ATMO-1132](https://pods.iplantcollaborative.org/jira/browse/ATMO-1132)). 

Change:  [Before](http://recordit.co/rx7fA7fCWj) => [After](http://recordit.co/GY7PgCleRE)
