### PR TITLE
Correct source path for image assets (not theme-ready).

### DIFF
--- a/troposphere/templates/no_user.html
+++ b/troposphere/templates/no_user.html
@@ -4,12 +4,12 @@
   <title>
     Atmosphere | iPlant Collaborative
   </title>
-  <link rel="shortcut icon" href="/assets/images/favicon.ico" />
+  <link rel="shortcut icon" href="/assets/resources/images/favicon.ico" />
   <link type="text/css" rel="stylesheet" href="/assets/no_user.css" />
   <link rel="stylesheet" href="{{ site_root }}/assets/resources/css/login.css"/>
 </head>
 <body>
-    <img src="/assets/images/login_mainimage.png">
+    <img src="/assets/resources/images/login_mainimage.png">
     <div class="message-wrapper">
         {% if banner %}
         <div id="toast-container" class="toast-top-full-width">


### PR DESCRIPTION
This fixes [ATMO-1139](https://pods.iplantcollaborative.org/jira/browse/ATMO-1139) by appropriately linking to the static image asset as _assets/resources/images_. 

This is not a "theme-ready" fix. See [lenards:atmo-1139](https://github.com/lenards/troposphere/tree/atmo-1139) for work on including `THEME_URL` in the `no_user.html` template (including changing in the django backend). 
