### PR TITLE
Provide a method to remove Image and External Link from Project

### DIFF
--- a/troposphere/static/js/actions/ProjectActions.js
+++ b/troposphere/static/js/actions/ProjectActions.js
@@ -251,7 +251,6 @@ define(function (require) {
           project: project
         }, options);
       } else if (resource instanceof Image) {
-        //Do NOT delete the Image, just remove the Image from the project.
         actions.ProjectImageActions.removeImageFromProject({
           project: project,
           image: resource

--- a/troposphere/static/js/actions/ProjectExternalLinkActions.js
+++ b/troposphere/static/js/actions/ProjectExternalLinkActions.js
@@ -15,10 +15,10 @@ define(function (require) {
 
     addExternalLinkToProject: function (payload, options) {
       if (!payload.project) throw new Error("Missing project");
-      if (!payload.link && !payload.link.id) throw new Error("Missing link");
+      if (!payload.external_link && !payload.external_link.id) throw new Error("Missing external_link");
 
       var project = payload.project,
-        external_link = payload.link,
+        external_link = payload.external_link,
         projectExternalLink = new ProjectExternalLink(),
         data = {
           project: project.id,
@@ -32,10 +32,10 @@ define(function (require) {
 
     removeExternalLinkFromProject: function (payload, options) {
       if (!payload.project) throw new Error("Missing project");
-      if (!payload.link) throw new Error("Missing link");
+      if (!payload.external_link) throw new Error("Missing external_link");
 
       var project = payload.project,
-        external_link = payload.link,
+        external_link = payload.external_link,
         projectExternalLink = stores.ProjectExternalLinkStore.findOne({
           'project.id': project.id,
           'external_link.id': external_link.id

--- a/troposphere/static/js/actions/ProjectImageActions.js
+++ b/troposphere/static/js/actions/ProjectImageActions.js
@@ -36,7 +36,6 @@ define(function (require) {
 
       var project = params.project,
         image = params.image,
-        //FIXME: the line below has 0 models (When the value should be >1)
         projectImage = stores.ProjectImageStore.findOne({
           'project.id': project.id,
           'image.id': image.id

--- a/troposphere/static/js/actions/ProjectImageActions.js
+++ b/troposphere/static/js/actions/ProjectImageActions.js
@@ -36,6 +36,7 @@ define(function (require) {
 
       var project = params.project,
         image = params.image,
+        //FIXME: the line below has 0 models (When the value should be >1)
         projectImage = stores.ProjectImageStore.findOne({
           'project.id': project.id,
           'image.id': image.id

--- a/troposphere/static/js/actions/link/create.js
+++ b/troposphere/static/js/actions/link/create.js
@@ -11,11 +11,11 @@ define(function (require) {
     create: function (params) {
       if (!params.name) throw new Error("Missing name");
       if (!params.description) throw new Error("Missing description");
-      if (!params.link) throw new Error("Missing link");
+      if (!params.external_link) throw new Error("Missing external_link");
 
       var name = params.name,
         description = params.description,
-        link = params.link;
+        link = params.external_link;
 
       var external_link = new ExternalLink({
         name: name,
@@ -24,12 +24,12 @@ define(function (require) {
       });
 
       // Add the external_link optimistically
-      Utils.dispatch(ExternalLinkConstants.ADD_LINK, {link: external_link}, {silent: false});
+      Utils.dispatch(ExternalLinkConstants.ADD_LINK, {external_link: external_link}, {silent: false});
 
       external_link.save().done(function () {
-        Utils.dispatch(ExternalLinkConstants.UPDATE_LINK, {link: external_link}, {silent: false});
+        Utils.dispatch(ExternalLinkConstants.UPDATE_LINK, {external_link: external_link}, {silent: false});
       }).fail(function (response) {
-        Utils.dispatch(ExternalLinkConstants.REMOVE_LINK, {link: external_link}, {silent: false});
+        Utils.dispatch(ExternalLinkConstants.REMOVE_LINK, {external_link: external_link}, {silent: false});
         Utils.displayError({title: "ExternalLink could not be created", response: response});
       });
       return external_link;

--- a/troposphere/static/js/actions/link/createAndAddToProject.js
+++ b/troposphere/static/js/actions/link/createAndAddToProject.js
@@ -12,12 +12,12 @@ define(function (require) {
 
       if (!payload.title) throw new Error("Missing title");
       if (!payload.description) throw new Error("Missing description");
-      if (!payload.link) throw new Error("Missing link");
+      if (!payload.external_link) throw new Error("Missing external_link");
       if (!payload.project) throw new Error("Missing project");
 
       var title = payload.title,
         project = payload.project,
-        link = payload.link,
+        link = payload.external_link,
         description = payload.description;
 
       var external_link = new ExternalLink({
@@ -27,22 +27,22 @@ define(function (require) {
       });
 
       // Add the external_link optimistically
-      Utils.dispatch(ExternalLinkConstants.ADD_LINK, {link: external_link}, {silent: false});
+      Utils.dispatch(ExternalLinkConstants.ADD_LINK, {external_link: external_link}, {silent: false});
 
       external_link.save().done(function () {
-        Utils.dispatch(ExternalLinkConstants.UPDATE_LINK, {link: external_link}, {silent: false});
-        Utils.dispatch(ExternalLinkConstants.REMOVE_PENDING_LINK_FROM_PROJECT, {link: external_link, project: project});
+        Utils.dispatch(ExternalLinkConstants.UPDATE_LINK, {external_link: external_link}, {silent: false});
+        Utils.dispatch(ExternalLinkConstants.REMOVE_PENDING_LINK_FROM_PROJECT, {external_link: external_link, project: project});
         actions.ProjectExternalLinkActions.addExternalLinkToProject({
           project: project,
-          link: external_link
+          external_link: external_link
         });
       }).fail(function (response) {
-        Utils.dispatch(ExternalLinkConstants.REMOVE_LINK, {link: external_link}, {silent: false});
-        Utils.dispatch(ExternalLinkConstants.REMOVE_PENDING_LINK_FROM_PROJECT, {link: external_link, project: project});
+        Utils.dispatch(ExternalLinkConstants.REMOVE_LINK, {external_link: external_link}, {silent: false});
+        Utils.dispatch(ExternalLinkConstants.REMOVE_PENDING_LINK_FROM_PROJECT, {external_link: external_link, project: project});
         Utils.displayError({title: "ExternalLink could not be created", response: response});
       });
 
-      Utils.dispatch(ExternalLinkConstants.ADD_PENDING_LINK_TO_PROJECT, {link: external_link, project: project});
+      Utils.dispatch(ExternalLinkConstants.ADD_PENDING_LINK_TO_PROJECT, {external_link: external_link, project: project});
 
     }
 

--- a/troposphere/static/js/actions/link/destroy.js
+++ b/troposphere/static/js/actions/link/destroy.js
@@ -10,23 +10,23 @@ define(function (require) {
   return {
 
     destroy: function (payload, options) {
-      if (!payload.link) throw new Error("Missing link");
+      if (!payload.external_link) throw new Error("Missing external_link");
       if (payload.project) {
           //Remove the project from the link if included in destroy
           ProjectExternalLinkActions.removeExternalLinkFromProject({
               project: payload.project,
-              external_link: payload.link
+              external_link: payload.external_link
           });
       }
-      var external_link = payload.link;
-      Utils.dispatch(ExternalLinkConstants.REMOVE_LINK, {link: external_link});
+      var external_link = payload.external_link;
+      Utils.dispatch(ExternalLinkConstants.REMOVE_LINK, {external_link: external_link});
 
       external_link.destroy().done(function () {
         //NotificationController.success(null, "ExternalLink " + external_link.get('title') + " deleted.");
       }).fail(function () {
         var failureMessage = "Error deleting ExternalLink " + external_link.get('title') + ".";
         NotificationController.error(failureMessage);
-        Utils.dispatch(ExternalLinkConstants.ADD_LINK, {link: external_link});
+        Utils.dispatch(ExternalLinkConstants.ADD_LINK, {external_link: external_link});
       });
     },
 

--- a/troposphere/static/js/actions/link/destroy.js
+++ b/troposphere/static/js/actions/link/destroy.js
@@ -4,12 +4,20 @@ define(function (require) {
     stores = require('stores'),
     Utils = require('../Utils'),
     globals = require('globals'),
+    ProjectExternalLinkActions = require('../ProjectExternalLinkActions'),
     ExternalLinkConstants = require('constants/ExternalLinkConstants');
 
   return {
 
     destroy: function (payload, options) {
       if (!payload.link) throw new Error("Missing link");
+      if (payload.project) {
+          //Remove the project from the link if included in destroy
+          ProjectExternalLinkActions.removeExternalLinkFromProject({
+              project: payload.project,
+              external_link: payload.link
+          });
+      }
       var external_link = payload.link;
       Utils.dispatch(ExternalLinkConstants.REMOVE_LINK, {link: external_link});
 

--- a/troposphere/static/js/components/modals/link/ExternalLinkDeleteModal.react.js
+++ b/troposphere/static/js/components/modals/link/ExternalLinkDeleteModal.react.js
@@ -33,7 +33,7 @@ define(function(require) {
     //
 
     renderBody: function () {
-      var link = this.props.link;
+      var link = this.props.external_link;
       return (
         <div>
           <p>

--- a/troposphere/static/js/components/modals/project/ProjectRemoveResourceModal.react.js
+++ b/troposphere/static/js/components/modals/project/ProjectRemoveResourceModal.react.js
@@ -53,7 +53,7 @@ define(
             <div className='form-group'>
               <label htmlFor='volumeSize'>Resources to Remove</label>
 
-              <p>If you are viewing this you have administrative rights for Atmosphere. The following resources will be
+              <p>The following resources will be
                 removed from the project:</p>
               <ul>
                 {this.props.resources.map(this.renderResource)}

--- a/troposphere/static/js/components/projects/detail/resources/ExternalLinkActionButtons.react.js
+++ b/troposphere/static/js/components/projects/detail/resources/ExternalLinkActionButtons.react.js
@@ -1,0 +1,48 @@
+define(function (require) {
+
+  var React = require('react/addons'),
+    Backbone = require('backbone'),
+    Button = require('./Button.react'),
+    actions = require('actions'),
+    modals = require('modals');
+
+  return React.createClass({
+    displayName: "ExternalLinkActionButtons",
+
+    propTypes: {
+      multipleSelected: React.PropTypes.bool.isRequired,
+      external_link: React.PropTypes.instanceOf(Backbone.Model).isRequired,
+      project: React.PropTypes.instanceOf(Backbone.Model).isRequired
+    },
+
+    onDelete: function () {
+      this.props.onUnselect(this.props.external_link);
+      modals.ExternalLinkModals.destroy({
+        external_link: this.props.external_link,
+        project: this.props.project
+      });
+    },
+
+    render: function () {
+      var external_link = this.props.external_link,
+        linksArray = [];
+      linksArray.push(
+        <Button
+          key="Delete"
+          icon="remove"
+          tooltip="Delete"
+          onClick={this.onDelete}
+          isVisible={true}
+          />
+      );
+
+      return (
+        <div style={{borderLeft: "1px solid #ddd", display: "inline-block", paddingLeft: "10px", float: "right"}}>
+          {linksArray}
+        </div>
+      );
+    }
+
+  });
+
+});

--- a/troposphere/static/js/components/projects/detail/resources/ImageActionButtons.react.js
+++ b/troposphere/static/js/components/projects/detail/resources/ImageActionButtons.react.js
@@ -1,0 +1,48 @@
+define(function (require) {
+
+  var React = require('react/addons'),
+    Backbone = require('backbone'),
+    Button = require('./Button.react'),
+    actions = require('actions'),
+    modals = require('modals');
+
+  return React.createClass({
+    displayName: "ImageActionButtons",
+
+    propTypes: {
+      multipleSelected: React.PropTypes.bool.isRequired,
+      image: React.PropTypes.instanceOf(Backbone.Model).isRequired,
+      project: React.PropTypes.instanceOf(Backbone.Model).isRequired
+    },
+
+    onDelete: function () {
+      this.props.onUnselect(this.props.image);
+      modals.ProjectModals.removeResources(
+        new Backbone.Collection([this.props.image]),
+        this.props.project
+      );
+    },
+
+    render: function () {
+      var image = this.props.image,
+        linksArray = [];
+      linksArray.push(
+        <Button
+          key="Delete"
+          icon="remove"
+          tooltip="Delete"
+          onClick={this.onDelete}
+          isVisible={true}
+          />
+      );
+
+      return (
+        <div style={{borderLeft: "1px solid #ddd", display: "inline-block", paddingLeft: "10px", float: "right"}}>
+          {linksArray}
+        </div>
+      );
+    }
+
+  });
+
+});

--- a/troposphere/static/js/components/projects/detail/resources/ResourceActionButtons.react.js
+++ b/troposphere/static/js/components/projects/detail/resources/ResourceActionButtons.react.js
@@ -4,7 +4,11 @@ define(function (require) {
     Backbone = require('backbone'),
     Button = require('./Button.react'),
     Instance = require('models/Instance'),
+    Image = require('models/Image'),
+    ExternalLink = require('models/ExternalLink'),
     Volume = require('models/Volume'),
+    ImageActionButtons = require('./ImageActionButtons.react'),
+    ExternalLinkActionButtons = require('./ExternalLinkActionButtons.react'),
     InstanceActionButtons = require('./InstanceActionButtons.react'),
     VolumeActionButtons = require('./VolumeActionButtons.react');
 
@@ -30,6 +34,24 @@ define(function (require) {
             onUnselect={this.props.onUnselect}
             multipleSelected={this.props.multipleSelected}
             instance={resource}
+            project={project}
+            />
+        );
+      } else if (resource instanceof Image) {
+        return (
+          <ImageActionButtons
+            onUnselect={this.props.onUnselect}
+            multipleSelected={this.props.multipleSelected}
+            image={resource}
+            project={project}
+            />
+        );
+      } else if (resource instanceof ExternalLink) {
+        return (
+          <ExternalLinkActionButtons
+            onUnselect={this.props.onUnselect}
+            multipleSelected={this.props.multipleSelected}
+            external_link={resource}
             project={project}
             />
         );

--- a/troposphere/static/js/components/projects/resources/link/details/ExternalLinkDetailsView.react.js
+++ b/troposphere/static/js/components/projects/resources/link/details/ExternalLinkDetailsView.react.js
@@ -16,7 +16,7 @@ define(function (require) {
 
     render: function () {
       var project = this.props.project,
-        link = this.props.link;
+        link = this.props.external_link;
 
       var breadcrumbs = [
         {

--- a/troposphere/static/js/components/projects/resources/link/details/sections/ExternalLinkActions.react.js
+++ b/troposphere/static/js/components/projects/resources/link/details/sections/ExternalLinkActions.react.js
@@ -10,26 +10,26 @@ define(function (require) {
     displayName: "ExternalLinkActions",
 
     propTypes: {
-      link: React.PropTypes.instanceOf(Backbone.Model).isRequired,
+      external_link: React.PropTypes.instanceOf(Backbone.Model).isRequired,
       project: React.PropTypes.instanceOf(Backbone.Model).isRequired
     },
 
     onDelete: function () {
       var project = this.props.project,
-        link = this.props.link;
+        link = this.props.external_link;
 
       modals.ExternalLinkModals.destroy({
-        link: this.props.link,
+        external_link: this.props.external_link,
         project: this.props.project
       });
     },
 
     handleReport: function () {
-      modals.ExternalLinkModals.report({link: this.props.link});
+      modals.ExternalLinkModals.report({external_link: this.props.external_link});
     },
 
     render: function () {
-      var link = this.props.link;
+      var link = this.props.external_link;
       var linksArray = [
         {label: 'Actions', icon: null},
         {label: 'Go To Link', icon: 'globe', target:"_blank", href: link.get('link'), onClick: this.handleReport}
@@ -40,25 +40,25 @@ define(function (require) {
         {label: 'Delete', icon: 'remove', onClick: this.onDelete, isDangerLink: true}
       ]);
 
-      var links = linksArray.map(function (link) {
+      var links = linksArray.map(function (ext_link) {
         // Links without icons are generally section headings
-        if (!link.icon) return (
-          <li key={link.label} className="section-label">{link.label}</li>
+        if (!ext_link.icon) return (
+          <li key={ext_link.label} className="section-label">{ext_link.label}</li>
         );
 
         var className = "section-link";
-        if (link.isDangerLink) className += " danger";
+        if (ext_link.isDangerLink) className += " danger";
 
         // Some actions have hrefs, because they redirect to actual pages (and are
         // not actions in need of confirmation).  While we *could* call
         // Backbone.history.navigate from an onClick callback, we want all url
         // changes to pass through our Backbone catcher in main.js that we can use
         // to log requests to Google Analytics
-        if (link.href) return (
-          <li key={link.label} className={className + " link"}>
-            <a href={link.href} target={link.target ? link.target : "_self"}>
+        if (ext_link.href) return (
+          <li key={ext_link.label} className={className + " link"}>
+            <a href={ext_link.href} target={ext_link.target ? ext_link.target : "_self"}>
             <span>
-              <Glyphicon name={link.icon}/>{link.label}
+              <Glyphicon name={ext_link.icon}/>{ext_link.label}
             </span>
             </a>
           </li>
@@ -67,9 +67,9 @@ define(function (require) {
         // Links with onClick callbacks will typically trigger modals requiring
         // confirmation before continuing
         return (
-          <li key={link.label} className={className} onClick={link.onClick}>
+          <li key={ext_link.label} className={className} onClick={ext_link.onClick}>
             <span>
-              <Glyphicon name={link.icon}/>{link.label}
+              <Glyphicon name={ext_link.icon}/>{ext_link.label}
             </span>
           </li>
         );

--- a/troposphere/static/js/components/projects/resources/link/details/sections/ExternalLinkInfoSection.react.js
+++ b/troposphere/static/js/components/projects/resources/link/details/sections/ExternalLinkInfoSection.react.js
@@ -14,11 +14,11 @@ define(function (require) {
     displayName: "ExternalLinkInfoSection",
 
     propTypes: {
-      link: React.PropTypes.instanceOf(Backbone.Model).isRequired
+      external_link: React.PropTypes.instanceOf(Backbone.Model).isRequired
     },
 
     getInitialState: function () {
-      var link = this.props.link;
+      var link = this.props.external_link;
 
       return {
         name: link.get('title'),
@@ -43,7 +43,7 @@ define(function (require) {
     },
 
     onDoneEditingDescription: function (text) {
-      var link = this.props.link;
+      var link = this.props.external_link;
 
       this.setState({
         description: text,
@@ -53,7 +53,7 @@ define(function (require) {
     },
 
     onDoneEditingLink: function (text) {
-      var link = this.props.link;
+      var link = this.props.external_link;
 
       this.setState({
         link: text,
@@ -63,7 +63,7 @@ define(function (require) {
     },
 
     onDoneEditingName: function (text) {
-      var link = this.props.link;
+      var link = this.props.external_link;
 
       this.setState({
         name: text,
@@ -73,7 +73,7 @@ define(function (require) {
     },
 
     render: function () {
-      var link = this.props.link,
+      var link = this.props.external_link,
         profile = stores.ProfileStore.get(),
         type = profile.get('icon_set'),
         instanceHash = CryptoJS.MD5((link.id || link.cid).toString()).toString(),

--- a/troposphere/static/js/modals/link/createAndAddToProject.js
+++ b/troposphere/static/js/modals/link/createAndAddToProject.js
@@ -16,7 +16,7 @@ define(function (require) {
         actions.ExternalLinkActions.createAndAddToProject({
           title: name,
           description: description,
-          link: link,
+          external_link: link,
           project: project
         });
       });

--- a/troposphere/static/js/modals/link/destroy.js
+++ b/troposphere/static/js/modals/link/destroy.js
@@ -10,22 +10,22 @@ define(function (require) {
 
     destroy: function (payload, options) {
       if (!payload.project) throw new Error("Missing project");
-      if (!payload.link) throw new Error("Missing link");
+      if (!payload.external_link) throw new Error("Missing external_link");
 
       var project = payload.project,
-        link = payload.link,
+        external_link = payload.external_link,
         ModalComponent,
         props;
 
       ModalComponent = ExternalLinkDeleteModal;
       props = {
-        link: link
+        external_link: external_link
       };
 
       ModalHelpers.renderModal(ModalComponent, props, function () {
         actions.ExternalLinkActions.destroy({
           project: project,
-          link: link
+          external_link: external_link
         });
         Router.getInstance().transitionTo("project-resources", {projectId: project.id});
       })

--- a/troposphere/static/js/stores/BaseStore.js
+++ b/troposphere/static/js/stores/BaseStore.js
@@ -93,8 +93,11 @@ define(function (require) {
     remove: function (model) {
       this.models.remove(model);
 
-      // Remove model from polling dictionary
-      delete this.pollingModels[model.cid];
+      // If already polling, Remove model from polling dictionary
+      if (this.pollingModels[model.cid]) {
+          delete this.pollingModels[model.cid];
+      }
+      return;
     },
 
     // --------------

--- a/troposphere/static/js/stores/ExternalLinkStore.js
+++ b/troposphere/static/js/stores/ExternalLinkStore.js
@@ -36,15 +36,15 @@ define(function (require) {
     switch (actionType) {
 
       case ExternalLinkConstants.ADD_LINK:
-        store.add(payload.link);
+        store.add(payload.external_link);
         break;
 
       case ExternalLinkConstants.UPDATE_LINK:
-        store.update(payload.link);
+        store.update(payload.external_link);
         break;
 
       case ExternalLinkConstants.REMOVE_LINK:
-        store.remove(payload.link);
+        store.remove(payload.external_link);
         break;
 
       default:

--- a/troposphere/static/js/stores/ProjectExternalLinkStore.js
+++ b/troposphere/static/js/stores/ProjectExternalLinkStore.js
@@ -55,7 +55,6 @@ define(function (require) {
       if (!_modelsFor[project.id]) return this.fetchModelsFor(project.id);
       if (!allExternalLinks) return;
 
-      //TODO: The logic here is broken. Everything returns 0 -- but values *do* exist.
       var external_links = this.models.filter(function (p_link) {
         // filter out irrelevant project external_links (not in target project)
         return p_link.get('project').id === project.id;

--- a/troposphere/static/js/stores/ProjectImageStore.js
+++ b/troposphere/static/js/stores/ProjectImageStore.js
@@ -51,12 +51,21 @@ define(function (require) {
     },
 
     getImagesFor: function (project) {
-      //NOTE: The logic here falls to pieces. As a result we actually need _all_ the images in order to ensure that the images
-      // Added by _user_ can be searched through in the filter-filter-filter that happens below.
       var allImages = stores.ImageStore.getForProject(project.id);
+      if (!_modelsFor[project.id]) return this.fetchModelsFor(project.id);
       if (!allImages) return;
 
-      return allImages;
+      var images = this.models.filter(function (project_image) {
+        // filter out irrelevant project images (not in target project)
+        return project_image.get('project').id === project.id;
+      }).filter(function (project_image) {
+        // filter out the images that don't exist (not in local cache)
+        return allImages.get(project_image.get('image').id);
+      }).map(function (project_image) {
+        // return the actual images
+        return allImages.get(project_image.get('image').id);
+      });
+      return new ImageCollection(images);
     }
   });
 


### PR DESCRIPTION
Highlight reel:
- [x] Do not allow projects to be deleted if they contain links or images (in addition to instances or volumes)
- [x] Give users a method to delete ExternalLinks so that they are not 'orphaned'
- [x] Give users a method to remove Images from projects
- [x] Rename 'link' to 'external_link' when referencing the object (matches Atmosphere), and use `link` to refer to the attribute contained inside the object.

"Live Demo":
![Live Demo](http://g.recordit.co/rteeiJpCko.gif)