### PR TITLE
Add ID's to buttons for QA

### DIFF
--- a/troposphere/static/js/components/common/ProjectCreateView.react.js
+++ b/troposphere/static/js/components/common/ProjectCreateView.react.js
@@ -105,6 +105,7 @@ export default React.createClass({
                 {this.renderBody()}
                 <div className="modal-footer">
                     <button
+                        id="cancelCreateProject"
                         type="button"
                         className="btn btn-default"
                         onClick={this.props.cancel}
@@ -112,6 +113,7 @@ export default React.createClass({
                         Cancel
                     </button>
                     <button
+                        id="submitCreateProject"
                         type="button"
                         className="btn btn-primary"
                         onClick={this.confirm}


### PR DESCRIPTION
QA lost it's selector when the cancel button class was changed from `btn-danger` to `btn-default` unique ID's were provided as better selectors.