### PR TITLE
Fix provider size lookup when calculating resource usage

### DIFF
--- a/troposphere/static/js/collections/SizeCollection.js
+++ b/troposphere/static/js/collections/SizeCollection.js
@@ -9,7 +9,7 @@ define(function (require) {
   return Backbone.Collection.extend({
     model: Size,
 
-    url: globals.API_V2_ROOT + "/sizes",
+    url: globals.API_V2_ROOT + "/sizes?archived=true",
 
     parse: function (response) {
       this.meta = {

--- a/troposphere/static/js/collections/SizeCollection.js
+++ b/troposphere/static/js/collections/SizeCollection.js
@@ -9,7 +9,7 @@ define(function (require) {
   return Backbone.Collection.extend({
     model: Size,
 
-    url: globals.API_V2_ROOT + "/sizes?archived=true",
+    url: globals.API_V2_ROOT + "/sizes",
 
     parse: function (response) {
       this.meta = {

--- a/troposphere/static/js/components/providers/Instances.react.js
+++ b/troposphere/static/js/components/providers/Instances.react.js
@@ -40,6 +40,7 @@ define(function (require) {
         }),
         sizes = stores.SizeStore.fetchWhere({
           provider__id: provider.id,
+          archived: true,
           page_size: 100
         }),
         content = null;

--- a/troposphere/static/js/components/providers/Resources.react.js
+++ b/troposphere/static/js/components/providers/Resources.react.js
@@ -24,6 +24,7 @@ define(function (require) {
         }),
         sizes = stores.SizeStore.fetchWhere({
           provider__id: provider.id,
+          archived: true,
           page_size: 100
         });
 

--- a/troposphere/static/js/components/providers/Stats.react.js
+++ b/troposphere/static/js/components/providers/Stats.react.js
@@ -79,6 +79,7 @@ define(function (require) {
         instances = stores.InstanceStore.findWhere({'provider.id': provider.id}),
         sizes = stores.SizeStore.fetchWhere({
           provider__id: provider.id,
+          archived: true,
           page_size: 100
         });
 

--- a/troposphere/static/js/models/Identity.js
+++ b/troposphere/static/js/models/Identity.js
@@ -40,8 +40,9 @@ define(function (require) {
 
       return instances.reduce(function (total, instance) {
         if (isRelevant(instance, identityId)) {
-          var size = sizes.get(instance.get('size').id);
-          return total + size.get('cpu');
+          var size = sizes.get(instance.get('size').id),
+            cpuCount = size ? size.get('cpu') : 0;
+          return total + cpuCount;
         } else {
           return total;
         }
@@ -53,9 +54,9 @@ define(function (require) {
 
       return instances.reduce(function (total, instance) {
         if (isRelevant(instance, identityId)) {
-
-          var size = sizes.get(instance.get('size').id);
-          return total + size.get('mem');
+          var size = sizes.get(instance.get('size').id),
+            memConsumed = size ? size.get('mem') : 0;
+          return total + memConsumed;
         } else {
           return total;
         }
@@ -67,7 +68,7 @@ define(function (require) {
 
       return volumes.reduce(function (total, volume) {
         if (isRelevant(volume, identityId)) {
-          var size = volume.get('size');
+          var size = volume.get('size') || 0;
           return total + size;
         } else {
           return total;


### PR DESCRIPTION
If you do not hit `api/v2/size?archived=true`, then you will only get
the _active_ sizes (tiny1, tiny2, small1, medium, etc) for a cloud
(by the providers within a cloud).

So, if you are just looking at _active_ sizes, there is a possibility
that an instance's size is no longer available when fetching data to
show statistics or resource consumption, the number of that ilk.

This commit offers two improvements:
- leverage the fact that Atmosphere API does *not* delete things, it
  merely end-dates them
- handle a situation when the 'size' for the Identity model is not
  known (so be robust ... or dare I say _anti-fragile_)

One notion missing from this is the ability to communicate a statistic
is "uncertain" because of the failure to find the associated CPU or
memory for an instance. If `size.get('cpu')` fails because `size` is
false-y (null, undefined, etc) - there is not a way to say "hey, this
CPU count is *kind of* close, but _not_ exactly right".

- [ ] cherry-pick to `master`
