### PR TITLE
Introduce Public Image Catalog at landing page; Bugfixes for Troposphere as "Default UI"

### DIFF
--- a/api/admin.py
+++ b/api/admin.py
@@ -3,9 +3,9 @@ from .models import MaintenanceRecord, UserPreferences
 
 @admin.register(UserPreferences)
 class UserPreferencesAdmin(admin.ModelAdmin):
-    list_display = ["user", "show_beta_interface", "created_date", "modified_date"]
+    list_display = ["user", "show_beta_interface", "airport_ui", "created_date", "modified_date"]
     list_filter = [
-        "show_beta_interface",
+        "show_beta_interface", "airport_ui",
     ]
 
 

--- a/api/migrations/0003_transition_to_iplantauth_mod.py
+++ b/api/migrations/0003_transition_to_iplantauth_mod.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('api', '0002_alter_ui_pref_default'),
+    ]
+
+    operations =  [
+        migrations.RemoveField(
+            model_name='usertoken',
+            name='user',
+        ),
+        migrations.DeleteModel(
+            name='UserToken',
+        ),
+    ]

--- a/api/migrations/0004_userpreferences_airport_ui.py
+++ b/api/migrations/0004_userpreferences_airport_ui.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('api', '0003_transition_to_iplantauth_mod'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='userpreferences',
+            name='airport_ui',
+            field=models.NullBooleanField(default=None),
+            preserve_default=True,
+        ),
+    ]

--- a/api/models.py
+++ b/api/models.py
@@ -53,6 +53,7 @@ class UserPreferences(models.Model):
     show_beta_interface = models.BooleanField(default=True)
     created_date = models.DateTimeField(auto_now_add=True)
     modified_date = models.DateTimeField(auto_now=True)
+    airport_ui = models.NullBooleanField(default=None, null=True)
 
     def __unicode__(self):
         return "%s" % self.user.username

