### PR TITLE
Only use 'cas_oauth_client' if 'OAuthLoginBackend' is installed

### DIFF
--- a/troposphere/views/emulation.py
+++ b/troposphere/views/emulation.py
@@ -26,7 +26,9 @@ def is_emulated_session(request):
 
 def emulate(request, username):
     if 'access_token' not in request.session:
-        return redirect(cas_oauth_client.authorize_url())
+        if 'iplantauth.authBackends.OAuthLoginBackend' in settings.AUTHENTICATION_BACKENDS:
+            return redirect(cas_oauth_client.authorize_url())
+        return redirect('/application')
 
     if 'emulator_token' in request.session:
         old_token = request.session['emulator_token']


### PR DESCRIPTION
Use `settings.AUTHENTICATION_BACKEND` tuple to determine whether or not to redirect to a CAS client.

For clients that do *not* use CAS, redirect to `/application`.