### PR TITLE
Prevent volume attach on non-active instances

### DIFF
--- a/troposphere/static/js/components/modals/volume/VolumeAttachModal.react.js
+++ b/troposphere/static/js/components/modals/volume/VolumeAttachModal.react.js
@@ -161,8 +161,9 @@ define(
                     <strong>Uh oh! </strong>
                     It looks like you don't have any instances in this project
                     that you can attach the volume to. Volumes can only be
-                    attached to instances that are in the <strong>same project</strong> and
-                    on the <strong>same provider</strong> as the volume.
+                    attached to instances that are <strong>active</strong>, in
+                    the <strong>same project</strong> and on the <strong>same
+                    provider</strong> as the volume.
                   </p>
 
                   <p>
@@ -227,12 +228,14 @@ define(
             instances = this.state.instances,
             content;
 
-        if (!instances) {
+        var activeInstances = instances && instances.filter(i => i.is_active());
+
+        if (instances == null) {
           content = this.renderLoadingContent();
-        } else if (instances.length <= 0) {
-          content = this.renderAttachRulesContent();
+        } else if (activeInstances.length > 0) {
+          content = this.renderAttachVolumeContent(activeInstances);
         } else {
-          content = this.renderAttachVolumeContent(instances);
+          content = this.renderAttachRulesContent(); 
         }
 
         return (

--- a/troposphere/static/js/components/projects/resources/instance/details/actions/InstanceActionsAndLinks.react.js
+++ b/troposphere/static/js/components/projects/resources/instance/details/actions/InstanceActionsAndLinks.react.js
@@ -63,8 +63,8 @@ define(function(require) {
     },
 
     render: function() {
-      var webShellUrl = this.props.instance.get('shell_url'),
-          remoteDesktopUrl = this.props.instance.get('vnc_url'),
+      var webShellUrl = this.props.instance.shell_url(),
+          remoteDesktopUrl = this.props.instance.vnc_url(),
           status = this.props.instance.get('state').get('status'),
           activity = this.props.instance.get('state').get('activity'),
           ip_address = this.props.instance.get('ip_address'),

--- a/troposphere/static/js/models/Instance.js
+++ b/troposphere/static/js/models/Instance.js
@@ -80,72 +80,69 @@ define(
         };
       },
 
-      computed: {
+      shell_url: function () {
+        var username = context.profile.get('username'),
+          ip = this.get('ip_address'),
+          location = ip.split(".").join("-");
+        return globals.WEB_SH_URL + "?location=" + location +
+            "&ssh=ssh://" + username + "@" + ip + ":22";
+      },
 
-        shell_url: function () {
-          var username = context.profile.get('username'),
-            ip = this.get('ip_address'),
-            location = ip.split(".").join("-");
-          return globals.WEB_SH_URL + "?location=" + location +
-              "&ssh=ssh://" + username + "@" + ip + ":22";
-        },
+      vnc_url: function () {
+        return "http://" + this.get('ip_address') + ":5904";
+      },
 
-        vnc_url: function () {
-          return "http://" + this.get('ip_address') + ":5904";
-        },
+      is_active: function () {
+        var states = ['active', 'running', 'verify_resize'];
+        return _.contains(states, this.get('status'));
+      },
 
-        is_active: function () {
-          var states = ['active', 'running', 'verify_resize'];
-          return _.contains(states, this.get('status'));
-        },
+      is_build: function () {
+        var states = [
+          'build',
+          'build - requesting_launch',
+          'build - block_device_mapping',
+          'build - scheduling',
+          'build - spawning',
+          'build - networking',
+          'active - powering-off',
+          'active - image_uploading',
+          'shutoff - powering-on',
+          'pending',
+          'suspended - resuming',
+          'active - suspending',
+          'resize - resize_prep',
+          'resize - resize_migrating',
+          'resize - resize_migrated',
+          'resize - resize_finish',
+          'active - networking',
+          'active - deploying',
+          'active - initializing',
+          'hard_reboot - rebooting_hard',
+          'revert_resize - resize_reverting'
+        ];
+        return _.contains(states, this.get('status'));
+      },
 
-        is_build: function () {
-          var states = [
-            'build',
-            'build - requesting_launch',
-            'build - block_device_mapping',
-            'build - scheduling',
-            'build - spawning',
-            'build - networking',
-            'active - powering-off',
-            'active - image_uploading',
-            'shutoff - powering-on',
-            'pending',
-            'suspended - resuming',
-            'active - suspending',
-            'resize - resize_prep',
-            'resize - resize_migrating',
-            'resize - resize_migrated',
-            'resize - resize_finish',
-            'active - networking',
-            'active - deploying',
-            'active - initializing',
-            'hard_reboot - rebooting_hard',
-            'revert_resize - resize_reverting'
-          ];
-          return _.contains(states, this.get('status'));
-        },
+      is_delete: function () {
+        var states = ['delete', 'active - deleting', 'deleted', 'shutting-down',
+          'terminated'];
+        return _.contains(states, this.get('status'));
+      },
 
-        is_delete: function () {
-          var states = ['delete', 'active - deleting', 'deleted', 'shutting-down',
-            'terminated'];
-          return _.contains(states, this.get('status'));
-        },
+      is_inactive: function () {
+        var states = ['suspended', 'shutoff', 'shutoff - powering-on'];
+        return _.contains(states, this.get('status'));
+      },
 
-        is_inactive: function () {
-          var states = ['suspended', 'shutoff', 'shutoff - powering-on'];
-          return _.contains(states, this.get('status'));
-        },
+      is_resize: function () {
+        return this.get('status').indexOf('resize') > -1;
+      },
 
-        is_resize: function () {
-          return this.get('status').indexOf('resize') > -1;
-        },
-
-        action_url: function () {
-          var instanceUrl = this.url();
-          if (instanceUrl.slice(-1) !== "/") instanceUrl += "/";
-          return instanceUrl + 'action';
-        }
+      action_url: function () {
+        var instanceUrl = this.url();
+        if (instanceUrl.slice(-1) !== "/") instanceUrl += "/";
+        return instanceUrl + 'action';
       },
 
       destroy: function (options) {
@@ -245,16 +242,5 @@ define(
         this.set({status: 'active - rebooting'});
         this.performAction('reboot', options);
       },
-
-      /*
-       * Here, were override the get method to allow lazy-loading of computed
-       * attributes
-       */
-      get: function (attr) {
-        if (typeof this.computed !== "undefined" && typeof this.computed[attr] === 'function')
-          return this.computed[attr].call(this);
-        return Backbone.Model.prototype.get.call(this, attr);
-      }
     });
-
 });


### PR DESCRIPTION
Several functions were inlined. models/Instance could use more refactor.

When this commit was cherried onto master there was a conflict involving `shell_url` in:
	troposphere/static/js/models/Instance.js