### PR TITLE
Fix instance history

### DIFF
--- a/troposphere/static/js/components/dashboard/InstanceHistoryList.react.js
+++ b/troposphere/static/js/components/dashboard/InstanceHistoryList.react.js
@@ -36,7 +36,6 @@ define(function(require) {
     refreshHistory: function(){
         this.setState({instanceHistoryItems: stores.InstanceHistoryStore.fetchFirstPageWhere({"page_size": 10}, {clearQueryCache: true})});
         stores.InstanceHistoryStore.lastUpdated = Date.now();
-        this.forceUpdate();
     },
 
     renderRefreshButton: function(){

--- a/troposphere/static/js/components/dashboard/InstanceHistoryList.react.js
+++ b/troposphere/static/js/components/dashboard/InstanceHistoryList.react.js
@@ -34,7 +34,7 @@ define(function(require) {
     },
 
     refreshHistory: function(){
-        stores.InstanceHistoryStore.fetchFirstPage();
+        this.setState({instanceHistoryItems: stores.InstanceHistoryStore.fetchFirstPageWhere({"page_size": 10}, {clearQueryCache: true})});
         stores.InstanceHistoryStore.lastUpdated = Date.now();
         this.forceUpdate();
     },

--- a/troposphere/static/js/components/dashboard/InstanceHistoryList.react.js
+++ b/troposphere/static/js/components/dashboard/InstanceHistoryList.react.js
@@ -13,8 +13,6 @@ define(function(require) {
 
     getInitialState: function() {
       return {
-        isLoadingMoreResults: false,
-        nextUrl: null,
         instanceHistoryItems: stores.InstanceHistoryStore.fetchWhere({"page_size": 10})
       }
     },

--- a/troposphere/static/js/components/dashboard/InstanceHistoryList.react.js
+++ b/troposphere/static/js/components/dashboard/InstanceHistoryList.react.js
@@ -103,6 +103,7 @@ define(function(require) {
 
       instanceHistoryItems = instanceHistories.map(function(instance) {
         var providerId = null,
+            name = instance.get('instance').name,
             image = instance.get('image'),
             provider = instance.get('provider'),
             instanceId = instance.get('instance').id;
@@ -145,7 +146,7 @@ define(function(require) {
                   <div>
                     <Gravatar hash={instanceHistoryHash} size={iconSize} type={type}/>
                     <div className="instance-history-details">
-                      <strong className="name">{instance.get('name')}</strong>
+                      <strong className="name">{name}</strong>
                       <div>Launched from {imageLink}</div>
                       <div>{"Ran: " + formattedStartDate + " - " + formattedEndDate}</div>
                     </div>

--- a/troposphere/static/js/stores/BaseStore.js
+++ b/troposphere/static/js/stores/BaseStore.js
@@ -173,7 +173,12 @@ define(function (require) {
     },
 
     // same as fetchFirstPage, but with URL query params
-    fetchFirstPageWhere: function(queryParams) {
+    fetchFirstPageWhere: function(queryParams, options) {
+      if(options.clearQueryCache){
+        var queryString = buildQueryStringFromQueryParams(queryParams);
+        delete this.queryModels[queryString];
+      }
+
       if (!this.isFetching) {
         this.isFetching = true;
         queryParams = queryParams || {};

--- a/troposphere/static/js/stores/BaseStore.js
+++ b/troposphere/static/js/stores/BaseStore.js
@@ -341,12 +341,10 @@ define(function (require) {
       if (nextUrl && !this.isFetchingQuery[queryString]) {
         this.isFetchingQuery[queryString] = true;
         var moreModels = new this.collection();
-        moreModels.fetch({
-          url: nextUrl
+        this.queryModels[queryString].fetch({
+          url: nextUrl, remove: false
         }).done(function () {
           this.isFetchingQuery[queryString] = false;
-          searchResults.add(moreModels.models);
-          searchResults.meta = moreModels.meta;
           this.emitChange();
         }.bind(this));
       }


### PR DESCRIPTION
Currently, the instance history list doesn't show instance names. It also displays 100 items initially and the "load more" button has no effect.

The problem is in the current use of getAll() and fetchMoreWhere() in the component, coupled with the fact that fetchMoreWhere() is currently broken. Adding `remove: false` when fetching on an existing collection will add to the existing collection, which is what we expected fetchMoreWhere() to do in the first place. 

Before: ![beforefix](https://cloud.githubusercontent.com/assets/11079642/12991083/d2cd2ef4-d0ca-11e5-85c8-0768ff471c3b.gif)

After: 
![afterfix](https://cloud.githubusercontent.com/assets/11079642/12991092/e0f33262-d0ca-11e5-8c61-0e1ad2a94ed1.gif)

