### PR TITLE
Projects Grid Improvement ATMO-1236

### DIFF
--- a/troposphere/static/css/app/media-cards.scss
+++ b/troposphere/static/css/app/media-cards.scss
@@ -43,4 +43,8 @@
     padding:20px;
     box-shadow: $shadow-1;
     background: white;
+
+    .media__footer {
+        margin: 0 -20px -20px;
+    }
 }

--- a/troposphere/static/css/app/projects.scss
+++ b/troposphere/static/css/app/projects.scss
@@ -1,79 +1,6 @@
 #project-list {
-  margin: 0;
   padding: 0;
   list-style: none;
-
-  > li {
-    background: #fff;
-    border: 1px solid #ccc;
-    box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.15);
-
-    display: inline-block;
-    position: relative;
-    margin-right: 50px;
-    margin-bottom: 50px;
-    float: left;
-    &.active {
-      border: 1px solid #F00;
-    }
-    &:nth-child(3n) {
-      margin-right: 0;
-    }
-
-    .content {
-      max-height: 219px;
-      overflow-y: hidden;
-    }
-
-    .description {
-      color: #6D6E71;
-      margin-top: 5px;
-    }
-
-    > a > div {
-      padding: 15px;
-      height: 275px;
-      width: 344px; //225px; //width: 278px;
-
-      h2 {
-        font-size: 19px;
-        margin: 0;
-        color: #231F20;
-      }
-
-      time {
-        color: #6D6E71;
-      }
-    }
-  }
-}
-
-@media (max-width: 1199px) {
-  #project-list > li {
-    &:nth-child(3n) {
-      margin-right: 0;
-    }
-
-    > a > div {
-      width: 278px;
-    }
-  }
-}
-
-@media (max-width: 991px) {
-  #project-list > li {
-    &:nth-child(2n) {
-      margin-right: 0;
-    }
-
-    &:nth-child(3n) {
-      margin-right: 50px;
-    }
-
-    > a > div {
-      width: 333px;
-    }
-  }
 }
 
 // Project Resource Modal
