### PR TITLE
Add condition if script is in list

### DIFF
--- a/troposphere/static/js/components/modals/instance/InstanceLaunchWizardModal.react.js
+++ b/troposphere/static/js/components/modals/instance/InstanceLaunchWizardModal.react.js
@@ -301,8 +301,9 @@ export default React.createClass({
 
     onAddAttachedScript: function(value) {
         let attachedScripts = this.state.attachedScripts;
-
-        this.setState({ attachedScripts: [...attachedScripts, value] });
+        if (attachedScripts.indexOf(value) === -1) {
+            this.setState({ attachedScripts: [...attachedScripts, value] });
+        }
     },
 
     onRemoveAttachedScript: function(item) {


### PR DESCRIPTION
Fixes ATMO-1266
Simply won't add the script if it is already in the list.

A message "candybar" could be added to the modal for relaying messages to user.

In this case a message could be triggered in the event handler that lets the user know that they can't add the same script twice. 

Another place to use it would be to confirm that the advanced options has been reset. In [this PR](https://github.com/iPlantCollaborativeOpenSource/troposphere/pull/314)