### PR TITLE
fixed missing path slash for theme url refs

### DIFF
--- a/troposphere/static/js/components/MaintenanceScreen.react.js
+++ b/troposphere/static/js/components/MaintenanceScreen.react.js
@@ -3,7 +3,7 @@ define(function (require) {
 
   var React = require('react/addons'),
     stores = require('stores'),
-    login = THEME_URL + "images/login_mainimage.png";
+    login = THEME_URL + "/images/login_mainimage.png";
 
   return React.createClass({
     displayName: "MaintenanceScreen",

--- a/troposphere/static/js/no_user.js
+++ b/troposphere/static/js/no_user.js
@@ -1,7 +1,7 @@
 import React from "react";
 import "css/no_user.scss";
 
-var login = THEME_URL + "images/login_mainimage.png";
+var login = THEME_URL + "/images/login_mainimage.png";
 
 var NoUser = React.createClass({
     render: function() {


### PR DESCRIPTION
### Incorrect path ref to THEME_URL 

Was missing the "/" before the subpath to THEME_URL path in the following two files: 
troposphere/static/js/components/MaintenanceScreen.react.js
troposphere/static/js/components/MaintenanceScreen.react.js