### PR TITLE
Extend backbone with functions which return collections

### DIFF
--- a/troposphere/static/js/bootstrapper.js
+++ b/troposphere/static/js/bootstrapper.js
@@ -7,6 +7,7 @@ define(function (require) {
     React = require('react/addons'),
     SplashScreen = require('components/SplashScreen.react'),
     MaintenanceScreen = require('components/MaintenanceScreen.react'),
+    FunctionalCollection = require('collections/FunctionalCollection'),
     modernizr = require('lib/modernizr-latest.js');
 
   // Disconnect all Backbone Events from Models and Collections
@@ -29,6 +30,9 @@ define(function (require) {
       //return model.id == String(obj) || model.id === String(obj.id) || model.cid === obj.cid;
     });
   };
+
+  // Extend the base collection to include useful functions
+  Backbone.Collection = Backbone.Collection.extend(FunctionalCollection);
 
   // Register which stores the image should use
   var stores = require('stores');

--- a/troposphere/static/js/collections/FunctionalCollection.js
+++ b/troposphere/static/js/collections/FunctionalCollection.js
@@ -1,0 +1,23 @@
+import 'backbone';
+
+// Decorate any collection function, so that it returns a collection rather
+// than an array
+var fix = function(f) {
+    return function(...args) {
+        return new this.constructor(f.apply(this, args));
+    }
+}
+
+// Export variants of common functions, to operate on and return collections
+// For example:
+//    var c = new Collection();
+//    c.cmap(add1)
+//     .cfilter(greaterThan1)
+//     ...
+export default {
+    cmap: fix(new Backbone.Collection().map),
+    cfilter: fix(new Backbone.Collection().filter),
+    csome: fix(new Backbone.Collection().some),
+    cwhere: fix(new Backbone.Collection().where),
+    csort: fix(new Backbone.Collection().sort),
+}


### PR DESCRIPTION
In FunctionalCollection are a list of functions such as cmap, cfilter which
correspond to map, filter. It is now possible to chain these transformations
on a collection **without** wrapping the returned arrays with new Collection(..)
etc.

    c.cmap(add1)
     .cfilter(greaterThan1)
     .csome(...)
     ....