### PR TITLE
[ATMO-1248] validate project names for max length

### DIFF
--- a/troposphere/static/js/components/common/ProjectCreateView.react.js
+++ b/troposphere/static/js/components/common/ProjectCreateView.react.js
@@ -13,9 +13,9 @@ export default React.createClass({
 
     validateName: function() {
         let name = this.state.projectName;
-        let maxCharLen = 60;
-        let message = "";
         let hasError = false;
+        let message = "";
+        let maxCharLen = 60;
 
         if (name === "") {
             hasError = true;
@@ -35,8 +35,8 @@ export default React.createClass({
 
     validateDescription: function() {
         let description = this.state.projectDescription;
-        let message = "";
         let hasError = false;
+        let message = "";
 
         if (description === "") {
             hasError = true;

--- a/troposphere/static/js/components/common/ProjectCreateView.react.js
+++ b/troposphere/static/js/components/common/ProjectCreateView.react.js
@@ -11,8 +11,46 @@ export default React.createClass({
         };
     },
 
+    validateName: function() {
+        let name = this.state.projectName;
+        let maxCharLen = 60;
+        let message = "";
+        let hasError = false;
+
+        if (name === "") {
+            hasError = true;
+            message = "This field is required";
+        }
+
+        if (name.length > maxCharLen) {
+            hasError = true;
+            message = `Must be less than ${maxCharLen} charactors long`;
+        }
+
+        return {
+            hasError,
+            message
+        }
+    },
+
+    validateDescription: function() {
+        let description = this.state.projectDescription;
+        let message = "";
+        let hasError = false;
+
+        if (description === "") {
+            hasError = true;
+            message = "This field is required";
+        }
+
+        return {
+            hasError,
+            message
+        }
+    },
+
     isSubmittable: function() {
-        if (this.state.projectName !== "" && this.state.projectDescription !== "") {
+        if (!this.validateName().hasError && !this.validateDescription().hasError) {
             return true;
         }
 
@@ -55,15 +93,12 @@ export default React.createClass({
         let descriptionErrorMessage = null;
 
         if (this.state.showValidation) {
-            if (projectName === "") {
-                nameClassNames = "form-group has-error";
-                nameErrorMessage = "This field is required";
-            }
-
-            if (projectDescription === "") {
-                descriptionClassNames = "form-group has-error";
-                descriptionErrorMessage = "This field is required";
-            }
+            nameClassNames = this.validateName().hasError ?
+                "form-group has-error" : null;
+            nameErrorMessage = this.validateName().message;
+            descriptionClassNames = this.validateDescription().hasError ?
+                "form-group has-error" : null;
+            descriptionErrorMessage = this.validateDescription().message;
         }
 
         return (

--- a/troposphere/static/js/components/common/ProjectCreateView.react.js
+++ b/troposphere/static/js/components/common/ProjectCreateView.react.js
@@ -24,7 +24,7 @@ export default React.createClass({
 
         if (name.length > maxCharLen) {
             hasError = true;
-            message = `Must be less than ${maxCharLen} charactors long`;
+            message = `Must be less than ${maxCharLen} characters long`;
         }
 
         return {


### PR DESCRIPTION
This PR resolves [ATMO-1248](https://pods.iplantcollaborative.org/jira/browse/ATMO-1248) by adding validation to the project Name field so that a user can't submit a new project with a name that exceeds the char limit on the backend. 

The limit on the API is around 250 some characters but we are validated for 60 on the client since longer titles could be problematic with layout in the UI. This can easily be changed in the `maxCharLen` variable. 

#### Screen Shot
![name-len-validation_screen-shot](https://cloud.githubusercontent.com/assets/7366338/14620994/ba72bf48-0574-11e6-9448-049fdc039b30.gif)

  