### PR TITLE
Fix volume update

### DIFF
--- a/troposphere/static/js/actions/volume/update.js
+++ b/troposphere/static/js/actions/volume/update.js
@@ -17,7 +17,8 @@ define(function (require) {
       volume.save({
         name: volume.get('name')
       }, {
-        patch: true
+        patch: true,
+        merge: true
       }).done(function () {
         // Nothing to do here
       }).fail(function (response) {


### PR DESCRIPTION
Addresses ATMO-1116
Currently, when a user updates the name of a volume, the start date field in the UI updates to "Invalid date" as seen here:
![volnamebefore](https://cloud.githubusercontent.com/assets/11079642/12648414/1340dee8-c597-11e5-934c-67f9127df16a.gif)

This is a result of setting the updated Backbone model's attributes to be whatever is returned by the API after the PATCH, which is just the volume name and description. Without `merge: true`, this means that the local model only contains these two attributes, not the `start_date` that existed before the PATCH, leading to the "Invalid date" being displayed for the now nonexistent value.

Here is the result of setting `merge: true` when saving the Backbone model:
![volnameafter](https://cloud.githubusercontent.com/assets/11079642/12648494/8194bf68-c597-11e5-9eec-3b52403ea41b.gif)

