### PR TITLE
Address styling on Interactive DateField component 

### DIFF
--- a/troposphere/static/js/components/common/InteractiveDateField.react.js
+++ b/troposphere/static/js/components/common/InteractiveDateField.react.js
@@ -47,13 +47,38 @@ define(function (require) {
     },
 
     render: function () {
-      var labelEl = this.props.labelText ? (<label>{this.props.labelText}</label>) : "";
+      var labelEl = this.props.labelText ? (<label htmlFor="interactive-date-field">{this.props.labelText}</label>) : null;
+      var btnStyle = {
+        lineHeight: '1.31' // I know this is quite heinous ...
+      };
+      var lastBtnStyle = {
+        borderTopRightRadius: '5px',
+        borderBottomRightRadius: '5px'
+      };
+      _.extend(lastBtnStyle, btnStyle);
+
       return (
-        <div className="form-group">
-          {labelEl}
-          <input type='text' className='form-control' value={this.state.value} onChange={this.onValueChanged}/>
-          <span className="input-group-addon" id="enddate-set-addon" onClick={this.setEndDateNow}>Today</span>
-          <span className="input-group-addon" id="enddate-clear-addon" onClick={this.unsetDate}>Clear</span>
+        <div>
+        {labelEl}
+        <div className="input-group">
+          <input id="interactive-date-field"
+            type="text"
+            className="form-control"
+            value={this.state.value}
+            onChange={this.onValueChanged} />
+          <div className="input-group-btn">
+            <button type="button"
+                id="enddate-set-addon"
+                className="btn btn-default"
+                style={btnStyle}
+                onClick={this.setEndDateNow}>Today</button>
+            <button type="button"
+                id="enddate-clear-addon"
+                className="btn btn-default"
+                style={lastBtnStyle}
+                onClick={this.unsetDate}>Clear</button>
+          </div>
+        </div>
         </div>
       );
     }

--- a/troposphere/static/js/components/common/InteractiveDateField.react.js
+++ b/troposphere/static/js/components/common/InteractiveDateField.react.js
@@ -30,10 +30,10 @@ define(function (require) {
     },
 
     unsetDate: function (e) {
-      var new_value = "";
-      this.setState({value: new_value});
+      var newValue = "";
+      this.setState({value: newValue});
       if(this.props.onChange != null) {
-        this.props.onChange(new_value)
+        this.props.onChange(newValue)
       }
     },
 

--- a/troposphere/static/js/components/images/detail/EditImageDetails.react.js
+++ b/troposphere/static/js/components/images/detail/EditImageDetails.react.js
@@ -97,7 +97,7 @@ define(function (require) {
               onChange={this.handleNameChange}
             />
             <CreatedView image={image}/>
-            
+
             <div className='image-info-segment row'>
                 <h4 className="titel col-md-2">Date to hide image from public view</h4>
                 <div className="col-md-10">

--- a/troposphere/static/js/components/modals/image_version/ImageVersionEditModal.react.js
+++ b/troposphere/static/js/components/modals/image_version/ImageVersionEditModal.react.js
@@ -350,6 +350,7 @@ define(function (require) {
           }
           {startDateView}
           {endDateView}
+          <hr />
           <div className="form-group clearfix">
             <button type="button" className="btn btn-default pull-right"
                     onClick={this.onOptionsChange}>


### PR DESCRIPTION
Fixes [ATMO-1150](https://pods.iplantcollaborative.org/jira/browse/ATMO-1150). 

The styling & markup on InteractiveDateField was previous such that it has rendering quirks/issues (see below:
![screen shot 2016-01-28 at 3 21 02 pm](https://cloud.githubusercontent.com/assets/5923/13057165/8bcba5d4-d3d7-11e5-9767-93e2fe2628b6.png)

The modal is not the only place the component it is used: 
- `troposphere/static/js/components/images/detail/EditImageDetails.react.js`
- `troposphere/static/js/components/modals/admin/ManageUserModal.react.js`
- `troposphere/static/js/components/modals/image_version/ImageVersionEditModal.react.js`

*Note:* `ManageUserModal` is currently not reachable within the _Admin_ user interface. 

## Within `EditImageDetails`
![component used in EditImageDetails](https://cloud.githubusercontent.com/assets/5923/13057113/2ae3e70e-d3d7-11e5-9624-e8a100fa6b61.png)

## Within `ImageVersionEditModal`
![component used in ImageVersionEditModal](https://cloud.githubusercontent.com/assets/5923/13057112/2ad4c5b2-d3d7-11e5-8bbd-f81af1c5cd37.png)