--- a/troposphere/static/js/components/Header.react.js
+++ b/troposphere/static/js/components/Header.react.js
@@ -77,7 +77,7 @@ define(function (require) {
     render: function () {
       return (
         <li className="dropdown">
-          <a href="/login?redirect=/application?beta=true&airport_ui=false">Login</a>
+          <a id="login_link" href="/login?redirect=/application?beta=true&airport_ui=false">Login</a>
         </li>
       );
     }

--- a/troposphere/static/js/components/Header.react.js
+++ b/troposphere/static/js/components/Header.react.js
@@ -77,7 +77,7 @@ define(function (require) {
     render: function () {
       return (
         <li className="dropdown">
-          <a href="/login?redirect=/application?beta=true">Login</a>
+          <a href="/login?redirect=/application?beta=true&airport_ui=false">Login</a>
         </li>
       );
     }
@@ -120,7 +120,7 @@ define(function (require) {
               <a href="http://atmosphere.status.io" target="_blank">Status</a>
             </li>
             <li>
-              <a href="/logout?cas=True">Sign out</a>
+              <a href="/logout?cas=True&airport_ui=false">Sign out</a>
             </li>
           </ul>
         </li>
@@ -159,7 +159,7 @@ define(function (require) {
       if (!window.show_troposphere_only) {
         return (
           <div className="beta-toggle">
-            <a href="/application?beta=false">
+            <a href="/application?beta=false&airport_ui=true">
               <div className="toggle-wrapper">
                 <div className="toggle-background">
                   <div className="toggle-text">View Old UI</div>

--- a/troposphere/static/js/components/Header.react.js
+++ b/troposphere/static/js/components/Header.react.js
@@ -114,13 +114,13 @@ define(function (require) {
             </li>
             <li className="divider"></li>
             <li>
-              <a href="#" onClick={this.onShowVersion}>Version</a>
+              <a id="version_link" href="#" onClick={this.onShowVersion}>Version</a>
             </li>
             <li>
               <a href="http://atmosphere.status.io" target="_blank">Status</a>
             </li>
             <li>
-              <a href="/logout?cas=True&airport_ui=false">Sign out</a>
+              <a id="logout_link" href="/logout?cas=True&airport_ui=false">Sign out</a>
             </li>
           </ul>
         </li>

--- a/troposphere/static/js/components/Master.react.js
+++ b/troposphere/static/js/components/Master.react.js
@@ -16,6 +16,7 @@ define(function (require) {
   // Routing
   var Router = require('react-router'),
     RouteHandler = Router.RouteHandler;
+
   return React.createClass({
     displayName: "Master",
 
@@ -69,14 +70,14 @@ define(function (require) {
 
       // The code below is only relevant to logged in users
       if (!context.profile || !context.profile.get('selected_identity')) return;
+
       // IMPORTANT! We get one shot at this. If the instances and volumes aren't
       // fetched before this component is mounted we miss our opportunity to migrate
       // the users resources (so make sure they're fetched in the Splash Screen)
+      var instances = stores.InstanceStore.getInstancesNotInAProject(),
+            volumes = stores.VolumeStore.getVolumesNotInAProject(),
+            nullProject = new NullProject({instances: instances, volumes: volumes});
 
-
-        var instances = stores.InstanceStore.getInstancesNotInAProject(),
-        volumes = stores.VolumeStore.getVolumesNotInAProject(),
-        nullProject = new NullProject({instances: instances, volumes: volumes});
       if (!modernizrTest.unsupported()) {
           showUnsupportedModal.showModal(this.closeUnsupportedModal);
       }

--- a/troposphere/static/js/components/images/ImageDetailsPage.react.js
+++ b/troposphere/static/js/components/images/ImageDetailsPage.react.js
@@ -15,7 +15,7 @@ define(function (require) {
     renderBody: function(){
       var image = stores.ImageStore.get(Number(this.getParams().imageId)),
         tags = stores.TagStore.getAll(),
-        userLoggedIn = context.profile,
+        userLoggedIn = (context.profile && context.profile.get('selected_identity')),
         providers = userLoggedIn ? stores.ProviderStore.getAll() : null,
         identities = userLoggedIn ? stores.IdentityStore.getAll() : null;
 

--- a/troposphere/static/js/components/images/common/SecondaryImageNavigation.react.js
+++ b/troposphere/static/js/components/images/common/SecondaryImageNavigation.react.js
@@ -27,10 +27,13 @@ define(function (require) {
           allImages = stores.ImageStore.getAll(),
           images = stores.ImageStore.fetchWhere({
             created_by__username: profile.get('username')
-          }) || [], 
-          favoritedImages = stores.ImageBookmarkStore.getBookmarkedImages() || [];
+          }) || [];
 
-      if(!images || !favoritedImages){
+      // only attempt to get bookmarks if there is a profile that might have them ...
+      var userLoggedIn = !!(profile && profile.get('selected_identity')),
+        favoritedImages =  userLoggedIn ? stores.ImageBookmarkStore.getBookmarkedImages() : [];
+
+      if(!images || (userLoggedIn && !favoritedImages)){
         return <div className="loading"></div>
       }
 

--- a/troposphere/static/js/components/images/detail/ImageDetailsView.react.js
+++ b/troposphere/static/js/components/images/detail/ImageDetailsView.react.js
@@ -18,8 +18,8 @@ define(
 
       propTypes: {
         image: React.PropTypes.instanceOf(Backbone.Model).isRequired,
-        providers: React.PropTypes.instanceOf(Backbone.Collection).isRequired,
-        identities: React.PropTypes.instanceOf(Backbone.Collection).isRequired,
+        providers: React.PropTypes.instanceOf(Backbone.Collection),
+        identities: React.PropTypes.instanceOf(Backbone.Collection),
         tags: React.PropTypes.instanceOf(Backbone.Collection).isRequired
       },
 
@@ -48,11 +48,12 @@ define(
       },
 
       render: function () {
-        var view, versionView;
-        versionView = (
-          <VersionsView image={this.props.image}
-          />
+        var view,
+            versionView = (
+                <VersionsView image={this.props.image}
+            />
         );
+
         if(this.state.isEditing){
           view = (
             <EditImageDetails image={this.props.image}

--- a/troposphere/static/js/components/images/detail/ViewImageDetails.react.js
+++ b/troposphere/static/js/components/images/detail/ViewImageDetails.react.js
@@ -20,8 +20,8 @@ define(
 
       propTypes: {
         image: React.PropTypes.instanceOf(Backbone.Model).isRequired,
-        providers: React.PropTypes.instanceOf(Backbone.Collection).isRequired,
-        identities: React.PropTypes.instanceOf(Backbone.Collection).isRequired,
+        providers: React.PropTypes.instanceOf(Backbone.Collection),
+        identities: React.PropTypes.instanceOf(Backbone.Collection),
         tags: React.PropTypes.instanceOf(Backbone.Collection).isRequired,
         onEditImageDetails: React.PropTypes.func.isRequired
       },

--- a/troposphere/static/js/components/images/detail/launch/ImageLaunchCard.react.js
+++ b/troposphere/static/js/components/images/detail/launch/ImageLaunchCard.react.js
@@ -23,6 +23,7 @@ define(
         var image = this.props.image;
         var versions = stores.ImageStore.getVersions(image.id);
         var type = stores.ProfileStore.get().get('icon_set');
+        var userLoggedIn = (context.profile && context.profile.get('selected_identity'));
 
         var iconSize = 145;
         // always use the Gravatar icons
@@ -32,7 +33,7 @@ define(
 
         // Hide bookmarking on the public page
         var bookmark;
-        if (context.profile) {
+        if (userLoggedIn) {
           bookmark = (
             <Bookmark image={image}/>
           );
@@ -40,16 +41,18 @@ define(
         //When versions is 'not loaded' OR 'has length > 0', you can launch.
         var canLaunch = (versions !== null && versions.length !== 0) ? true : false;
         var button;
-        if (context.profile) {
+        if (userLoggedIn) {
           button = (
-            <button className='btn btn-primary launch-button' onClick={this.props.onLaunch} disabled={!canLaunch}>
+            <button className='btn btn-primary launch-button'
+                onClick={this.props.onLaunch}
+                disabled={!canLaunch}>
               Launch
             </button>
           );
         } else {
           var loginUrl = URL.login(null, {relative: true}),
             imageUrl = URL.image(this.props.image),
-            fullUrl = loginUrl + "?redirect=" + imageUrl + "?beta=true";
+            fullUrl = loginUrl + "?redirect=" + imageUrl + "?beta=true&airport_ui=false";
 
           button = (
             <a className='btn btn-primary launch-button' href={fullUrl}>

--- a/troposphere/static/js/components/images/detail/versions/VersionsView.react.js
+++ b/troposphere/static/js/components/images/detail/versions/VersionsView.react.js
@@ -2,6 +2,7 @@ define(function (require) {
 
   var React = require('react/addons'),
     Backbone = require('backbone'),
+    context = require('context'),
     stores = require('stores'),
     VersionList = require('./VersionList.react');
 
@@ -13,14 +14,19 @@ define(function (require) {
     },
     render: function () {
       var image = this.props.image,
-        versions = stores.ImageStore.getVersions(image.id);
+        versions = stores.ImageStore.getVersions(image.id),
+        showAvailableOn = !!(context.profile && context.profile.get('selected_identity'));
+
       if(!versions) {
           return (<div className="loading" />);
       }
       return (
         <div className="image-versions image-info-segment row">
           <h4 className="title col-md-2">Versions:</h4>
-          <VersionList image={image} versions={versions} editable={true}/>
+          <VersionList image={image}
+            versions={versions}
+            editable={true}
+            showAvailability={showAvailableOn} />
         </div>
       );
     }

--- a/troposphere/static/js/context.js
+++ b/troposphere/static/js/context.js
@@ -1,7 +1,7 @@
 define([], function () {
   return {
     hasLoggedInUser: function() {
-        return !!this.profile.get('username');
+        return !!(this.profile && this.profile.get('username'));
     },
     profile: null
   }

--- a/troposphere/static/js/context.js
+++ b/troposphere/static/js/context.js
@@ -1,7 +1,7 @@
 define([], function () {
   return {
     hasLoggedInUser: function() {
-        return !!(this.profile && this.profile.get('username'));
+        return !!(this.profile && this.profile.get('selected_identity'));
     },
     profile: null
   }

--- a/troposphere/static/js/context.js
+++ b/troposphere/static/js/context.js
@@ -1,5 +1,8 @@
 define([], function () {
   return {
+    hasLoggedInUser: function() {
+        return !!this.profile.get('username');
+    },
     profile: null
   }
 });

--- a/troposphere/static/js/stores/ImageVersionStore.js
+++ b/troposphere/static/js/stores/ImageVersionStore.js
@@ -29,9 +29,10 @@ define(function (require) {
         return _scripts;
     },
     getMachines: function(versionId) {
-        var _machines = stores.ProviderMachineStore.fetchWhere(
-            {version_id: versionId}
-        );
+        var _machines = stores.ProviderMachineStore ?
+            stores.ProviderMachineStore.fetchWhere(
+                {version_id: versionId}
+            ) : null;
 
         if(_machines == null) {
             return null;

--- a/troposphere/static/resources/js/cf2/router.js
+++ b/troposphere/static/resources/js/cf2/router.js
@@ -236,17 +236,9 @@ $(document).ready(function () {
 
     $('.beta-toggle').click(function (e) {
       e.preventDefault();
-      console.log('beta switch clicked');
+      console.log('user interface switch clicked');
 
-      var header = 'New UI Preview';
-      var body = "<p>We've been working hard to create an improved experience for Atmosphere. Check out the new features in the video below and try it out for yourself.  We'd love to hear what you think!</p>";
-      body += '<iframe width="560" height="315" src="https://www.youtube.com/embed/oasiNn-6mDw" frameborder="0" allowfullscreen></iframe>';
-      var ok_button = 'Take me to the new UI';
-      var on_confirm = function() {
-        window.location = '/application?beta=true';
-      };
-
-      Atmo.Utils.confirm(header, body, { ok_button: ok_button, on_confirm: on_confirm });
+      window.location = '/application?beta=true&airport_ui=false';
     });
   }
 });

--- a/troposphere/static/resources/js/cloudfront2.js
+++ b/troposphere/static/resources/js/cloudfront2.js
@@ -134,7 +134,7 @@ $(function() {
         $("#countdown_time").html(count);
         count--;
         if (count == 0)
-            window.location.replace(site_root + "/logout");
+            window.location.replace(site_root + "/logout?airport_ui=true");
       }, 1000);
 
 
@@ -142,12 +142,13 @@ $(function() {
             ok_button: "Log out of all iPlant services",
             on_confirm: function(){
                 var csrftoken = Atmo.Utils.getCookie('csrftoken');
-                Atmo.Utils.post_to_url(site_root + "/logout?cas=true", { cas: true, 'csrfmiddlewaretoken':csrftoken })
+                Atmo.Utils.post_to_url(site_root + "/logout?cas=true&airport_ui=true",
+                  { cas: true, 'csrfmiddlewaretoken':csrftoken })
             },
 
             cancel_button: "Log out of Atmosphere Only",
             on_cancel: function(){
-                window.location.replace(site_root + "/logout");
+                window.location.replace(site_root + "/logout?airport_ui=true");
             }
       });
 

--- a/troposphere/templates/cf2.html
+++ b/troposphere/templates/cf2.html
@@ -77,7 +77,7 @@
                     <a class="beta-toggle">
                       <div class="toggle-wrapper">
                         <div class="toggle-background">
-                          <div class="toggle-text">Preview New UI</div>
+                          <div class="toggle-text">View Current UI</div>
                         </div>
                         <div class="toggle-switch"></div>
                       </div>
@@ -129,7 +129,7 @@
                 <a target="_blank" href="http://ask.iplantcollaborative.org">User Help Forums</a>
                 <a target="_blank" href="https://pods.iplantcollaborative.org/wiki/x/UKxm">Get VNC Viewer</a>
                 <a target="_blank" href="#" id="contact_support">Support</a>
-                <a href="{{ BASE_URL }}/logout">Logout
+                <a href="{{ BASE_URL }}/logout?airport_ui=true">Logout
                     <div id="username"></div>
                 </a>
             </div>

--- a/troposphere/views/app.py
+++ b/troposphere/views/app.py
@@ -109,7 +109,6 @@ def _handle_public_application_request(request, maintenance_records, disabled_lo
     if "airport_ui" not in request.session:
         request.session['airport_ui'] = 'false'
         # the absence flag to show the airport_ui would be equal to 'false'
-
     show_airport = request.session['airport_ui'] == 'true'
 
     # Return the new Troposphere UI
@@ -138,8 +137,9 @@ def _handle_authenticated_application_request(request, maintenance_records):
     template_params, show_troposphere_only = _populate_template_params(request,
             maintenance_records, disabled_login=False, public=False)
 
-    user_preferences, created = UserPreferences.objects\
-        .get_or_create(user=request.user)
+    user_preferences, created = UserPreferences.objects.get_or_create(
+        user=request.user)
+
     prefs_modified = False
 
     # TODO - once phased out, we should ignore show_beta_interface altogether
@@ -222,7 +222,6 @@ def forbidden(request):
     user, but was found to be unauthorized to use Atmosphere by OAuth.
     Returns HTTP status code 403 Forbidden
     """
-
     # If banner message in query params, pass it into the template
     template_params = {}
 
@@ -241,6 +240,7 @@ def forbidden(request):
         context_instance=RequestContext(request)
     )
     return response
+
 
 def version(request):
     v = get_version()

--- a/troposphere/views/app.py
+++ b/troposphere/views/app.py
@@ -42,12 +42,25 @@ def _populate_template_params(request, maintenance_records, disabled_login, publ
         'emulator_token': request.session.get('emulator_token'),
         'emulated_by': request.session.get('emulated_by'),
         'records': maintenance_records,
-        'disable_login': disabled_login,
-        # for the template, consider public site as "show tropo only"
-        # but use settings value for determining template render...
-        'show_troposphere_only': True,
-        'show_public_site': True
+        'show_troposphere_only': show_troposphere_only,
+        'show_public_site': public
     }
+
+    show_instance_metrics = getattr(settings, "SHOW_INSTANCE_METRICS", False)
+
+    if public:
+        template_params['disable_login'] = disabled_login
+    else:
+        logger.info("public was false... ")
+        template_params['disable_login'] = False
+        template_params['show_instance_metrics'] = show_instance_metrics
+        # Only include Intercom information when rendering the authenticated
+        # version of the site.
+        if hasattr(settings, "INTERCOM_APP_ID"):
+            template_params['intercom_app_id'] = settings.INTERCOM_APP_ID
+            template_params['intercom_company_id'] = settings.INTERCOM_COMPANY_ID
+            template_params['intercom_company_name'] = settings.INTERCOM_COMPANY_NAME
+
     template_params['SITE_TITLE'] = settings.SITE_TITLE
     template_params['SITE_FOOTER'] = settings.SITE_FOOTER
     template_params['SUPPORT_EMAIL'] = settings.SUPPORT_EMAIL
@@ -68,24 +81,45 @@ def _populate_template_params(request, maintenance_records, disabled_login, publ
     if hasattr(settings, "API_V2_ROOT"):
         template_params['API_V2_ROOT'] = settings.API_V2_ROOT
 
-    # If beta flag in query params, set the session value to that
-    if "beta" in request.GET:
+    if hasattr(settings, "USE_GATE_ONE_API"):
+        template_params["USE_GATE_ONE_API"] = settings.USE_GATE_ONE_API
+        template_params["WEB_SH_URL"] = settings.WEB_SH_URL
+
+    return template_params, show_troposphere_only
+
+
+def _handle_public_application_request(request, maintenance_records, disabled_login=False):
+    """
+    Deal with unauthenticated requests:
+
+    - For troposphere, there is the opportunity to browser the Public Image Catalog.
+    - For airport, there is nothing to do but ask for people to `login.html`.
+    """
+    template_params, show_troposphere_only = _populate_template_params(request,
+            maintenance_records, disabled_login, True)
+
+    # If show airport_ui flag in query params, set the session value to that
+    if "airport_ui" in request.GET:
+        request.session['airport_ui'] = request.GET['airport_ui'].lower()
+
+    # only honor `?beta=false` from the query string...
+    if "beta" in request.GET and request.GET['beta'].lower() is 'false':
         request.session['beta'] = request.GET['beta'].lower()
 
-    # If beta flag not defined, default it to false to show the old UI
-    if "beta" not in request.session:
-        request.session['beta'] = 'false'
+    if "airport_ui" not in request.session:
+        request.session['airport_ui'] = 'false'
+        # the absence flag to show the airport_ui would be equal to 'false'
+
+    show_airport = request.session['airport_ui'] == 'true'
 
     # Return the new Troposphere UI
-    if request.session['beta'] == 'true' or show_troposphere_only:
+    if not show_airport or show_troposphere_only:
         response = render_to_response(
             'index.html',
             template_params,
             context_instance=RequestContext(request)
         )
-
-    # Return the old Airport UI
-    else:
+    else: # Return the old Airport UI
         response = render_to_response(
             'login.html',
             template_params,
@@ -93,79 +127,63 @@ def _populate_template_params(request, maintenance_records, disabled_login, publ
         )
 
     response.set_cookie('beta', request.session['beta'])
+    response.set_cookie('airport_ui', request.session['airport_ui'])
     return response
 
 
 def _handle_authenticated_application_request(request, maintenance_records):
-    show_troposphere_only = getattr(settings, "SHOW_TROPOSPHERE_ONLY", False)
-    show_instance_metrics = getattr(settings, "SHOW_INSTANCE_METRICS", False)
+    """
+    Deals with request verified identities via `iplantauth` module.
+    """
+    template_params, show_troposphere_only = _populate_template_params(request,
+            maintenance_records, disabled_login=False, public=False)
 
-    template_params = {
-        'access_token': request.session.get('access_token'),
-        'emulator_token': request.session.get('emulator_token'),
-        'emulated_by': request.session.get('emulated_by'),
-        'records': maintenance_records,
-        'show_troposphere_only': show_troposphere_only,
-        'show_instance_metrics': show_instance_metrics,
-        'disable_login': False,
-        'show_public_site': False
-    }
+    user_preferences, created = UserPreferences.objects\
+        .get_or_create(user=request.user)
+    prefs_modified = False
 
-    template_params['SITE_TITLE'] = settings.SITE_TITLE
-    template_params['SITE_FOOTER'] = settings.SITE_FOOTER
-    template_params['SUPPORT_EMAIL'] = settings.SUPPORT_EMAIL
-    template_params['UI_VERSION'] = settings.UI_VERSION
-    template_params['BADGE_HOST'] = getattr(settings, "BADGE_HOST", None)
-
-    if hasattr(settings, "INTERCOM_APP_ID"):
-        template_params['intercom_app_id'] = settings.INTERCOM_APP_ID
-        template_params['intercom_company_id'] = settings.INTERCOM_COMPANY_ID
-        template_params['intercom_company_name'] = settings.INTERCOM_COMPANY_NAME
-
-    #TODO: Replace this line when theme support is re-enabled.
-    #template_params["THEME_URL"] = "assets"
-    template_params["THEME_URL"] = "/themes/%s" % settings.THEME_NAME
-    template_params['ORG_NAME'] = settings.ORG_NAME
-    if hasattr(settings, "BASE_URL"):
-        template_params['BASE_URL'] = settings.BASE_URL
-
-    if hasattr(settings, "API_ROOT"):
-        template_params['API_ROOT'] = settings.API_ROOT
-
-    if hasattr(settings, "API_V2_ROOT"):
-        template_params['API_V2_ROOT'] = settings.API_V2_ROOT
-
-    if hasattr(settings, "USE_GATE_ONE_API"):
-        template_params["USE_GATE_ONE_API"] = settings.USE_GATE_ONE_API
-        template_params["WEB_SH_URL"] = settings.WEB_SH_URL
-
-    user_preferences, created = UserPreferences.objects.get_or_create(user=request.user)
-
+    # TODO - once phased out, we should ignore show_beta_interface altogether
+    # ----
     # If beta flag in query params, set the session value to that
     if "beta" in request.GET:
+        prefs_modified = True
         request.session['beta'] = request.GET['beta'].lower()
-        show_beta_interface = True if request.session['beta'] == 'true' else False
-        user_preferences.show_beta_interface = show_beta_interface
-        user_preferences.save()
-        return redirect('application')
+        user_preferences.show_beta_interface = (
+            request.session['beta'] is 'true')
 
-    # Return the new Troposphere UI
-    if user_preferences.show_beta_interface or show_troposphere_only:
+    # Moving forward, the UI version shown will be controlled by
+    # `airport_ui=<bool>` - and `beta` will be removed.
+    if "airport_ui" in request.GET:
+        prefs_modified = True
+        request.session['airport_ui'] = request.GET['airport_ui'].lower()
+        user_preferences.airport_ui = (
+            request.session['airport_ui'] is 'true')
+
+    if prefs_modified and not is_emulated_session(request):
+        user_preferences.save()
+
+    chose_airport = (user_preferences.airport_ui or
+        not user_preferences.show_beta_interface)
+
+    # show airport-ui if it's true and we are showing the option
+    # of switching UIs
+    # ----------
+    # Return the old Airport UI
+    if chose_airport and not show_troposphere_only:
+        response = render_to_response(
+            'cf2.html',
+            template_params,
+            context_instance=RequestContext(request)
+        )
+    else: # Return the new Troposphere UI
         response = render_to_response(
             'index.html',
             template_params,
             context_instance=RequestContext(request)
         )
 
-    # Return the old Airport UI
-    else:
-        response = render_to_response(
-            'cf2.html',
-            template_params,
-            context_instance=RequestContext(request)
-        )
-
     return response
+
 
 def application_backdoor(request):
     response = HttpResponse()

--- a/troposphere/views/app.py
+++ b/troposphere/views/app.py
@@ -222,7 +222,7 @@ def forbidden(request):
     user, but was found to be unauthorized to use Atmosphere by OAuth.
     Returns HTTP status code 403 Forbidden
     """
-    
+
     # If banner message in query params, pass it into the template
     template_params = {}
 
@@ -231,7 +231,7 @@ def forbidden(request):
     template_params['SITE_TITLE'] = settings.SITE_TITLE
     template_params['SITE_FOOTER'] = settings.SITE_FOOTER
     if hasattr(settings, "BASE_URL"):
-        template_params['BASE_URL'] = settings.BASE_URL 
+        template_params['BASE_URL'] = settings.BASE_URL
 
     if "banner" in request.GET:
         template_params['banner'] = request.GET['banner']

--- a/troposphere/views/app.py
+++ b/troposphere/views/app.py
@@ -6,11 +6,12 @@ from django.http import HttpResponse
 from django.shortcuts import render, redirect, render_to_response
 from django.template import RequestContext
 
-from troposphere.version import get_version
 from api.models import UserPreferences, MaintenanceRecord
+from troposphere.version import get_version
+from .emulation import is_emulated_session
+from .maintenance import get_maintenance
 
 logger = logging.getLogger(__name__)
-from .maintenance import get_maintenance
 
 def root(request):
     return redirect('application')

--- a/troposphere/views/app.py
+++ b/troposphere/views/app.py
@@ -13,14 +13,29 @@ from .maintenance import get_maintenance
 
 logger = logging.getLogger(__name__)
 
-def root(request):
-    return redirect('application')
+
 #TODO: Move this into a settings file.
 STAFF_LIST_USERNAMES = ['estevetest01', 'estevetest02','estevetest03','estevetest04',
                         'estevetest13', 'sgregory', 'lenards', 'tharon', 'cdosborn']
 
-def _handle_public_application_request(request, maintenance_records, disabled_login=False):
-    show_troposphere_only = hasattr(settings, "SHOW_TROPOSPHERE_ONLY") and settings.SHOW_TROPOSPHERE_ONLY is True
+
+def root(request):
+    return redirect('application')
+
+
+def _should_show_troposphere_only():
+    # `SHOW_TROPOSPHERE_ONLY` may not be present in `settings`, so use
+    # `hasattr` to handle when it is not present & avoid 500 errors on load.
+    return hasattr(settings, "SHOW_TROPOSPHERE_ONLY") and settings.SHOW_TROPOSPHERE_ONLY is True
+
+
+def _populate_template_params(request, maintenance_records, disabled_login, public=False):
+    """
+    Creates a dict of parameters for later template merge given the arguments,
+    request session, and django settings (defined in `default.py` or overidden
+    in `local.py`).
+    """
+    show_troposphere_only = _should_show_troposphere_only()
 
     template_params = {
         'access_token': request.session.get('access_token'),

--- a/troposphere/views/emulation.py
+++ b/troposphere/views/emulation.py
@@ -1,10 +1,10 @@
 import logging
 import os
 
+import requests
+
 from django.conf import settings
 from django.shortcuts import redirect
-
-import requests
 
 from caslib import OAuthClient as CAS_OAuthClient
 

--- a/troposphere/views/emulation.py
+++ b/troposphere/views/emulation.py
@@ -16,6 +16,13 @@ cas_oauth_client = CAS_OAuthClient(settings.CAS_SERVER,
                                    settings.OAUTH_CLIENT_SECRET,
                                    auth_prefix=settings.CAS_AUTH_PREFIX)
 
+def is_emulated_session(request):
+    """
+    Indicates if the session being handled is someone _emulating_
+    another user/identity within the system.
+    """
+    return 'emulator_token' in request.session
+
 
 def emulate(request, username):
     if 'access_token' not in request.session:


### PR DESCRIPTION
This makes it so any unauthenticated visitor will land on the "Public Image Catalog" for a cloud: 

![screen shot 2016-02-18 at 7 48 34 am](https://cloud.githubusercontent.com/assets/5923/13146665/0e534b36-d614-11e5-9c85-af59c1f757d7.png)

This relates to #247. Notably, it brings in a refactored/reworked version `troposphere/views/app.py` for handling requests, query string arguments, and associated response cookies. 

See JIRA tickets: [ATMO-1020](https://pods.iplantcollaborative.org/jira/browse/ATMO-1020), [ATMO-1021](https://pods.iplantcollaborative.org/jira/browse/ATMO-1021), [ATMO-1016](https://pods.iplantcollaborative.org/jira/browse/ATMO-1016), [ATMO-400](https://pods.iplantcollaborative.org/jira/browse/ATMO-400)