### PR TITLE
GB === 1024

### DIFF
--- a/troposphere/static/js/components/modals/instance/launch/components/ResourceGraphs.react.js
+++ b/troposphere/static/js/components/modals/instance/launch/components/ResourceGraphs.react.js
@@ -84,7 +84,7 @@ export default React.createClass({
 
             // Memory have used + will use
             allocationGb = identityProvider.get('quota').memory;
-            gbUsed = resourcesUsed.mem / 1000;
+            gbUsed = resourcesUsed.mem / 1024;
             gbWillUse = size.get('mem');
             gbWillTotal = gbUsed + gbWillUse;
             percentOfGbUsed = Math.round(gbUsed / allocationGb * 100);


### PR DESCRIPTION
Fixes a miscalculation in the resource overview on the Instance Launch where 1GB should have been equal to 1024MB.