### PR TITLE
Fix Bootstrap being extended at wrong time

### DIFF
--- a/troposphere/static/js/bootstrapper.js
+++ b/troposphere/static/js/bootstrapper.js
@@ -32,7 +32,7 @@ define(function (require) {
   };
 
   // Extend the base collection to include useful functions
-  Backbone.Collection = Backbone.Collection.extend(FunctionalCollection);
+  _.extend(Backbone.Collection.prototype, FunctionalCollection);
 
   // Register which stores the image should use
   var stores = require('stores');


### PR DESCRIPTION
This fixes the issue where Collections lacked the cmap,cfilter,etc extensions.

Setting a Backbone.Collection to a new reference does not affect collections
whose prototype references the old Backbone.Collection, before being extended
with said functions.