### PR TITLE
Bring requirements up to date with atmosphere.

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -2,6 +2,6 @@
 colorama==0.3.3
 coverage==3.7.1
 django-jenkins==0.16.2
-django-sslserver==0.15
+django-sslserver==0.18
 emoji==0.3.6
-ipython==4.0.0
+ipython==4.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
-caslib.py==2.1.0
-django==1.7.4
+caslib.py==2.2.2
+django==1.8.5
 djangorestframework==3.0.4
 Jinja2==2.8
 psycopg2==2.5.2
 pycrypto==2.6.1
 PyJWT==1.4.0
-python-dateutil==2.2
-requests==2.2.1
+python-dateutil==2.4
+requests==2.7
 django-iplant-auth==0.1.2
-uWSGI==2.0.11
+uWSGI==2.0.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ pycrypto==2.6.1
 PyJWT==1.4.0
 python-dateutil==2.4
 requests==2.7
-django-iplant-auth==0.1.2
+django-iplant-auth==0.1.4
 uWSGI==2.0.12


### PR DESCRIPTION
This brings the Django backend and related dependencies up-to-date with [atmosphere:requirements.txt](https://github.com/iPlantCollaborativeOpenSource/atmosphere/blob/0dd7bea28a555b8017efd36349ab2a813653ffd6/requirements.txt).

In order to update `djangorestframework`, we will need to make changed to endpoints within `tropo-api/`. 

