### PR TITLE
Jetstream machine request fixes

### DIFF
--- a/troposphere/static/js/components/admin/ImageMaster.react.js
+++ b/troposphere/static/js/components/admin/ImageMaster.react.js
@@ -63,9 +63,16 @@ define(function (require) {
             this.onResourceClick(request);
         }.bind(this);
 
+        var errorStatus;
+
+        if(request.get('old_status').indexOf("ERROR") > -1 || request.get('old_status').indexOf("Traceback") > -1
+            || request.get('old_status').indexOf("Exception") > -1){
+            errorStatus = "(ERROR)";
+        }
+
         return (
           <li key={request.id} onClick={handleClick}>
-            {request.get('new_machine_owner').username} - <strong>{request.get('status').name}</strong>
+            {request.get('new_machine_owner').username} - <strong>{request.get('status').name}{errorStatus}</strong>
           </li>
         );
       }.bind(this));

--- a/troposphere/static/js/components/admin/ImageRequest.react.js
+++ b/troposphere/static/js/components/admin/ImageRequest.react.js
@@ -110,7 +110,7 @@ define(function (require) {
               onChange={this.handleResponseChange}/><br />
             <button disabled={request.get('status').name != 'pending'}onClick={this.approve} type="button" className="btn btn-default btn-sm">Approve</button>
             <button disabled={request.get('status').name != 'pending'}onClick={this.deny} type="button" className="btn btn-default btn-sm">Deny</button>
-            <button disabled={request.get('status').name == 'rejected'}onClick={this.resubmit} type="button" className="btn btn-default btn-sm">Re-Submit</button>
+            <button disabled={request.get('status').name == 'closed'}onClick={this.resubmit} type="button" className="btn btn-default btn-sm">Re-Submit</button>
           </div>
         </div>
       );


### PR DESCRIPTION
Display better status text if there's an error with the request, enable resubmitting a rejected request, and disable resubmitting a closed request