### PR TITLE
Fix volume update

### DIFF
--- a/troposphere/static/js/models/Volume.js
+++ b/troposphere/static/js/models/Volume.js
@@ -22,9 +22,15 @@ define(function (require) {
     urlRoot: globals.API_V2_ROOT + "/volumes",
 
     parse: function (attributes) {
-      attributes.start_date = new Date(attributes.start_date);
-      attributes.state = new VolumeState({status_raw: attributes.status});
-      attributes.status = attributes.status || "Unknown";
+      if(attributes.start_date){
+        attributes.start_date = new Date(attributes.start_date);
+      }
+      if(attributes.status){
+        attributes.state = new VolumeState({status_raw: attributes.status});
+      }
+      else{
+        attributes.status = "Unknown";
+      }
       attributes.attach_data = extractAttachData(attributes);
       return attributes;
     },


### PR DESCRIPTION
Addresses ATMO-1116
Currently, the response from the API after a successful PATCH to a volume only contains a name and description. This causes other information such as `volume_status` and `start_date` to be lost when updating the backbone model. The information is not regained until another fetch is made to `api/v2/volumes`

The solution is to update the volume model's `parse` method to only update attributes if new attributes exist.