### PR TITLE
[ATMO-1014] Instance activity to uppercase

### DIFF
--- a/troposphere/static/js/components/projects/detail/resources/tableData/instance/Activity.react.js
+++ b/troposphere/static/js/components/projects/detail/resources/tableData/instance/Activity.react.js
@@ -14,7 +14,7 @@ var Activity = React.createClass({
         var activity = instance.get('state').get('activity');
 
         return (
-          <span>{activity}</span>
+          <span style={{textTransform: "capitalize"}}>{activity}</span>
         );
       }
 });

--- a/troposphere/static/js/components/projects/detail/resources/tableData/instance/Size.react.js
+++ b/troposphere/static/js/components/projects/detail/resources/tableData/instance/Size.react.js
@@ -25,7 +25,7 @@ define(
         }
 
         return (
-          <span>{size.get('name')}</span>
+          <span style={{textTransform: "capitalize"}}>{size.get('name')}</span>
         );
       }
 

--- a/troposphere/static/js/components/projects/detail/resources/tableData/instance/Status.react.js
+++ b/troposphere/static/js/components/projects/detail/resources/tableData/instance/Status.react.js
@@ -1,4 +1,3 @@
-
 define(
   [
     'react',
@@ -33,15 +32,14 @@ define(
 
         var rawStatus = instanceState.get('status_raw');
 
-        var style = {};
-        var capitalizedStatus = status.charAt(0).toUpperCase() + status.slice(1);
+        var style = {textTransform: "capitalize"};
 
         if (instanceState.isDeployError()) {
           return (
           <span>
             <div>
               <StatusLight status="error"/>
-              <span style={style}>{capitalizedStatus}</span>
+              <span style={style}>{status}</span>
             </div>
           </span>
           );
@@ -51,7 +49,7 @@ define(
           <span>
             <div>
               <StatusLight status={lightStatus}/>
-              <span style={style}>{capitalizedStatus}</span>
+              <span style={style}>{status}</span>
             </div>
             <StatusBar state={instanceState} activity={activity}/>
           </span>

--- a/troposphere/static/js/components/projects/detail/resources/tableData/volume/Size.react.js
+++ b/troposphere/static/js/components/projects/detail/resources/tableData/volume/Size.react.js
@@ -15,7 +15,7 @@ define(
 
       render: function () {
         return (
-          <span>{this.props.volume.get('size') + " GB"}</span>
+          <span style={{textTransform: "capitalize"}}>{this.props.volume.get('size') + " GB"}</span>
         );
       }
 

--- a/troposphere/static/js/components/projects/detail/resources/tableData/volume/Status.react.js
+++ b/troposphere/static/js/components/projects/detail/resources/tableData/volume/Status.react.js
@@ -22,7 +22,7 @@ define(function (require) {
         activity = volumeState.get('activity'),
         placeholderMessage = status,
         lightStatus = "active",
-        style = {},
+        style = {textTransform: "capitalize"},
         instance;
 
       if (status === "available") {


### PR DESCRIPTION
This resolves ATMO-1014 where instance activity messages are lowercase.

In addition to the activity field, the other applicable fields were updated. The uppercase JS method on the instance status field was changed to the css solution as this converts all words to uppercase and is consistent with the other modified fields.  

<img width="808" alt="screen shot 2016-04-18 at 3 55 40 pm" src="https://cloud.githubusercontent.com/assets/7366338/14622523/5477edfc-057f-11e6-97b4-e719856f66b5.png">
