### PR TITLE
Fix tags

### DIFF
--- a/troposphere/static/js/components/images/detail/tags/ActualEditTagsView.react.js
+++ b/troposphere/static/js/components/images/detail/tags/ActualEditTagsView.react.js
@@ -46,7 +46,7 @@ define(function (require) {
 
       if (query) {
         tags = this.props.tags.filter(function (tag) {
-          return tag.get('name').toLowerCase().indexOf(query) >= 0;
+          return tag.get('name').toLowerCase().indexOf(query.toLowerCase()) >= 0;
         });
         tags = new Backbone.Collection(tags);
       }

--- a/troposphere/static/js/components/images/detail/tags/ActualEditTagsView.react.js
+++ b/troposphere/static/js/components/images/detail/tags/ActualEditTagsView.react.js
@@ -37,7 +37,7 @@ define(function (require) {
     },
 
     onQueryChange: function (query) {
-      this.setState({query: query.toLowerCase()});
+      this.setState({query: query});
     },
 
     render: function () {
@@ -46,7 +46,7 @@ define(function (require) {
 
       if (query) {
         tags = this.props.tags.filter(function (tag) {
-          return tag.get('name').toLowerCase().indexOf(query) >= 0;
+          return tag.get('name').toLowerCase().indexOf(query.toLowerCase()) >= 0;
         });
         tags = new Backbone.Collection(tags);
       }

--- a/troposphere/static/js/components/images/detail/tags/ActualEditTagsView.react.js
+++ b/troposphere/static/js/components/images/detail/tags/ActualEditTagsView.react.js
@@ -59,6 +59,7 @@ define(function (require) {
             activeModels={this.props.activeTags}
             onModelAdded={this.props.onTagAdded}
             onModelRemoved={this.props.onTagRemoved}
+            onCreateNewTag={this.props.onCreateNewTag}
             onEnterKeyPressed={this.onEnterKeyPressed}
             onQueryChange={this.onQueryChange}
             placeholderText="Search by tag name..."

--- a/troposphere/static/js/components/images/detail/tags/ActualEditTagsView.react.js
+++ b/troposphere/static/js/components/images/detail/tags/ActualEditTagsView.react.js
@@ -37,7 +37,7 @@ define(function (require) {
     },
 
     onQueryChange: function (query) {
-      this.setState({query: query});
+      this.setState({query: query.toLowerCase()});
     },
 
     render: function () {
@@ -46,7 +46,7 @@ define(function (require) {
 
       if (query) {
         tags = this.props.tags.filter(function (tag) {
-          return tag.get('name').toLowerCase().indexOf(query.toLowerCase()) >= 0;
+          return tag.get('name').toLowerCase().indexOf(query) >= 0;
         });
         tags = new Backbone.Collection(tags);
       }


### PR DESCRIPTION
Addresses ATMO-1130
Changes tag search in image edit details page to lowercase to match the tags themselves which are converted to lowercase when being searched.

Also fixes bug when creating new tag on details page that caused a console error when pressing enter. onCreateNewTag is added as a prop when rendering the tag box, which causes the modal to be properly rendered when a user presses the enter key.