### PR TITLE
Validate ssh keys

### DIFF
--- a/troposphere/static/js/components/modals/SSHKeyUpload.react.js
+++ b/troposphere/static/js/components/modals/SSHKeyUpload.react.js
@@ -36,7 +36,7 @@ export default React.createClass({
     validateKey: function() {
         let parts = this.state.pubKey.split(/ +/);
         let lengthTest = parts.length == 2 || parts.length == 3
-        let keyTypeTest = /^(ssh-dss|ecdsa-sha2-nistp256|ssh-ed25519|ssh-rsa)/.test(this.state.pubKey);
+        let keyTypeTest = /^(ssh-dss|ecdsa-sha2-nistp256|ssh-ed25519|ssh-rsa) /.test(this.state.pubKey);
 
         return keyTypeTest && lengthTest;
     },


### PR DESCRIPTION
A little research showed the possible ssh key prefixes

     ssh-rsa, ssh-dss, ecdsa-sha2-nistp256, ssh-ed25519

This fix also tests to make sure that the key is either 3 or 2 words. Also,
the key/name are trimmed of white space.

![screen shot 2016-03-25 at 4 21 23 pm](https://cloud.githubusercontent.com/assets/3847314/14056158/a6248e0e-f2a5-11e5-8cc7-c6704652661a.png)

While it is a little hard to tell, that confirm button is actually disabled.