### PR TITLE
[Atmo-1241] Disable Images without versions in the Launch Modal

### DIFF
--- a/troposphere/static/css/app/media-cards.scss
+++ b/troposphere/static/css/app/media-cards.scss
@@ -36,6 +36,11 @@
     }
 }
 
+.media.disabled {
+    opacity:.3;
+    cursor: no-drop !important;
+}
+
 // The card class is used on the same wrapper as the media class
 // it can be reused without the media class.
 .card {

--- a/troposphere/static/css/app/media-cards.scss
+++ b/troposphere/static/css/app/media-cards.scss
@@ -10,6 +10,11 @@
     _overflow:visible;
     zoom:1;
 
+    .media--disabled {
+        opacity:.4;
+        cursor: no-drop !important;
+    }
+
     //wraps around all of the content next to the optional image anchor
     .media__content {
         overflow: hidden;
@@ -36,10 +41,6 @@
     }
 }
 
-.media.disabled {
-    opacity:.3;
-    cursor: no-drop !important;
-}
 
 // The card class is used on the same wrapper as the media class
 // it can be reused without the media class.

--- a/troposphere/static/js/components/modals/instance/launch/components/Image.react.js
+++ b/troposphere/static/js/components/modals/instance/launch/components/Image.react.js
@@ -66,8 +66,7 @@ define(
         let inactiveClass = !this.state.active ? "disabled" : "";
 
         return (
-            <li onClick={this.handleClick}>
-                <div className={`media card ${inactiveClass}`}>
+            <li className={`media card ${inactiveClass}`} onClick={this.handleClick}>
                     <div className="media__img">
                         {icon}
                     </div>
@@ -86,7 +85,6 @@ define(
                             </div>
                         </div>
                     </div>
-                </div>
             </li>
         )
       }

--- a/troposphere/static/js/components/modals/instance/launch/components/Image.react.js
+++ b/troposphere/static/js/components/modals/instance/launch/components/Image.react.js
@@ -32,7 +32,9 @@ export default React.createClass({
     handleClick: function () {
     if (this.state.active) {
         this.props.onSelectImage(this.props.image);
+        return;
     }
+    this.setState({ showAlert: true });
     },
 
     renderTags: function () {

--- a/troposphere/static/js/components/modals/instance/launch/components/Image.react.js
+++ b/troposphere/static/js/components/modals/instance/launch/components/Image.react.js
@@ -57,11 +57,45 @@ export default React.createClass({
     icon = (
         <Gravatar hash={image.get('uuid_hash')} size={iconSize} type={type}/>
     );
+    let inactiveClass = "";
+    let alertMessage = () => null;
 
-    let inactiveClass = !this.state.active ? "disabled" : "";
-
+    if (!this.state.active) {
+        inactiveClass = "media--disabled";
+        if (this.state.showAlert) {
+            alertMessage = () => {
+                return (
+                    <div
+                        style={{
+                                position: "absolute",
+                                display: "inline-block",
+                                width: "250px",
+                                top: "25%", 
+                                right: "0",
+                                left: "0",
+                                margin: "auto",
+                                padding: "5px 10px",
+                                background: "#F15757",
+                                boxShadow: "0 1px 2px rgba(0,0,0,.4)",
+                                color: "white",
+                                textAlign: "center",
+                                cursor: "no-drop !important"
+                            }}
+                        >
+                        <i className="glyphicon glyphicon-exclamation-sign"/>
+                        {" Image Disabled - No Versions"}
+                    </div>
+                )
+            }
+        }
+    }
     return (
-        <li className={`media card ${inactiveClass}`} onClick={this.handleClick}>
+        <li 
+            style={{position: "relative" }} 
+            className="media card"
+            onClick={this.handleClick}
+            >
+            <div className={`clearfix ${inactiveClass}`}>
                 <div className="media__img">
                     {icon}
                 </div>
@@ -80,6 +114,8 @@ export default React.createClass({
                         </div>
                     </div>
                 </div>
+            </div>
+            {alertMessage()}
         </li>
     )
     }

--- a/troposphere/static/js/components/modals/instance/launch/components/Image.react.js
+++ b/troposphere/static/js/components/modals/instance/launch/components/Image.react.js
@@ -25,101 +25,101 @@ export default React.createClass({
     },
 
     propTypes: {
-    image: React.PropTypes.instanceOf(Backbone.Model).isRequired,
-    onClick: React.PropTypes.func
+        image: React.PropTypes.instanceOf(Backbone.Model).isRequired,
+        onClick: React.PropTypes.func
     },
 
     handleClick: function () {
-    if (this.state.active) {
-        this.props.onSelectImage(this.props.image);
-        return;
-    }
-    this.setState({ showAlert: true });
+        if (this.state.active) {
+            this.props.onSelectImage(this.props.image);
+            return;
+        }
+        this.setState({ showAlert: true });
     },
 
     renderTags: function () {
-    var tags = stores.TagStore.getAll();
-    var activeTags = stores.TagStore.getImageTags(this.props.image);
+        let tags = stores.TagStore.getAll();
+        let activeTags = stores.TagStore.getImageTags(this.props.image);
 
-    return (
-        <Tags tags={tags} activeTags={activeTags} renderLinks={false}/>
-    );
+        return (
+            <Tags tags={tags} activeTags={activeTags} renderLinks={false}/>
+        );
     },
 
     render: function () {
-    var image = this.props.image,
-        type = stores.ProfileStore.get().get('icon_set'),
-        imageCreationDate = moment(image.get('start_date')).format("MMM D, YYYY hh:mm a"),
-        iconSize = 67,
-        icon;
-    let fullDescription = image.get('description');
-    let renderDescription = fullDescription.length < 150 ? fullDescription : (fullDescription.substring(0,150) + " ...");
+        let image = this.props.image;
+        let type = stores.ProfileStore.get().get('icon_set');
+        let imageCreationDate = moment(image.get('start_date')).format("MMM D, YYYY hh:mm a");
+        let iconSize = 67;
+        let icon;
+        let fullDescription = image.get('description');
+        let renderDescription = fullDescription.length < 150 ? fullDescription : (fullDescription.substring(0,150) + " ...");
+        let inactiveClass = "";
+        let alertMessage = () => null;
 
-    // always use the Gravatar icons
-    icon = (
-        <Gravatar hash={image.get('uuid_hash')} size={iconSize} type={type}/>
-    );
-    let inactiveClass = "";
-    let alertMessage = () => null;
+        // always use the Gravatar icons
+        icon = (
+            <Gravatar hash={image.get('uuid_hash')} size={iconSize} type={type}/>
+        );
 
-    if (!this.state.active) {
-        inactiveClass = "media--disabled";
-        if (this.state.showAlert) {
-            alertMessage = () => {
-                return (
-                    <div
-                        style={{
-                                position: "absolute",
-                                display: "inline-block",
-                                width: "250px",
-                                top: "25%", 
-                                right: "0",
-                                left: "0",
-                                margin: "auto",
-                                padding: "5px 10px",
-                                background: "#F15757",
-                                boxShadow: "0 1px 2px rgba(0,0,0,.4)",
-                                color: "white",
-                                textAlign: "center",
-                                cursor: "no-drop !important"
-                            }}
-                        >
-                        <i className="glyphicon glyphicon-exclamation-sign"/>
-                        {" Image Disabled - No Versions"}
-                    </div>
-                )
+        if (!this.state.active) {
+            inactiveClass = "media--disabled";
+            if (this.state.showAlert) {
+                alertMessage = () => {
+                    return (
+                        <div
+                            style={{
+                                    position: "absolute",
+                                    display: "inline-block",
+                                    width: "250px",
+                                    top: "25%",
+                                    right: "0",
+                                    left: "0",
+                                    margin: "auto",
+                                    padding: "5px 10px",
+                                    background: "#F15757",
+                                    boxShadow: "0 1px 2px rgba(0,0,0,.4)",
+                                    color: "white",
+                                    textAlign: "center",
+                                    cursor: "no-drop !important"
+                                }}
+                            >
+                            <i className="glyphicon glyphicon-exclamation-sign"/>
+                            {" Image Disabled - No Versions"}
+                        </div>
+                    )
+                }
             }
         }
-    }
-    return (
-        <li 
-            style={{position: "relative" }} 
-            className="media card"
-            onClick={this.handleClick}
+        return (
+            <li
+                style={{position: "relative" }}
+                className="media card"
+                onClick={this.handleClick}
             >
-            <div className={`clearfix ${inactiveClass}`}>
-                <div className="media__img">
-                    {icon}
-                </div>
-                <div className="media__content">
-                    <div className="row">
-                        <div className="col-md-3 t-wordBreaker">
-                            <h2 className="t-body-1" style={{margin: "0 0 5px"}}>{image.get('name')}</h2>
-                            <hr style={{margin: "0 0 5px" }}/>
-                            <time>{imageCreationDate}</time> by <strong>{image.get('created_by').username}</strong>
-                        </div>
-                        <p className="media__description col-md-5">
-                            {renderDescription}
-                        </p>
-                        <div className="col-md-4">
-                            {this.renderTags()}
+                <div className={`clearfix ${inactiveClass}`}>
+                    <div className="media__img">
+                        {icon}
+                    </div>
+                    <div className="media__content">
+                        <div className="row">
+                            <div className="col-md-3 t-wordBreaker">
+                                <h2 className="t-body-1" style={{margin: "0 0 5px"}}>{image.get('name')}</h2>
+                                <hr style={{margin: "0 0 5px" }}/>
+                                <time>{imageCreationDate}</time> by <strong>{image.get('created_by').username}</strong>
+                            </div>
+                            <p className="media__description col-md-5">
+                                {renderDescription}
+                            </p>
+                            <div className="col-md-4">
+                                {this.renderTags()}
+                            </div>
                         </div>
                     </div>
                 </div>
-            </div>
-            {alertMessage()}
-        </li>
-    )
+                {alertMessage()}
+            </li>
+        )
     }
 
 });

--- a/troposphere/static/js/components/modals/instance/launch/components/Image.react.js
+++ b/troposphere/static/js/components/modals/instance/launch/components/Image.react.js
@@ -1,94 +1,88 @@
+import React from 'react';
+import Backbone from 'backbone';
+import stores from 'stores';
+import moment from 'moment';
+import Tags from 'components/common/tags/ViewTags.react';
+import Gravatar from 'components/common/Gravatar.react';
 
-define(
-  [
-    'react',
-    'backbone',
-    'stores',
-    'moment',
-    'components/common/tags/ViewTags.react',
-    'components/common/Gravatar.react'
-  ],
-  function (React, Backbone, stores, moment, Tags, Gravatar) {
+export default React.createClass({
+    displayName: "Image",
 
-    return React.createClass({
-      displayName: "Image",
+    getInitialState: function(){
+        let image = this.props.image;
+        let versionList = null;
+        let active = false;
+        if (image) {
+            versionList = image.get('versions');
 
-      getInitialState: function(){
-          let image = this.props.image;
-          let versionList = null;
-          let active = false;
-            if (image) {
-                versionList = image.get('versions');
-
-                if (versionList.length > 0) {
-                    active = true;
-                }
+            if (versionList.length > 0) {
+                active = true;
             }
-            return {
-                active
-            }
-      },
-
-      propTypes: {
-        image: React.PropTypes.instanceOf(Backbone.Model).isRequired,
-        onClick: React.PropTypes.func
-      },
-
-      handleClick: function () {
-        if (this.state.active) {
-            this.props.onSelectImage(this.props.image);
         }
-      },
+        return {
+            active
+        }
+    },
 
-      renderTags: function () {
-        var tags = stores.TagStore.getAll();
-        var activeTags = stores.TagStore.getImageTags(this.props.image);
+    propTypes: {
+    image: React.PropTypes.instanceOf(Backbone.Model).isRequired,
+    onClick: React.PropTypes.func
+    },
 
-        return (
-          <Tags tags={tags} activeTags={activeTags} renderLinks={false}/>
-        );
-      },
+    handleClick: function () {
+    if (this.state.active) {
+        this.props.onSelectImage(this.props.image);
+    }
+    },
 
-      render: function () {
-        var image = this.props.image,
-          type = stores.ProfileStore.get().get('icon_set'),
-          imageCreationDate = moment(image.get('start_date')).format("MMM D, YYYY hh:mm a"),
-          iconSize = 67,
-          icon;
-        let fullDescription = image.get('description');
-        let renderDescription = fullDescription.length < 150 ? fullDescription : (fullDescription.substring(0,150) + " ...");
+    renderTags: function () {
+    var tags = stores.TagStore.getAll();
+    var activeTags = stores.TagStore.getImageTags(this.props.image);
 
-        // always use the Gravatar icons
-        icon = (
-          <Gravatar hash={image.get('uuid_hash')} size={iconSize} type={type}/>
-        );
+    return (
+        <Tags tags={tags} activeTags={activeTags} renderLinks={false}/>
+    );
+    },
 
-        let inactiveClass = !this.state.active ? "disabled" : "";
+    render: function () {
+    var image = this.props.image,
+        type = stores.ProfileStore.get().get('icon_set'),
+        imageCreationDate = moment(image.get('start_date')).format("MMM D, YYYY hh:mm a"),
+        iconSize = 67,
+        icon;
+    let fullDescription = image.get('description');
+    let renderDescription = fullDescription.length < 150 ? fullDescription : (fullDescription.substring(0,150) + " ...");
 
-        return (
-            <li className={`media card ${inactiveClass}`} onClick={this.handleClick}>
-                    <div className="media__img">
-                        {icon}
-                    </div>
-                    <div className="media__content">
-                        <div className="row">
-                            <div className="col-md-3 t-wordBreaker">
-                                <h2 className="t-body-1" style={{margin: "0 0 5px"}}>{image.get('name')}</h2>
-                                <hr style={{margin: "0 0 5px" }}/>
-                                <time>{imageCreationDate}</time> by <strong>{image.get('created_by').username}</strong>
-                            </div>
-                            <p className="media__description col-md-5">
-                                {renderDescription}
-                            </p>
-                            <div className="col-md-4">
-                                {this.renderTags()}
-                            </div>
+    // always use the Gravatar icons
+    icon = (
+        <Gravatar hash={image.get('uuid_hash')} size={iconSize} type={type}/>
+    );
+
+    let inactiveClass = !this.state.active ? "disabled" : "";
+
+    return (
+        <li className={`media card ${inactiveClass}`} onClick={this.handleClick}>
+                <div className="media__img">
+                    {icon}
+                </div>
+                <div className="media__content">
+                    <div className="row">
+                        <div className="col-md-3 t-wordBreaker">
+                            <h2 className="t-body-1" style={{margin: "0 0 5px"}}>{image.get('name')}</h2>
+                            <hr style={{margin: "0 0 5px" }}/>
+                            <time>{imageCreationDate}</time> by <strong>{image.get('created_by').username}</strong>
+                        </div>
+                        <p className="media__description col-md-5">
+                            {renderDescription}
+                        </p>
+                        <div className="col-md-4">
+                            {this.renderTags()}
                         </div>
                     </div>
-            </li>
-        )
-      }
+                </div>
+        </li>
+    )
+    }
 
-    });
+});
 
-  });


### PR DESCRIPTION
# This PR aims to defend against the edge case where an image has no versions

There is a rare case when an Image can be left with no versions. This Image can not be launched, therefore we have to prevent the user from trying. A user might own the image or have seen it in another list, in this case hiding it could result in more tickets asking why the image is missing. Steve and I agree that showing the image however disabling it would solve both problems.

## Greyed out Image with disabled cursor and message when clicked
![ygi1dimbno](https://cloud.githubusercontent.com/assets/7366338/13611152/37c99f88-e51e-11e5-9604-913ea33555fc.gif)
 