@@ -166,8 +93,6 @@
 }
 
 ul.project-resource-list {
-  position: absolute;
-  bottom: 0px;
   font-size: 18px;
   color: #231F20;
   list-style-type: none;
@@ -175,7 +100,6 @@ ul.project-resource-list {
 
   width: 100%;
   border-top: 1px solid #ccc;
-  margin-left: -15px;
   li {
     display: inline-block;
     margin-left: 29px;

--- a/troposphere/static/js/components/projects/list/Project.react.js
+++ b/troposphere/static/js/components/projects/list/Project.react.js
@@ -27,17 +27,24 @@ define(function (require) {
     renderForRouter: function () {
       var project = this.props.project;
       return (
-        <li className={"project-card " + this.props.className}>
-          <Router.Link to="project-resources" params={{projectId: project.id}}>
-            {this.renderBody()}
-          </Router.Link>
+        <li className={"col-md-4" + this.props.className} style={{padding: "15px"}}>
+          <div className="media card">
+            <Router.Link to="project-resources" 
+              params={{projectId: project.id}}
+              style={{color: "inherit"}}
+            >
+              {this.renderBody()}
+            </Router.Link>
+          </div>
         </li>);
     },
     renderForClick: function () {
       var project = this.props.project;
       return (
-        <li className="project-card" onClick={this.clicked}>
-          {this.renderBody()}
+        <li className={"col-md-4" + this.props.className} style={{padding: "15px"}}>
+          <div className="media card">
+            {this.renderBody()}
+          </div>
         </li>);
     },
     render: function () {
@@ -49,14 +56,12 @@ define(function (require) {
 
       if (!project.id || !projectExternalLinks || !projectInstances || !projectVolumes || !projectImages) {
         return (
-          <li>
-            <a>
-              <div>
-                <h2>{project.get('name')}</h2>
+        <li className={"col-md-4" + this.props.className} style={{padding: "15px"}}>
+          <div className="media card">
+                <h2 className="t-title">{project.get('name')}</h2>
 
                 <div className="loading" style={{marginTop: "65px"}}/>
-              </div>
-            </a>
+            </div>
           </li>
         );
       }

--- a/troposphere/static/js/components/projects/list/Project.react.js
+++ b/troposphere/static/js/components/projects/list/Project.react.js
@@ -76,7 +76,6 @@ define(function (require) {
       var project = this.props.project,
         converter = new Showdown.Converter(),
         description = project.get('description'),
-        descriptionHtml = converter.makeHtml(description),
         projectExternalLinks = stores.ProjectExternalLinkStore.getExternalLinksFor(project),
         projectInstances = stores.ProjectInstanceStore.getInstancesFor(project),
         projectVolumes = stores.ProjectVolumeStore.getVolumesFor(project),
@@ -85,29 +84,36 @@ define(function (require) {
 
       return (
         <div style={{"position": "relative"}}>
-          <div className="content">
-            <h2>{project.get('name')}</h2>
-            <time>{"Created " + projectCreationDate}</time>
-            <div className="description" dangerouslySetInnerHTML={{__html: descriptionHtml}}/>
+          <div className="media__content">
+            <h2 className="t-title">{project.get('name')}</h2>
+            <hr/>
+            <time className="t-caption" style={{display: "block"}}>{"Created " + projectCreationDate}</time>
+            <p className="description" 
+              style={{minHeight: "200px"}} 
+            >
+                {description}
+            </p>
           </div>
-          <ul className="project-resource-list">
-            <ProjectResource icon={"tasks"}
-                             count={projectInstances.length}
-                             resourceType={"instances"}
-              />
-            <ProjectResource icon={"hdd"}
-                             count={projectVolumes.length}
-                             resourceType={"volumes"}
-              />
-            <ProjectResource icon={"floppy-disk"}
-                             count={projectImages.length}
-                             resourceType={"images"}
-              />
-            <ProjectResource icon={"globe"}
-                             count={projectExternalLinks.length}
-                             resourceType={"links"}
-              />
-          </ul>
+          <div className="media__footer">
+            <ul className="project-resource-list ">
+                <ProjectResource icon={"tasks"}
+                                count={projectInstances.length}
+                                resourceType={"instances"}
+                />
+                <ProjectResource icon={"hdd"}
+                                count={projectVolumes.length}
+                                resourceType={"volumes"}
+                />
+                <ProjectResource icon={"floppy-disk"}
+                                count={projectImages.length}
+                                resourceType={"images"}
+                />
+                <ProjectResource icon={"globe"}
+                                count={projectExternalLinks.length}
+                                resourceType={"links"}
+                />
+            </ul>
+          </div>
         </div>
       );
     }

--- a/troposphere/static/js/components/projects/list/ProjectList.react.js
+++ b/troposphere/static/js/components/projects/list/ProjectList.react.js
@@ -35,7 +35,7 @@ define(
           }.bind(this));
 
         return (
-          <ul id="project-list">
+          <ul id="project-list" className="row">
             {projects}
           </ul>
         );


### PR DESCRIPTION
# Refactor Project List to a better grid structure

This PR aims to improve on the grid structure of the project list and fix a bug when zooming out.

When zoomed out the grid would break because of some margin shenanigans. An inspection of the grid methods used, begged for a refactor because better solutions exist for grid layouts.

In this PR the media card layout was also used in place of the previous card styles. 

Note: The Bootstrap grid was used for this, against my preference, because that is the grid we have. All of our grids should employ the same grid system. If we decide to move to a new grid system, a refactor will be easier with this consistency.

## Resizing Window
![resize](https://cloud.githubusercontent.com/assets/7366338/13645432/3c8a2842-e5e8-11e5-8343-c8b3302b2bab.gif)

## Zooming out 
![zoom-out](https://cloud.githubusercontent.com/assets/7366338/13645463/5b5ce1ce-e5e8-11e5-9a33-c2684553cb35.gif)
