### PR TITLE
Include `error` as final state when determining percent complete for instance state

### DIFF
--- a/troposphere/static/js/models/InstanceState.js
+++ b/troposphere/static/js/models/InstanceState.js
@@ -58,10 +58,8 @@ var InstanceState = Backbone.Model.extend({
 });
 
 var get_percent_complete = function (state, activity) {
-  activity = activity || '*';
-
-  // Number represents percent task *completed* when in this state
-  var states = {
+  var lookup,
+    states = { // Number represents percent task *completed* when in this state
     'build': {
       'block_device_mapping': 10,
       'scheduling': 20,
@@ -90,13 +88,21 @@ var get_percent_complete = function (state, activity) {
     'suspended': {
       'resuming': 50
     },
-    'error': {
-      '*': 10
-    }
+    'error': {}
   };
 
+  lookup = states[state];
+
+  if(!lookup) {
+    lookup = {};
+    console.error("Unknown state (%s) representation passed", state);
+  }
+  if(state === 'error') {
+    console.log("Error state processed: activity = %s", activity);
+  }
+
   // Note: 100 is graphically similar to 0
-  return states[state][activity] || 100;
+  return lookup[activity] || 100;
 };
 
 var get_final_state = function (activity) {

--- a/troposphere/static/js/models/InstanceState.js
+++ b/troposphere/static/js/models/InstanceState.js
@@ -58,6 +58,7 @@ var InstanceState = Backbone.Model.extend({
 });
 
 var get_percent_complete = function (state, activity) {
+  activity = activity || '*';
 
   // Number represents percent task *completed* when in this state
   var states = {
@@ -88,6 +89,9 @@ var get_percent_complete = function (state, activity) {
     },
     'suspended': {
       'resuming': 50
+    },
+    'error': {
+      '*': 10
     }
   };
 


### PR DESCRIPTION
According to [InstanceState](https://github.com/iPlantCollaborativeOpenSource/troposphere/blob/master/troposphere/static/js/models/InstanceState.js), `'error'` is contained in the valid [final states](https://github.com/iPlantCollaborativeOpenSource/troposphere/blob/master/troposphere/static/js/models/InstanceState.js#L9-L16). However, when determine the percentage complete, `'error'` is not handled as a possibility: 

```javascript
var get_percent_complete = function (state, activity) {

  // Number represents percent task *completed* when in this state
  var states = {
    'build': { /* ... */ },
    'active': { /* ... */ },
    'hard_reboot': { /* ... */ },
    'reboot': { /* ... */ },
    'shutoff': { /* ... */ },
    'suspended': { /* ... */ },
  };

 // note - no `'error'` state above...
 // 
 // ... no case for when `states[state]` is undefined
 return states[state][activity] || 100;
};
```
source: [troposphere/static/js/models/InstanceState.js](https://github.com/iPlantCollaborativeOpenSource/troposphere/blob/master/troposphere/static/js/models/InstanceState.js#L60-L96)

This cause an _Uncaught TypeError_ which leads to the entire instance detail view appearing _blank_ because of failures to error. 

This PR should be _considered_ a *patch* to prevent the chain of failures in the components rendered for instance detail view. 

In testing instances that I forced into "error" as a state, the deletion completed as expect. 

See: [ATMO-1187](https://pods.iplantcollaborative.org/jira/browse/ATMO-1187)