### PR TITLE
[ATMO-1302] Bug, Project Link delete button

### DIFF
--- a/troposphere/static/js/components/projects/resources/link/details/sections/ExternalLinkActions.react.js
+++ b/troposphere/static/js/components/projects/resources/link/details/sections/ExternalLinkActions.react.js
@@ -16,11 +16,11 @@ define(function (require) {
 
     onDelete: function () {
       var project = this.props.project,
-        link = this.props.link;
+        external_link = this.props.link;
 
       modals.ExternalLinkModals.destroy({
-        link: this.props.link,
-        project: this.props.project
+        project,
+        external_link
       });
     },
 


### PR DESCRIPTION
This resolves a name discrepancy that prevented the delete button from working on the Project Link Detail page.