### PR TITLE
Provide a `post_save` signal to ensure a User has preferences.

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -1,5 +1,6 @@
 from django.db import models
 from django.db.models import Q
+from django.db.models.signals import post_save
 from django.utils import timezone
 from django.contrib.auth.models import User
 
@@ -55,3 +56,14 @@ class UserPreferences(models.Model):
 
     def __unicode__(self):
         return "%s" % self.user.username
+
+
+# Save Hook(s) Here:
+def get_or_create_preferences(sender, instance, created, **kwargs):
+    pref, _ = UserPreferences.objects.get_or_create(user=instance)
+    pref.user = instance
+    pref.save()
+
+
+# Instantiate the hook(s):
+post_save.connect(get_or_create_preferences, sender=User)


### PR DESCRIPTION
This gets troposphere a step closer to safe operations with an empty initial database. 

When a `django.contrib.auth.models.User`, a `post_save` _signal_ is connected as a hook to `User` that will _get or create_ a user preference for that model ([api/models.py](https://github.com/lenards/troposphere/blob/55b1ee3f2fd462a3a44b58e57487b0841e15cab0/api/models.py#L61-L69)). 

This relates back to QA regression test failures discussed in [ATMO-1143](https://pods.iplantcollaborative.org/jira/browse/ATMO-1143). 

