### PR TITLE
Fix image request bug

### DIFF
--- a/troposphere/static/js/components/admin/ImageMaster.react.js
+++ b/troposphere/static/js/components/admin/ImageMaster.react.js
@@ -17,19 +17,28 @@ define(function (require) {
 
     getInitialState: function(){
         return{
-            refreshing: false
+            refreshing: false,
+            requests: null
         }
     },
 
     componentDidMount: function(){
         stores.StatusStore.getAll();
+        stores.ImageRequestStore.fetchFirstPageWhere(
+            {"active": "true"},
+            {},
+            function(){
+                this.setState({requests: stores.ImageRequestStore.getAll()});
+            }.bind(this));
     },
 
     onRefresh: function(){
         this.setState({refreshing: true});
-        stores.ImageRequestStore.fetchFirstPage(function(){
-            this.setState({refreshing: false});
-        }.bind(this));
+        stores.ImageRequestStore.fetchFirstPageWhere({"active": "true"},
+            {},
+            function(){
+                this.setState({refreshing: false, requests: stores.ImageRequestStore.getAll()});
+            }.bind(this));
     },
 
     onResourceClick: function(request){
@@ -45,8 +54,7 @@ define(function (require) {
     },
 
     render: function () {
-      var requests = stores.ImageRequestStore.getAll();
-
+      var requests = this.state.requests;
       if (requests == null){
         return <div className="loading"></div>
       }

--- a/troposphere/static/js/stores/BaseStore.js
+++ b/troposphere/static/js/stores/BaseStore.js
@@ -188,12 +188,11 @@ define(function (require) {
             }
           }.bind(this));
       }
-      this.isFetching = false;
       return this.models;
     },
 
     // same as fetchFirstPage, but with URL query params
-    fetchFirstPageWhere: function(queryParams, options) {
+    fetchFirstPageWhere: function(queryParams, options, cb) {
       if (options && options.clearQueryCache){
         var queryString = buildQueryStringFromQueryParams(queryParams);
         delete this.queryModels[queryString];
@@ -211,6 +210,9 @@ define(function (require) {
             this.isFetching = false;
             this.models = models;
             this.emitChange();
+            if(cb){
+                cb();
+            }
           }.bind(this));
       }
     },

--- a/troposphere/static/js/stores/BaseStore.js
+++ b/troposphere/static/js/stores/BaseStore.js
@@ -188,6 +188,8 @@ define(function (require) {
             }
           }.bind(this));
       }
+      this.isFetching = false;
+      return this.models;
     },
 
     // same as fetchFirstPage, but with URL query params


### PR DESCRIPTION
**DEPENDS ON ATMO PR 126**
Fixes a bug where images shown in the admin UI only display the user's own requests until clicking the refresh button if the user has loaded the "my requests page."

In addition, instead of fetching all of the image requests and filtering them in `render()` use the request filtering added to the API in Atmo PR 126. This means it no longer takes ~15 seconds to load image requests! Woo!