### PR TITLE
Provide _catch-all_ route for public site.

### DIFF
--- a/troposphere/static/js/components/NotFoundPage.react.js
+++ b/troposphere/static/js/components/NotFoundPage.react.js
@@ -1,0 +1,31 @@
+import React from 'react/addons';
+import Glyphicon from 'components/common/Glyphicon.react';
+
+
+export default React.createClass({
+    displayName: "NotFoundPage",
+
+    render: function() {
+
+        return (
+        <div className="container">
+            <h2>Page Unavailable</h2>
+            <div>
+                <p style={{'font-size': '133%'}}>
+                <Glyphicon name="info-sign" />
+                {`
+                    The requested page cannot be viewed because
+                    it either does not exist or you do not currently
+                    have permission to view it.
+                `}
+                </p>
+                <p style={{'font-size': '133%'}}>
+                {`This page may be visible if you `}
+                <a href="/login?redirect=/application?beta=true">log in</a>{`.`}
+                </p>
+            </div>
+        </div>
+        );
+    }
+
+})

--- a/troposphere/static/js/public_site/AppRoutes.react.js
+++ b/troposphere/static/js/public_site/AppRoutes.react.js
@@ -15,7 +15,8 @@ define(function (require) {
       MyImageRequestsPage = require('components/images/MyImageRequestsPage.react'),
       ImageDetailsPage = require('components/images/ImageDetailsPage.react'),
       ImageTagsPage = require('components/images/ImageTagsPage.react'),
-      ImagesMaster = require('components/images/ImagesMaster.react');
+      ImagesMaster = require('components/images/ImagesMaster.react'),
+      NotFoundPage = require('components/NotFoundPage.react');
 
   var AppRoutes = (
     <Route name="root" path="/application" handler={Master}>
@@ -29,6 +30,7 @@ define(function (require) {
       </Route>
       <Route name="help" handler={HelpPage}/>
       <Redirect from="/application" to="/application/images"/>
+      <Route name="not-found" path="*" handler={NotFoundPage} />
     </Route>
   );
 


### PR DESCRIPTION
Fixes [ATMO-1157](https://pods.iplantcollaborative.org/jira/browse/ATMO-1157). 

## Summary 

If you were on an authenticated/authorized routes (say, `application/projects/1/resources`) and your session expired, you would be presented with a blank page - with no context (written up as ATMO-1157). 

This pull request adds a "catch all" `Route` that will handle when this happens on the public site and display a contextual message (shown below) similar to other web applications when the resource/page is no longer viewable. 

This functionality becomes critical when you apply fixes regarding [ATMO-1160](https://pods.iplantcollaborative.org/jira/browse/ATMO-1160) & [ATMO-1024](https://pods.iplantcollaborative.org/jira/browse/ATMO-1024) _(which both deal with session aging, expiring & validation)_. 

## Expected Unavailable Page View 

![screen shot 2016-02-10 at 9 42 02 am](https://cloud.githubusercontent.com/assets/5923/12959081/05a461f0-cff2-11e5-9e53-bbc06f89b733.png)