### PR TITLE
[ATMO-1211] Redesign of Advanced Footer

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
-    "stage": 3,
+    "stage": 2,
     "optional": ["runtime"]
 }

--- a/troposphere/static/js/components/common/ui/Button.react.js
+++ b/troposphere/static/js/components/common/ui/Button.react.js
@@ -48,7 +48,6 @@ export default React.createClass({
 
     icon: function() {
         let icon = this.props.icon;
-
         if (!icon) {
             return null
         }

--- a/troposphere/static/js/components/common/ui/Button.react.js
+++ b/troposphere/static/js/components/common/ui/Button.react.js
@@ -4,6 +4,16 @@ import $ from 'jquery';
 import Tooltip from 'components/common/ui/Tooltip.react';
 
 export default React.createClass({
+    propTypes: {
+        buttonType: React.PropTypes.string.isRequired,
+        title: React.PropTypes.string.isRequired,
+        isDisabled: React.PropTypes.bool,
+        icon: React.PropTypes.string,
+        onTouch: React.PropTypes.func,
+        tooltip: React.PropTypes.string,
+        style: React.PropTypes.object
+    },
+
     getInitialState: function() {
         return({
             showTooltip: false

--- a/troposphere/static/js/components/common/ui/Button.react.js
+++ b/troposphere/static/js/components/common/ui/Button.react.js
@@ -1,0 +1,59 @@
+import React from 'react';
+import bootstrap from 'bootstrap';
+import $ from 'jquery';
+
+export default React.createClass({
+    componentDidMount: function () {
+       if (this.props.tooltip) {
+            var el = this.getDOMNode(),
+                $el = $(el);
+
+            $el.tooltip(this.props.tooltip);
+       }
+    },
+
+    onTouch: function() {
+        this.setState({
+            outline: "none"
+        });
+        this.props.onClick();
+    },
+
+    icon: function() {
+        let icon = this.props.icon;
+
+        if (!icon) {
+            return null
+        }
+
+        return (
+            <i className={`glyphicon glyphicon-${icon}`} />
+        )
+    },
+
+    style: function() {
+        return ({
+            ...this.props.style,
+            outline: this.state.outline
+        })
+    },
+
+    render: function () {
+        // Expects default, primary, danger, etc..
+        // Better name than level?
+        let buttonType = this.props.buttonType;
+
+        return (
+            <button 
+                type="button"
+                disabled={this.props.isDisabled}
+                className={`btn btn-${buttonType}`}
+                onClick={this.onTouch}
+                style={this.style}
+            >
+                {this.icon()}
+                {` ${this.props.title}`}
+            </button>
+        )
+    }
+});

--- a/troposphere/static/js/components/common/ui/Button.react.js
+++ b/troposphere/static/js/components/common/ui/Button.react.js
@@ -1,22 +1,49 @@
 import React from 'react';
 import bootstrap from 'bootstrap';
 import $ from 'jquery';
+import Tooltip from 'components/common/ui/Tooltip.react';
 
 export default React.createClass({
-    componentDidMount: function () {
-       if (this.props.tooltip) {
-            var el = this.getDOMNode(),
-                $el = $(el);
+    getInitialState: function() {
+        return({
+            showTooltip: false
+        });
+    },
 
-            $el.tooltip(this.props.tooltip);
-       }
+    showTooltip: function() {
+        this.setState({
+            showTooltip: true
+        });
+    },
+
+    hideTooltip: function() {
+        this.setState({
+            showTooltip: false
+        });
+    },
+
+    onMouseEnter: function() {
+        if (!this.props.isDisabled) {
+            this.showTooltip();
+        }
+    },
+
+    onMouseLeave: function() {
+        this.hideTooltip();
     },
 
     onTouch: function() {
-        this.setState({
-            outline: "none"
-        });
-        this.props.onClick();
+        this.props.onTouch();
+        setTimeout( ()=> this.hideTooltip(), 2000);
+    },
+
+    tooltip: function() {
+        let tooltip = this.props.tooltip;
+        if (!tooltip || !this.state.showTooltip) { return };
+
+        return(
+            <Tooltip message={tooltip} />
+        )
     },
 
     icon: function() {
@@ -31,29 +58,29 @@ export default React.createClass({
         )
     },
 
-    style: function() {
-        return ({
-            ...this.props.style,
-            outline: this.state.outline
-        })
-    },
-
     render: function () {
-        // Expects default, primary, danger, etc..
-        // Better name than level?
+        // Expects link, default, primary, danger, etc..
         let buttonType = this.props.buttonType;
 
         return (
-            <button 
-                type="button"
-                disabled={this.props.isDisabled}
-                className={`btn btn-${buttonType}`}
-                onClick={this.onTouch}
-                style={this.style}
+            <div style={{
+                    ...this.props.style,
+                    position: "relative"
+                }}
             >
-                {this.icon()}
-                {` ${this.props.title}`}
-            </button>
+                <button
+                    type="button"
+                    disabled={this.props.isDisabled}
+                    className={`btn btn-${buttonType}`}
+                    onClick={this.onTouch}
+                    onMouseEnter={this.onMouseEnter}
+                    onMouseLeave={this.onMouseLeave}
+                >
+                    {this.icon()}
+                    {` ${this.props.title}`}
+                </button>
+                {this.tooltip()}
+            </div>
         )
     }
 });

--- a/troposphere/static/js/components/common/ui/Tooltip.react.js
+++ b/troposphere/static/js/components/common/ui/Tooltip.react.js
@@ -1,0 +1,39 @@
+import React from 'react';
+
+export default React.createClass({
+    style: {
+        content: {
+            position: "absolute",
+            bottom: "50px",
+            width: "200px",
+            padding: "10px",
+            background: "black",
+            boxShadow: "0px 2px 5px 0px rgba(0,0,0,.6)",
+            borderRadius: "3px",
+            color: "white",
+            textAlign: "center",
+
+        },
+        originPoint: {
+            position: "absolute",
+            right: "0",
+            left: "0",
+            bottom: "-20px",
+            margin:"auto",
+            width: "10px",
+            border: "solid 10px rgba(0,0,0,0)",
+            borderTop: "solid 10px black",
+        },
+    },
+
+    render: function() {
+        return (
+            <div style={this.style.content} >
+                <div>
+                    {this.props.message}
+                </div>
+                <div style={this.style.originPoint}/>
+            </div>
+        )
+    }
+})

--- a/troposphere/static/js/components/common/ui/Tooltip.react.js
+++ b/troposphere/static/js/components/common/ui/Tooltip.react.js
@@ -1,6 +1,10 @@
 import React from 'react';
 
 export default React.createClass({
+    propTypes: {
+        message: React.PropTypes.string.isRequired,
+    },
+
     style: {
         content: {
             position: "absolute",

--- a/troposphere/static/js/components/common/ui/Tooltip.react.js
+++ b/troposphere/static/js/components/common/ui/Tooltip.react.js
@@ -5,8 +5,30 @@ export default React.createClass({
         message: React.PropTypes.string.isRequired,
     },
 
+    getInitialState: function() {
+        return ({
+            animate: {
+                opacity: "0",
+                bottom: "55px",
+            }
+        })
+    },
+
+    componentDidMount: function() {
+        setTimeout( ()=> {
+            this.setState({
+                animate: {
+                    opacity: "1",
+                    bottom: "60px",
+                }
+            })
+        }
+        , 100);
+    },
+
     style: {
         content: {
+            transition: "all ease .2s",
             position: "absolute",
             bottom: "50px",
             width: "200px",
@@ -31,8 +53,12 @@ export default React.createClass({
     },
 
     render: function() {
+
         return (
-            <div style={this.style.content} >
+            <div style={{
+                ...this.style.content,
+                ...this.state.animate,
+            }} >
                 <div>
                     {this.props.message}
                 </div>

--- a/troposphere/static/js/components/modals/instance/InstanceLaunchWizardModal.react.js
+++ b/troposphere/static/js/components/modals/instance/InstanceLaunchWizardModal.react.js
@@ -538,6 +538,7 @@ export default React.createClass({
                     providerSizeList,
                     resourcesUsed,
                     viewAdvanced: this.viewAdvanced,
+                    hasAdvancedOptions: this.hasAdvancedOptions(),
                 }}
             />
         )

--- a/troposphere/static/js/components/modals/instance/InstanceLaunchWizardModal.react.js
+++ b/troposphere/static/js/components/modals/instance/InstanceLaunchWizardModal.react.js
@@ -59,7 +59,7 @@ export default React.createClass({
         }
 
         return {
-            // State for general operation (switching views, etc) 
+            // State for general operation (switching views, etc)
             view,
             image,
             provider: null,
@@ -148,7 +148,7 @@ export default React.createClass({
 
         // NOTE: This is not nice. This enforces that every time a component
         // mounts updateState gets called. Otherwise, if a component mounts
-        // after data has been fetched, then updateState never gets called. 
+        // after data has been fetched, then updateState never gets called
         this.updateState();
     },
 
@@ -316,9 +316,8 @@ export default React.createClass({
         this.viewBasic()
     },
 
-    onCancelAdvanced: function() {
+    onClearAdvanced: function() {
         this.setState({ attachedScripts: [] });
-        this.viewBasic();
     },
 
     onProjectCreateConfirm: function(name, description) {
@@ -546,7 +545,7 @@ export default React.createClass({
                 attachedScripts={this.state.attachedScripts}
                 onAddAttachedScript={this.onAddAttachedScript}
                 onRemoveAttachedScript={this.onRemoveAttachedScript}
-                cancelAdvanced={this.onCancelAdvanced}
+                onClearAdvanced={this.onClearAdvanced}
                 onSaveAdvanced={this.onSaveAdvanced}
             />
         );

--- a/troposphere/static/js/components/modals/instance/InstanceLaunchWizardModal.react.js
+++ b/troposphere/static/js/components/modals/instance/InstanceLaunchWizardModal.react.js
@@ -361,6 +361,12 @@ export default React.createClass({
     // Validation
     //======================
 
+    hasAdvancedOptions: function() {
+        //TODO: Once more advanced options are added,
+        //this will need to be a recursive check.
+        return (this.state.attachedScripts.length > 0)
+    },
+
     // This is a callback that returns true if the provider size in addition to resources already using
     // will exceed the user's allotted resources.
     exceedsResources: function() {
@@ -547,6 +553,7 @@ export default React.createClass({
                 onRemoveAttachedScript={this.onRemoveAttachedScript}
                 onClearAdvanced={this.onClearAdvanced}
                 onSaveAdvanced={this.onSaveAdvanced}
+                hasAdvancedOptions={this.hasAdvancedOptions()}
             />
         );
     },

--- a/troposphere/static/js/components/modals/instance/launch/components/AdvancedOptionsFooter.react.js
+++ b/troposphere/static/js/components/modals/instance/launch/components/AdvancedOptionsFooter.react.js
@@ -2,6 +2,9 @@ import React from 'react';
 import Button from 'components/common/ui/Button.react';
 
 export default React.createClass({
+    onClearAdvanced: function() {
+        this.props.onClearAdvanced();
+    },
 
     render: function() {
         let saveOptionsDisabled = this.props.saveOptionsDisabled ? "disabled" : "";

--- a/troposphere/static/js/components/modals/instance/launch/components/AdvancedOptionsFooter.react.js
+++ b/troposphere/static/js/components/modals/instance/launch/components/AdvancedOptionsFooter.react.js
@@ -5,25 +5,27 @@ export default React.createClass({
 
     render: function() {
         let saveOptionsDisabled = this.props.saveOptionsDisabled ? "disabled" : "";
+        let clearOptionsIsDisabled = this.props.footerDisabled ?
+            this.props.footerDisabled :
+            this.props.clearOptionsIsDisabled;
+        let tooltipTitle = this.props.clearOptionsIsDisabled ?
+            "Advanced Options have been reset to default values" :
+            "Warning, changes to Advanced Options will be lost";
+
+
+
         return (
             <div className="modal-footer">
                 <Button
                     style={{float:"right"}}
-                    isDisabled={this.props.saveOptionsDisabled}
+                    isDisabled={this.props.footerDisabled}
                     buttonType="default"
                     title="Continue to Launch"
                     onTouch={this.props.onSaveAdvanced}
                 />
                 <Button
-                    tooltip={{
-                        title: "Warning, any changes to Advanced Options will be lost",
-                        placement: "top"
-                    }}
-                    style={{
-                        marginRight:"10px",
-                        float:"right"
-                    }}
-                    icon="refresh"
+                    style={{float:"left"}}
+                    isDisabled={clearOptionsIsDisabled}
                     buttonType="link"
                     title="Restore Advaced Options"
                     onTouch={this.props.onClearAdvanced}

--- a/troposphere/static/js/components/modals/instance/launch/components/AdvancedOptionsFooter.react.js
+++ b/troposphere/static/js/components/modals/instance/launch/components/AdvancedOptionsFooter.react.js
@@ -1,24 +1,33 @@
 import React from 'react';
+import Button from 'components/common/ui/Button.react';
 
 export default React.createClass({
+
     render: function() {
         let saveOptionsDisabled = this.props.saveOptionsDisabled ? "disabled" : "";
         return (
             <div className="modal-footer">
-                <button type="button"
-                    disabled={this.props.saveOptionsDisabled}
-                    className="btn btn-primary pull-right"
-                    onClick={this.props.onSaveAdvanced}
-                >
-                    Save Advanced Options
-                </button>
-                <button type="button"
-                    className="btn btn-default pull-right"
-                    style={{marginRight:"10px"}}
-                    onClick={this.props.cancel}
-                >
-                        Cancel Advanced Options
-                </button>
+                <Button
+                    style={{float:"right"}}
+                    isDisabled={this.props.saveOptionsDisabled}
+                    buttonType="default"
+                    title="Continue to Launch"
+                    onTouch={this.props.onSaveAdvanced}
+                />
+                <Button
+                    tooltip={{
+                        title: "Warning, any changes to Advanced Options will be lost",
+                        placement: "top"
+                    }}
+                    style={{
+                        marginRight:"10px",
+                        float:"right"
+                    }}
+                    icon="refresh"
+                    buttonType="link"
+                    title="Restore Advaced Options"
+                    onTouch={this.props.onClearAdvanced}
+                />
             </div>
         )
     }

--- a/troposphere/static/js/components/modals/instance/launch/components/AdvancedOptionsFooter.react.js
+++ b/troposphere/static/js/components/modals/instance/launch/components/AdvancedOptionsFooter.react.js
@@ -27,8 +27,10 @@ export default React.createClass({
                     style={{float:"left"}}
                     isDisabled={clearOptionsIsDisabled}
                     buttonType="link"
-                    title="Restore Advaced Options"
-                    onTouch={this.props.onClearAdvanced}
+                    title="Restore Default Options"
+                    icon="refresh"
+                    onTouch={this.onClearAdvanced}
+                    tooltip={tooltipTitle}
                 />
             </div>
         )

--- a/troposphere/static/js/components/modals/instance/launch/components/BootScriptOption.react.js
+++ b/troposphere/static/js/components/modals/instance/launch/components/BootScriptOption.react.js
@@ -12,18 +12,15 @@ export default React.createClass({
         }
     },
 
-    componentDidMount: function() {
-    },
-
     onCreateScript: function() {
-        this.props.onDisableSave();
+        this.props.onDisableFooter();
         this.setState({
             view: "CREATESCRIPT_VIEW"
         });
     },
 
     onCloseCreateScript: function() {
-        this.props.onEnableSave();
+        this.props.onEnableFooter();
         this.setState({
             view: "ADDSCRIPT_VIEW"
         })

--- a/troposphere/static/js/components/modals/instance/launch/components/BootScriptOption.react.js
+++ b/troposphere/static/js/components/modals/instance/launch/components/BootScriptOption.react.js
@@ -1,4 +1,3 @@
-
 import React from 'react/addons';
 import AddScripts from './AddScripts.react';
 import CreateScript from './CreateScript.react';

--- a/troposphere/static/js/components/modals/instance/launch/components/InstanceLaunchFooter.react.js
+++ b/troposphere/static/js/components/modals/instance/launch/components/InstanceLaunchFooter.react.js
@@ -11,8 +11,15 @@ export default React.createClass({
         onBack: React.PropTypes.func,
     },
 
-    hasAdvancedOptions: function() {
-        if (!this.props.hasAdvancedOptions) { return }
+    advancedIcon: function() {
+        if (!this.props.hasAdvancedOptions) { 
+            return (
+                <span>
+                    <i className="glyphicon glyphicon-cog"/>
+                    {" "}
+                </span>
+            )
+        }
         return (
             <span>
                 <i className="glyphicon glyphicon-check" style={{color: "green"}}/>
@@ -51,8 +58,7 @@ export default React.createClass({
                 <a className="pull-left btn"
                     disabled={this.props.advancedIsDisabled}
                     onClick={this.props.viewAdvanced}>
-                        { this.hasAdvancedOptions() }
-                        <i className="glyphicon glyphicon-cog"/>
+                        { this.advancedIcon() }
                         {" Advanced Options"}
                 </a>
 

--- a/troposphere/static/js/components/modals/instance/launch/components/InstanceLaunchFooter.react.js
+++ b/troposphere/static/js/components/modals/instance/launch/components/InstanceLaunchFooter.react.js
@@ -42,7 +42,7 @@ export default React.createClass({
                     disabled={this.props.advancedIsDisabled}
                     onClick={this.props.viewAdvanced}>
                         <i className="glyphicon glyphicon-cog"/>
-                        Advanced Options
+                        {" Advanced Options"}
                 </a>
 
                 <button

--- a/troposphere/static/js/components/modals/instance/launch/components/InstanceLaunchFooter.react.js
+++ b/troposphere/static/js/components/modals/instance/launch/components/InstanceLaunchFooter.react.js
@@ -10,6 +10,17 @@ export default React.createClass({
         onCancel: React.PropTypes.func,
         onBack: React.PropTypes.func,
     },
+
+    hasAdvancedOptions: function() {
+        if (!this.props.hasAdvancedOptions) { return }
+        return (
+            <span>
+                <i className="glyphicon glyphicon-check" style={{color: "green"}}/>
+                {" "}
+            </span>
+        )
+    },
+
     renderBack: function() {
         if (this.props.backIsDisabled) {
             return
@@ -37,10 +48,10 @@ export default React.createClass({
             <div className="modal-footer">
 
                 {this.renderBack()}
-
                 <a className="pull-left btn"
                     disabled={this.props.advancedIsDisabled}
                     onClick={this.props.viewAdvanced}>
+                        { this.hasAdvancedOptions() }
                         <i className="glyphicon glyphicon-cog"/>
                         {" Advanced Options"}
                 </a>

--- a/troposphere/static/js/components/modals/instance/launch/steps/AdvancedLaunchStep.react.js
+++ b/troposphere/static/js/components/modals/instance/launch/steps/AdvancedLaunchStep.react.js
@@ -9,7 +9,8 @@ export default React.createClass({
     getInitialState: function() {
         return {
             view: "BOOTSCRIPT_VIEW",
-            saveOptionsDisabled: false,
+            footerDisabled: false,
+
             options:[
                 {
                     name: "Deployment Scripts",
@@ -34,15 +35,15 @@ export default React.createClass({
     },
 
 
-    onDisableSave: function() {
+    onDisableFooter: function() {
         this.setState({
-            saveOptionsDisabled: true
+            footerDisabled: true,
         })
     },
 
-    onEnableSave: function() {
+    onEnableFooter: function() {
         this.setState({
-            saveOptionsDisabled: false
+            footerDisabled: false,
         })
     },
 
@@ -74,15 +75,12 @@ export default React.createClass({
     },
 
     renderBootScripts: function() {
-        // TODO: handle else case
-        if (this.props.bootScriptList) {
             return (
                 <BootScriptOption {...this.props}
-                    onDisableSave={this.onDisableSave}
-                    onEnableSave={this.onEnableSave}
+                    onDisableFooter={this.onDisableFooter}
+                    onEnableFooter={this.onEnableFooter}
                 />
             );
-        }
     },
 
     renderOption2: function() {
@@ -121,7 +119,9 @@ export default React.createClass({
                     </div>
                 </div>
                 <AdvancedOptionsFooter
-                    saveOptionsDisabled={this.state.saveOptionsDisabled}
+                    continueToLaunch={this.state.continueToLaunch}
+                    clearOptionsIsDisabled={!this.props.hasAdvancedOptions}
+                    footerDisabled={this.state.footerDisabled}
                     onSaveAdvanced={this.props.onSaveAdvanced}
                     onClearAdvanced={this.props.onClearAdvanced}
                 />

--- a/troposphere/static/js/components/modals/instance/launch/steps/AdvancedLaunchStep.react.js
+++ b/troposphere/static/js/components/modals/instance/launch/steps/AdvancedLaunchStep.react.js
@@ -123,7 +123,7 @@ export default React.createClass({
                 <AdvancedOptionsFooter
                     saveOptionsDisabled={this.state.saveOptionsDisabled}
                     onSaveAdvanced={this.props.onSaveAdvanced}
-                    cancel={this.props.cancelAdvanced}
+                    onClearAdvanced={this.props.onClearAdvanced}
                 />
             </div>
         )


### PR DESCRIPTION
# Redesigning Basic Launch Footer and Advanced Options Footer for better user Experience

In this PR the Advanced Options Footer in the Instance Launch Modal has be redesigned so that the buttons better represent their actual behavior. 

What was the cancel button is now a "Restore to Default Options" button and includes a tooltip to communicate to the user what to expect as well as what has happened after it is initialized. 

What was the save button is now the "Continue To Launch" button. 

The "Advanced Options" button that takes the user to the Advanced options now indicates to the user that options have been changed by displaying a "check" icon next to it. 

## New Components
Bootstrap (BS) uses the DOM for most of it's implementation, this is an anti pattern in React. For this reason in addition to several other anti patterns, we should be moving away from it. By creating our own reusable components that look the same, we can slowly replace Bootstrap, eventually ridding our selves entirely.

Inline styles were used on the following components because I think this makes them more portable and compossible without the dependencies or adding to global namespace. 
 

- **Tooltip.react:** Since the text in the BS tooltip can't be easily changed on the fly, rebuilding the tooltip as a component made the most sense. `Tooltip.react` currently only takes a message prop but it can be expanded to take a position prop as well for replacing other uses of the BS tooltip in the app. A show prop with the show  / hide state kept in `Tooltip.react` would make animating the component when hiding easier. 

- **Button.react:** Keeping in line with the mission of replacing BS a `Button.react` was created. It made sense that the tool tip be a thing we would want on buttons often including this as part of the 'Button.react` API is a cleaner way of abstracting this complexity out of the call site. Since icon are often used on buttons this was also abstracted into the `Button.react`. The component currently uses BS CSS but once every instance of BS buttons are replaced with this component, restyling the component will be trivial. 

## Screenshot
![footer-redesign](https://cloud.githubusercontent.com/assets/7366338/13824710/70dfa872-eb6c-11e5-9014-597a21abf96d.gif)
