### PR TITLE
[ATMO-1233] resource details select behavior

### DIFF
--- a/troposphere/static/css/app/layout.scss
+++ b/troposphere/static/css/app/layout.scss
@@ -319,15 +319,14 @@
     padding-bottom: 10px;
 
     .detail-label {
-      width: 20%;
+      width: 25%;
       margin-right: 10%;
       display: block;
-      color: #5A5A5A;
       float:left;
     }
 
     .detail-value {
-      width:70%;
+      width: 65%;
       display: block;
       float:left;
     }
@@ -340,9 +339,7 @@
 // This is repeated above because the values are different here and the above are scoped within `.side-panel`
 .detail-label {
     width: 15%;
-    padding-right: 20px;
     display: block;
-    color: #5A5A5A;
     float:left;
     @media(max-width: 700px) {
         width: 100%;
@@ -354,6 +351,7 @@
     width: 85%;
     display: block;
     float: left;
+    padding-left: 10px;
     @media(max-width: 700px) {
         width: 100%;
         float: none;

--- a/troposphere/static/css/app/layout.scss
+++ b/troposphere/static/css/app/layout.scss
@@ -325,16 +325,31 @@
       color: #5A5A5A;
       float:left;
     }
-    
+
     .detail-value {
       width:70%;
       display: block;
       float:left;
     }
-    span {
+    div {
       font-size: 13px;
     }
   }
+}
+
+// This is repeated above because the values are different here and the above are scoped within `.side-panel`
+.detail-label {
+    width: 15%;
+    padding-right: 20px;
+    display: block;
+    color: #5A5A5A;
+    float:left;
+}
+
+.detail-value {
+    width: 85%;
+    display: block;
+    float: left;
 }
 
 .scrollable-content {

--- a/troposphere/static/css/app/layout.scss
+++ b/troposphere/static/css/app/layout.scss
@@ -344,12 +344,20 @@
     display: block;
     color: #5A5A5A;
     float:left;
+    @media(max-width: 700px) {
+        width: 100%;
+        float: none;
+    }
 }
 
 .detail-value {
     width: 85%;
     display: block;
     float: left;
+    @media(max-width: 700px) {
+        width: 100%;
+        float: none;
+    }
 }
 
 .scrollable-content {

--- a/troposphere/static/js/components/projects/common/ResourceDetail.react.js
+++ b/troposphere/static/js/components/projects/common/ResourceDetail.react.js
@@ -16,7 +16,7 @@ define(
       render: function () {
         return (
           <li className="clearfix">
-            <div className="detail-label">{this.props.label + " "}</div>
+            <div className="t-body-2 detail-label">{this.props.label + " "}</div>
             <div className="detail-value" >{this.props.children}</div>
           </li>
         );

--- a/troposphere/static/js/components/projects/common/ResourceDetail.react.js
+++ b/troposphere/static/js/components/projects/common/ResourceDetail.react.js
@@ -16,8 +16,8 @@ define(
       render: function () {
         return (
           <li className="clearfix">
-            <span className="detail-label">{this.props.label}</span>
-            <span className="detail-value" >{this.props.children}</span>
+            <div className="detail-label">{this.props.label + " "}</div>
+            <div className="detail-value" >{this.props.children}</div>
           </li>
         );
       }

--- a/troposphere/static/js/components/projects/resources/instance/details/sections/InstanceDetailsSection.react.js
+++ b/troposphere/static/js/components/projects/resources/instance/details/sections/InstanceDetailsSection.react.js
@@ -31,7 +31,7 @@ define(
         return (
           <div className="resource-details-section section">
             <h4 className="t-title">Instance Details</h4>
-            <ul>
+            <ul style={{paddingLeft: "10px"}}>
               <Status instance={instance}/>
               <Activity instance={instance}/>
               <Size instance={instance}/>


### PR DESCRIPTION
This PR addresses [ATMO-1233](https://pods.iplantcollaborative.org/jira/browse/ATMO-1233). Expected behavior is that two clicks would select a word and three would select the line. When a user tries to select something in the instance details (either on the details page or the details side pane) like for example an ip address, since the label is on the same line it would be expected for convenience that two clicks would select a word and three would select the value like the IP not the label. 

However, in this case currently two clicks on the value selects the label plus the first word of the value, in this case numbers before the `-`, and three clicks selects both the label and the value. 

This PR makes it so that two clicks on the value selects the word without the label and three selects the whole value without the label.

In addition this PR also adds a media query to inline the labels above the value when there isn't enough room. It also makes the labels more dominant for when above the value and right justifies both label and values for a cleaner layout. 


#### Screenshots 
Note: The point of this PR is not to improve the look rather it is to improve functionality. 
Screen shots are provided to simply show that layout is not broken or significantly altered.  

Side Pane Detail Before
<img width="376" alt="screen shot 2016-04-12 at 1 42 11 pm" src="https://cloud.githubusercontent.com/assets/7366338/14475126/3ef5a038-00b5-11e6-92b4-e6798e09f398.png">


Side Pane Detail After
<img width="408" alt="screen shot 2016-04-12 at 1 41 24 pm" src="https://cloud.githubusercontent.com/assets/7366338/14475137/484540b2-00b5-11e6-9b81-e5e21ec6f802.png">


Resource Detail Page Before
<img width="697" alt="screen shot 2016-04-12 at 1 42 23 pm" src="https://cloud.githubusercontent.com/assets/7366338/14475064/ecae82a4-00b4-11e6-8d0c-a3b022f8564d.png">

Resource Detail Page After
<img width="738" alt="screen shot 2016-04-12 at 1 42 40 pm" src="https://cloud.githubusercontent.com/assets/7366338/14475155/62053444-00b5-11e6-943a-8cee2dca8d0f.png">


