### PR TITLE
Machine request improvements

### DIFF
--- a/troposphere/static/js/actions/ImageRequestActions.js
+++ b/troposphere/static/js/actions/ImageRequestActions.js
@@ -21,7 +21,6 @@ define(function (require) {
       };
 
       request.set(newAttributes);
-      Router.getInstance().transitionTo("image-request-manager");
       request.save(newAttributes, {patch: true}).done(function () {
         Utils.dispatch(Constants.UPDATE, {model: request});
       });

--- a/troposphere/static/js/components/admin/ImageMaster.react.js
+++ b/troposphere/static/js/components/admin/ImageMaster.react.js
@@ -63,10 +63,6 @@ define(function (require) {
         var requestDate = moment(request.get('start_date'));
         var now = moment();
 
-        if(requestDate.isBefore(now.subtract(7, 'days')) && request.get('status').name != "pending"){
-          return;
-        }
-
         var handleClick = function(){
             this.onResourceClick(request);
         }.bind(this);


### PR DESCRIPTION
Delete leftover filtering from before it was added to the API, and don't redirect back to the admin list after resubmitting a machine request.