### PR TITLE
Featured Tab for Instance Launch ATMO-1213

### DIFF
--- a/troposphere/static/css/app/TabLinks.scss
+++ b/troposphere/static/css/app/TabLinks.scss
@@ -6,10 +6,11 @@
 
     .TabLinks-link {
         display: inline-block;
+        margin-right: 20px;
         a {
             display: block;
             color: $grey--mid;
-            padding: 10px 20px;
+            padding: 10px 0;
             border-bottom: solid 5px transparent;
             &:hover {
                 color: black;

--- a/troposphere/static/css/app/TabLinks.scss
+++ b/troposphere/static/css/app/TabLinks.scss
@@ -1,0 +1,23 @@
+.TabLinks {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 20px;
+    border-bottom: 1px solid $grey--lightmid;
+
+    .TabLinks-link {
+        display: inline-block;
+        a {
+            display: block;
+            color: $grey--mid;
+            padding: 10px 20px;
+            border-bottom: solid 5px transparent;
+            &:hover {
+                color: black;
+            }
+        }
+        a.TabLinks--active {
+            color: black;
+            border-bottom: solid 5px $brand-primary;
+        }
+    }
+}

--- a/troposphere/static/css/app/app.scss
+++ b/troposphere/static/css/app/app.scss
@@ -94,6 +94,7 @@ $icon-font-path: "~bootstrap-sass/assets/fonts/bootstrap/";
 @import "badges";
 @import "images";
 @import "media-cards";
+@import "TabLinks";
 @import "tags";
 
 // Primary - header

--- a/troposphere/static/js/components/common/ui/TabLinks.react.js
+++ b/troposphere/static/js/components/common/ui/TabLinks.react.js
@@ -1,10 +1,33 @@
 import React from 'react';
 
 export default React.createClass({
+    getInitialState: function() {
+        let active = this.props.linkList[0];
+        return ({
+            active
+        })
+    },
+
+    onChangeView: function(item) {
+        this.setState({
+            active: item
+        })
+        this.props.onChangeView(item);
+    },
+
     renderLinks: function(item) {
+        let active = "";
+        if (item === this.state.active) {
+            active = "TabLinks--active";
+        }
+
         return (
             <li className="TabLinks-link">
-                <a className="TabLinks--active">{item}</a>
+                <a className={active}
+                    onClick={this.onChangeView.bind(this, item)}
+                >
+                    {item}
+                </a>
             </li>
         )
     },

--- a/troposphere/static/js/components/common/ui/TabLinks.react.js
+++ b/troposphere/static/js/components/common/ui/TabLinks.react.js
@@ -1,0 +1,19 @@
+import React from 'react';
+
+export default React.createClass({
+    renderLinks: function(item) {
+        return (
+            <li className="TabLinks-link">
+                <a className="TabLinks--active">{item}</a>
+            </li>
+        )
+    },
+
+    render: function() {
+        return (
+            <ul className="TabLinks clearFix">
+                {this.props.linkList.map(this.renderLinks)}
+            </ul>
+        )
+    }
+});

--- a/troposphere/static/js/components/common/ui/TabLinks.react.js
+++ b/troposphere/static/js/components/common/ui/TabLinks.react.js
@@ -1,28 +1,26 @@
 import React from 'react';
 
 export default React.createClass({
-    getInitialState: function() {
-        let active = this.props.linkList[0];
-        return ({
-            active
-        })
+    displayName: "TabLinks",
+
+    propTypes: {
+        currentView: React.PropTypes.string.isRequired,
+        linkList: React.PropTypes.array.isRequired,
+        onChangeView: React.PropTypes.func.isRequired
     },
 
     onChangeView: function(item) {
-        this.setState({
-            active: item
-        })
         this.props.onChangeView(item);
     },
 
-    renderLinks: function(item) {
+    renderLinks: function(item, i) {
         let active = "";
-        if (item === this.state.active) {
+        if (item === this.props.currentView) {
             active = "TabLinks--active";
         }
 
         return (
-            <li className="TabLinks-link">
+            <li key={i} className="TabLinks-link">
                 <a className={active}
                     onClick={this.onChangeView.bind(this, item)}
                 >

--- a/troposphere/static/js/components/modals/instance/launch/steps/ImageSelectStep.react.js
+++ b/troposphere/static/js/components/modals/instance/launch/steps/ImageSelectStep.react.js
@@ -62,7 +62,6 @@ export default React.createClass({
 
     showAll: function() {
         let query = this.state.query;
-        let allImages = stores.ImageStore.getAll();
         let images = stores.ImageStore.getAll();
         if (query) {
             images = stores.ImageStore.fetchWhere({

--- a/troposphere/static/js/components/modals/instance/launch/steps/ImageSelectStep.react.js
+++ b/troposphere/static/js/components/modals/instance/launch/steps/ImageSelectStep.react.js
@@ -114,20 +114,14 @@ export default React.createClass({
     renderFilterDescription: function (images) {
         let message;
         let query = this.state.query;
+        let queryText = "";
+        if (query) { queryText = `for "${query}"` }
         if (images) {
-            if (query) {
-                if (images.length >= 20) {
-                    message = `Showing first ${images.length} images for "${query}"`;
-                }
-                else {
-                    message = `Showing ${images.length} image(s) for "${query}"`; 
-                }
-            }
-            else if (images.length >= 20) {
-                message = `Showing first ${images.length} images`;
+            if (images.length >= 20) {
+                message = `Showing first ${images.length} images ${queryText}`;
             }
             else {
-                message = `Showing ${images.length} image(s)`;
+                message = `Showing ${images.length} image(s) ${queryText}`;
             }
         }
 

--- a/troposphere/static/js/components/modals/instance/launch/steps/ImageSelectStep.react.js
+++ b/troposphere/static/js/components/modals/instance/launch/steps/ImageSelectStep.react.js
@@ -1,10 +1,12 @@
 import React from 'react/addons';
 import Backbone from 'backbone';
 import _ from 'underscore';
+import stores from 'stores';
+
+import TabLinks from 'components/common/ui/TabLinks.react';
 import ImageCollection from 'collections/ImageCollection';
 import ImageList from '../components/ImageList.react';
 import InstanceLaunchFooter from '../components/InstanceLaunchFooter.react';
-import stores from 'stores';
 
 export default React.createClass({
     displayName: "InstanceLaunchWizardModal-ImageSelectStep",
@@ -95,12 +97,14 @@ export default React.createClass({
     renderImages: function (images, allImages) {
         let totalNumberOfImages = allImages.length,
             query = this.state.query;
+        if (!images) { return ( <div className="loading"/> ) }
 
         return (
         <div>
             {this.renderSearchInput()}
             {this.renderFilterDescription()}
-            <ImageList images={images}
+            <ImageList
+                images={images}
                 onSelectImage={this.props.onSelectImage}
             >
             {this.renderMoreImagesButton(images, totalNumberOfImages)}
@@ -162,6 +166,9 @@ export default React.createClass({
                 <div className="modal-section">
                     <h3 className="t-title">First choose an image for your instance</h3>
                     <hr/>
+                    <TabLinks 
+                        linkList={['View Featured', 'View All']}
+                    />
                     {this.renderBody()}
                 </div>
                 <InstanceLaunchFooter

--- a/troposphere/static/js/components/modals/instance/launch/steps/ImageSelectStep.react.js
+++ b/troposphere/static/js/components/modals/instance/launch/steps/ImageSelectStep.react.js
@@ -126,18 +126,26 @@ export default React.createClass({
         }
     },
 
-    renderFilterDescription: function () {
-        let message,
-            query = this.state.query;
-        if (this.imageList().images) {
+    renderFilterDescription: function (images) {
+        let message;
+        let query = this.state.query;
+        if (images) {
             if (query) {
-                message = 'Showing results for "' + query + '"';
-            } else if (this.imageList().images.length >= 20) {
-                message = "Showing first 20 images";
-            } else {
-                message = `Showing ${this.imageList().images.length} images`;
+                if (images.length >= 20) {
+                    message = `Showing first ${images.length} images for "${query}"`;
                 }
+                else {
+                    message = `Showing ${images.length} image(s) for "${query}"`; 
+                }
+            }
+            else if (images.length >= 20) {
+                message = `Showing first ${images.length} images`;
+            }
+            else {
+                message = `Showing ${images.length} image(s)`;
+            }
         }
+
         return (
             <div className="filter-description">{message}</div>
         );
@@ -189,7 +197,7 @@ export default React.createClass({
         return (
         <div>
             {searchInput}
-            {this.renderFilterDescription()}
+            {this.renderFilterDescription(images)}
             <ImageList
                 images={images}
                 onSelectImage={this.props.onSelectImage}

--- a/troposphere/static/js/components/modals/instance/launch/steps/ImageSelectStep.react.js
+++ b/troposphere/static/js/components/modals/instance/launch/steps/ImageSelectStep.react.js
@@ -47,9 +47,17 @@ export default React.createClass({
     },
 
     onChangeView: function(listView) {
+        // This is poor, will not be needed when search is also on Favorites
+        if (listView === "Show Favorites") {
+            this.setState({
+                listView,
+                query: ""
+            })
+            return
+        }
         this.setState({
             listView
-        })
+        });
     },
 
     showAll: function() {

--- a/troposphere/static/js/components/modals/instance/launch/steps/ImageSelectStep.react.js
+++ b/troposphere/static/js/components/modals/instance/launch/steps/ImageSelectStep.react.js
@@ -10,9 +10,11 @@ import InstanceLaunchFooter from '../components/InstanceLaunchFooter.react';
 
 export default React.createClass({
     displayName: "InstanceLaunchWizardModal-ImageSelectStep",
+    views: ['View Featured', 'View All'],
 
     getInitialState: function () {
         return {
+            view: this.views[0],
             query: null,
             resultsPerPage: 20,
             page: 1
@@ -40,6 +42,24 @@ export default React.createClass({
 
     handleLoadMoreImages: function() {
         this.setState({page: this.state.page + 1})
+    },
+
+    onChangeView: function(view) {
+        this.setState({
+            view
+        })
+    },
+
+    images: function() {
+        let view = this.state.view;
+        switch(view) {
+            case 'View All':
+            return  stores.ImageStore.getAll()
+            case 'View Featured':
+            return stores.ImageStore.fetchWhere({
+                tags__name: 'Featured'
+            });
+        }
     },
 
     renderFilterDescription: function () {
@@ -129,10 +149,12 @@ export default React.createClass({
         </div>
         );
     },
+
     renderBody: function () {
 
-        let allImages = stores.ImageStore.getAll(),
-            images,
+        let allImages = this.images(),
+            // This list is the same now but will be filltered
+            images = this.images(),
             tags = stores.TagStore.getAll(),
             query = this.state.query,
             numberOfResults,
@@ -167,7 +189,8 @@ export default React.createClass({
                     <h3 className="t-title">First choose an image for your instance</h3>
                     <hr/>
                     <TabLinks 
-                        linkList={['View Featured', 'View All']}
+                        linkList={this.views}
+                        onChangeView={this.onChangeView}
                     />
                     {this.renderBody()}
                 </div>

--- a/troposphere/static/js/components/modals/instance/launch/steps/ImageSelectStep.react.js
+++ b/troposphere/static/js/components/modals/instance/launch/steps/ImageSelectStep.react.js
@@ -47,14 +47,6 @@ export default React.createClass({
     },
 
     onChangeView: function(listView) {
-        // This is poor, will not be needed when search is also on Favorites
-        if (listView === "Show Favorites") {
-            this.setState({
-                listView,
-                query: ""
-            })
-            return
-        }
         this.setState({
             listView
         });

--- a/troposphere/static/js/components/modals/instance/launch/steps/ImageSelectStep.react.js
+++ b/troposphere/static/js/components/modals/instance/launch/steps/ImageSelectStep.react.js
@@ -68,53 +68,39 @@ export default React.createClass({
             images = stores.ImageStore.fetchWhere({
                 search: query
             });
-        } else {
-            images = allImages;
         }
-        return {
-            images,
-            allImages
-        }
+
+        return images
     },
 
     showFeatured: function() {
         let query = this.state.query;
-        let allImages = stores.ImageStore.fetchWhere({
+        let images = stores.ImageStore.fetchWhere({
             tags__name: 'Featured'
         });
-        let images = stores.ImageStore.getAll();
         if (query) {
             images = stores.ImageStore.fetchWhere({
                 tags__name: 'Featured',
                 search: query
             });
-        } else {
-            images = allImages;
         }
-        return {
-            images,
-            allImages
-        }
+
+        return images
     },
 
     showFavorites: function() {
         let query = this.state.query;
-        let allImages = stores.ImageStore.fetchWhere({
+        let images = stores.ImageStore.fetchWhere({
             bookmarked: true
         });
-        let images = stores.ImageStore.getAll();
         if (query) {
             images = stores.ImageStore.fetchWhere({
                 bookmarked: true,
                 search: query
             });
-        } else {
-            images = allImages;
         }
-        return {
-            images,
-            allImages
-        }
+
+        return images
     },
 
     imageList: function() {
@@ -161,7 +147,7 @@ export default React.createClass({
     },
 
     renderMoreImagesButton: function (images, totalNumberOfImages) {
-        if (images.models.length < totalNumberOfImages) {
+        if (images.length < totalNumberOfImages) {
             return (
                 <li>
                     <button style={{
@@ -174,6 +160,7 @@ export default React.createClass({
             );
         }
     },
+
     focusSearchInput: function () {
         this.refs.searchField.getDOMNode().focus();
     },
@@ -226,8 +213,9 @@ export default React.createClass({
     },
 
     renderBody: function () {
-        let allImages = this.imageList().allImages,
-            images = this.imageList().images,
+        let allImages = this.imageList(),
+            // This might get paginated below
+            images = this.imageList(),
             tags = stores.TagStore.getAll(),
             query = this.state.query,
             numberOfResults,

--- a/troposphere/static/js/components/modals/instance/launch/steps/ImageSelectStep.react.js
+++ b/troposphere/static/js/components/modals/instance/launch/steps/ImageSelectStep.react.js
@@ -98,8 +98,19 @@ export default React.createClass({
     },
 
     showFavorites: function() {
-        let images = stores.ImageBookmarkStore.getBookmarkedImages();
-        let allImages = images;
+        let query = this.state.query;
+        let allImages = stores.ImageStore.fetchWhere({
+            bookmarked: true
+        });
+        let images = stores.ImageStore.getAll();
+        if (query) {
+            images = stores.ImageStore.fetchWhere({
+                bookmarked: true,
+                search: query
+            });
+        } else {
+            images = allImages;
+        }
         return {
             images,
             allImages
@@ -173,9 +184,6 @@ export default React.createClass({
         let totalNumberOfImages = allImages.length;
         let query = this.state.query;
         let searchInput = this.renderSearchInput();
-        if (this.state.listView === "Show Favorites") {
-            searchInput = null;
-        }
         if (!images) { return ( <div className="loading"/> ) }
         
         return (
@@ -240,6 +248,7 @@ export default React.createClass({
                     <hr/>
                     <TabLinks 
                         linkList={this.views}
+                        currentView={this.state.listView}
                         onChangeView={this.onChangeView}
                     />
                     {this.renderBody()}


### PR DESCRIPTION
# Tabbed List Views for New Instance Launch Modal
**_(Edit: Ready for review)_**

This adds a set of Tabs to the top of the Select Image Step as part of the new Instance Launch Modal.  The tabs will filter the Images list to their respective category. 

**Tabs created:**
- Show Featured
- Show Favorited 
- Show All

**Reusable components created:**
- TabLinks.react (Renders a set of tabs representing items in a list passed as a prop)
- TabLinks.scss (The CSS used by TabLinks.react)

## Note on CSS Naming
For the CSS in this PR I decided to switch to the [SUIT CSS](https://github.com/suitcss/suit/blob/master/doc/naming-conventions.md) naming convention. I realize I had started using [BEM CSS](https://en.bem.info/method/naming-convention/) in previous PR's and that this is confusing, but I feel strongly that this is the correct convention to use in our case. I can explain my reasoning off this thread. 

My intention is that all of our css should be updated to SUIT starting with the BEM recently written because BEM is structurally identical. 

## TODO:

- [x] Add search-ability to favorites. (Currently I don't think we have a method unless done client side)

## Screen Shot
![tabbed-image-select](https://cloud.githubusercontent.com/assets/7366338/13508667/2f0eed9e-e145-11e5-9831-53ff2f3c5524.gif)

