### PR TITLE
Send "admin_url" parameter when creating resource request

### DIFF
--- a/troposphere/static/js/actions/HelpActions.js
+++ b/troposphere/static/js/actions/HelpActions.js
@@ -69,7 +69,7 @@ define(function (require) {
         identity = params.identity,
         quota = params.quota,
         reason = params.reason,
-        // if ticket_link is undefined, the API will default to the django admin UI for ticket management
+        // if admin_url is undefined, the API will default to the django admin UI for ticket management
         admin_url = window.location.origin + "/application/admin/resource-requests/",
         username = user.get('username');
 

--- a/troposphere/static/js/actions/HelpActions.js
+++ b/troposphere/static/js/actions/HelpActions.js
@@ -59,7 +59,7 @@ define(function (require) {
       if (!params.identity) throw new Error("Missing identity");
       if (!params.quota) throw new Error("Missing quota");
       if (!params.reason) throw new Error("Missing reason");
-      
+
       if(globals.BADGES_ENABLED){
         actions.BadgeActions.askSupport();
       }
@@ -69,12 +69,15 @@ define(function (require) {
         identity = params.identity,
         quota = params.quota,
         reason = params.reason,
+        // if ticket_link is undefined, the API will default to the django admin UI for ticket management
+        admin_url = window.location.origin + "/application/admin/resource-requests/",
         username = user.get('username');
 
       var data = {
         identity: identity,
         request: quota,
-        description: reason
+        description: reason,
+        admin_url: admin_url
       };
 
       var requestUrl = globals.API_V2_ROOT + '/resource_requests';

--- a/troposphere/static/js/components/modals/RequestMoreResourcesModal.react.js
+++ b/troposphere/static/js/components/modals/RequestMoreResourcesModal.react.js
@@ -41,6 +41,7 @@ define(
 
       componentDidMount: function () {
         stores.IdentityStore.addChangeListener(this.updateState);
+        stores.ResourceRequestStore.addChangeListener(this.updateState);
       },
 
       componentWillUnmount: function () {
@@ -101,7 +102,13 @@ define(
 
       renderBody: function () {
         var identities = stores.IdentityStore.getAll(),
-            instances = stores.InstanceStore.getAll();
+            instances = stores.InstanceStore.getAll(),
+            username = stores.ProfileStore.get().get('username'),
+            requests = stores.ResourceRequestStore.findWhere({"created_by.username": username});
+
+        if(username == null || requests == null){
+            return <div className="loading"></div>;
+        }
 
         if (!identities || !instances) return <div className="loading"/>;
 
@@ -144,7 +151,6 @@ define(
       },
 
       render: function () {
-
         return (
           <div className="modal fade">
             <div className="modal-dialog">


### PR DESCRIPTION
**Depends on ATMO PR #102**
Send an `admin_url` parameter when making a POST to create a new resource request. This will allow the emails sent by Atmosphere to administrators to have a link to Troposphere's admin interface, instead of the Django admin interface the emails currently link to.