### PR TITLE
[ATMO-1107] Fix project resource buttons on mobile

### DIFF
--- a/troposphere/static/css/app/layout.scss
+++ b/troposphere/static/css/app/layout.scss
@@ -259,7 +259,6 @@
 }
 
 .button-bar {
-  border-bottom: 1px solid #dddddd;
   padding: 10px 0px;
 
   button {

--- a/troposphere/static/css/app/layout.scss
+++ b/troposphere/static/css/app/layout.scss
@@ -399,8 +399,12 @@
 // Table styles
 .td-sub-menu {
   float: left;
-  margin-right: 35px;
-  margin-top: 11px;
+  margin-right: 10px;
+  margin-top: 10px;
+  @media(max-width:950px) {
+    float: none;
+    display: block;
+  }
 }
 
 .td-project-content {

--- a/troposphere/static/css/app/utilities.scss
+++ b/troposphere/static/css/app/utilities.scss
@@ -6,3 +6,10 @@
 .u-wordBreak {
     word-break: break-all;
 }
+
+.u-md-pull-right {
+    float: right !important;
+    @media(max-width: 992px) {
+        float: none !important;
+    }
+}

--- a/troposphere/static/js/components/projects/detail/resources/ButtonBar.react.js
+++ b/troposphere/static/js/components/projects/detail/resources/ButtonBar.react.js
@@ -46,28 +46,32 @@ define(function (require) {
       // />
 
       return (
-        <div className="button-bar">
-          <RefreshButton/>
-          <RequestResourcesButton />
-          <Button
-            icon="folder-open"
-            tooltip="Move selected resources"
-            onClick={this.props.onMoveSelectedResources}
-            isVisible={this.props.isVisible}
-            />
-          <Button
-            icon="export"
-            tooltip="Remove selected resources (admin only)"
-            onClick={this.props.onRemoveSelectedResources}
-            style={{"backgroundColor": "bisque"}}
-            isVisible={context.profile.get('is_superuser') && this.props.isVisible}
-            />
-          <ResourceActionButtons
-            onUnselect={this.props.onUnselect}
-            previewedResource={this.props.previewedResource}
-            multipleSelected={this.props.multipleSelected}
-            project={this.props.project}
-            />
+        <div className="clearfix">
+            <div className="button-bar col-md-4">
+                <RefreshButton/>
+                <RequestResourcesButton />
+                <Button
+                    icon="folder-open"
+                    tooltip="Move selected resources"
+                    onClick={this.props.onMoveSelectedResources}
+                    isVisible={this.props.isVisible}
+                />
+                <Button
+                    icon="export"
+                    tooltip="Remove selected resources (admin only)"
+                    onClick={this.props.onRemoveSelectedResources}
+                    style={{"backgroundColor": "bisque"}}
+                    isVisible={context.profile.get('is_superuser') && this.props.isVisible}
+                />
+            </div>
+            <div style={{padding: "10px 0"}} className="col-md-3 u-md-pull-right">
+                <ResourceActionButtons
+                    onUnselect={this.props.onUnselect}
+                    previewedResource={this.props.previewedResource}
+                    multipleSelected={this.props.multipleSelected}
+                    project={this.props.project}
+                />
+            </div>
         </div>
       );
     }

--- a/troposphere/static/js/components/projects/detail/resources/ExternalLinkActionButtons.react.js
+++ b/troposphere/static/js/components/projects/detail/resources/ExternalLinkActionButtons.react.js
@@ -37,7 +37,7 @@ define(function (require) {
       );
 
       return (
-        <div style={{borderLeft: "1px solid #ddd", display: "inline-block", paddingLeft: "10px", float: "right"}}>
+        <div className="clearfix u-md-pull-right">
           {linksArray}
         </div>
       );

--- a/troposphere/static/js/components/projects/detail/resources/ImageActionButtons.react.js
+++ b/troposphere/static/js/components/projects/detail/resources/ImageActionButtons.react.js
@@ -37,7 +37,7 @@ define(function (require) {
       );
 
       return (
-        <div style={{borderLeft: "1px solid #ddd", display: "inline-block", paddingLeft: "10px", float: "right"}}>
+        <div className="clearfix u-md-pull-right">
           {linksArray}
         </div>
       );

--- a/troposphere/static/js/components/projects/detail/resources/InstanceActionButtons.react.js
+++ b/troposphere/static/js/components/projects/detail/resources/InstanceActionButtons.react.js
@@ -46,11 +46,13 @@ define(function (require) {
     render: function () {
       var instance = this.props.instance,
         status = instance.get('state').get('status_raw'),
-        linksArray = [];
+        linksArray = [],
+        style = {marginRight: "10px"};
       if (!this.props.multipleSelected && instance.get('state').isInFinalState()) {
         if (status === "active") {
           linksArray.push(
             <Button
+              style={style}
               key="Suspend"
               icon="pause"
               tooltip="Suspend"
@@ -60,6 +62,7 @@ define(function (require) {
           );
           linksArray.push(
             <Button
+              style={style}
               key="Stop"
               icon="stop"
               tooltip="Stop"
@@ -69,6 +72,7 @@ define(function (require) {
           );
           linksArray.push(
             <Button
+              style={style}
               key="Reboot"
               icon="repeat"
               tooltip="Reboot the selected instance"
@@ -79,6 +83,7 @@ define(function (require) {
         } else if (status === "suspended") {
           linksArray.push(
             <Button
+              style={style}
               key="Resume"
               icon="play"
               tooltip="Resume"
@@ -89,6 +94,7 @@ define(function (require) {
         } else if (status === "shutoff") {
           linksArray.push(
             <Button
+              style={style}
               key="Start"
               icon="play"
               tooltip="Start"
@@ -110,7 +116,7 @@ define(function (require) {
       );
 
       return (
-        <div style={{borderLeft: "1px solid #ddd", display: "inline-block", paddingLeft: "10px", float: "right"}}>
+        <div className="clearfix u-md-pull-right">
           {linksArray}
         </div>
       );

--- a/troposphere/static/js/components/projects/detail/resources/ProjectDetails.react.js
+++ b/troposphere/static/js/components/projects/detail/resources/ProjectDetails.react.js
@@ -128,7 +128,7 @@ define(function (require) {
       isButtonBarVisible = this.state.selectedResources.length > 0;
 
       return (
-        <div className="project-content">
+        <div className="project-content clearfix">
           <ButtonBar
             isVisible={isButtonBarVisible}
             onMoveSelectedResources={this.onMoveSelectedResources}
@@ -141,8 +141,8 @@ define(function (require) {
             project={project}
             />
 
-          <div className="resource-list">
-            <div className="scrollable-content">
+          <div className="resource-list clearfix">
+            <div className="scrollable-content" style={{borderTop: "solid 1px #E1E1E1"}}>
               <InstanceList
                 instances={projectInstances}
                 onResourceSelected={this.onResourceSelected}

--- a/troposphere/static/js/components/projects/detail/resources/VolumeActionButtons.react.js
+++ b/troposphere/static/js/components/projects/detail/resources/VolumeActionButtons.react.js
@@ -34,12 +34,14 @@ define(function (require) {
     render: function () {
       var volume = this.props.volume,
         status = volume.get('state').get('status'),
+        style = {marginRight: "10px"},
         linksArray = [];
 
       // Add in the conditional links based on current machine state
       if (!this.props.multipleSelected && status === "available") {
         linksArray.push(
           <Button
+            style={style}
             key="Attach"
             icon="save"
             tooltip="Attach"
@@ -50,6 +52,7 @@ define(function (require) {
       } else if (!this.props.multipleSelected && status === "in-use") {
         linksArray.push(
           <Button
+            style={style}
             key="Detach"
             icon="open"
             tooltip="Detach"
@@ -70,7 +73,7 @@ define(function (require) {
       );
 
       return (
-        <div style={{borderLeft: "1px solid #ddd", display: "inline-block", paddingLeft: "10px", float: "right"}}>
+        <div className="clearfix u-md-pull-right">
           {linksArray}
         </div>
       );


### PR DESCRIPTION
This PR is a temporary resolution to [ATMO-1107](https://pods.iplantcollaborative.org/jira/browse/ATMO-1107). 

The action buttons above the project resource lists do not retain a proper layout on smaller viewports. 

This PR corrects this using bootstrap grid and a media query. The buttons now form three rows on small viewports. 

This is only meant to be an intermediate solution. There is a contextual disconnect with the items the buttons are affecting. A better solution will be included in a proposed redesign of the page and how actions are associated with the items they affect.
#### Before
<img width="202" alt="screen shot 2016-04-13 at 2 29 49 pm" src="https://cloud.githubusercontent.com/assets/7366338/14510029/41da06ac-0184-11e6-9531-f44fb95fb2a5.png">


#### After
<img width="388" alt="screen shot 2016-04-13 at 2 24 08 pm" src="https://cloud.githubusercontent.com/assets/7366338/14509893/76bdf118-0183-11e6-8d14-4ded95a4dc71.png">
