### PR TITLE
checking for options before 

### DIFF
--- a/troposphere/static/js/stores/BaseStore.js
+++ b/troposphere/static/js/stores/BaseStore.js
@@ -189,7 +189,7 @@ define(function (require) {
 
     // same as fetchFirstPage, but with URL query params
     fetchFirstPageWhere: function(queryParams, options) {
-      if(options.clearQueryCache){
+      if (options && options.clearQueryCache){
         var queryString = buildQueryStringFromQueryParams(queryParams);
         delete this.queryModels[queryString];
       }


### PR DESCRIPTION
Evaluate `options` before `options.clearQueryCache`
to prevent ref of undefined.