### PR TITLE
[ATMO-1342] Add "no favorites" Message to Image Select Step in Launch Modal

### DIFF
--- a/troposphere/static/js/components/modals/instance/launch/steps/ImageSelectStep.react.js
+++ b/troposphere/static/js/components/modals/instance/launch/steps/ImageSelectStep.react.js
@@ -123,8 +123,15 @@ export default React.createClass({
     },
 
     renderNoResultsFor: function () {
-        let query = this.state.query,
+        let query = this.state.query;
+        let message = "";
+        let listView = this.state.listView;
+        if (listView === "Show Favorites") {
+            message = 'You currently have no favorited images';
+        }
+        if (query) {
             message = 'No images found matching "' + query + '"';
+        }
 
         return (
             <div className="filter-description">{message}</div>


### PR DESCRIPTION
The Instance Launch Modal in the Select Image Step with the favorites tab selected, has the wrong message for the case where a user has no favorited images.

This PR adds the message "You currently have no favorited images" when the user has no favorited images. 

<img width="884" alt="screen shot 2016-04-27 at 9 37 31 am" src="https://cloud.githubusercontent.com/assets/7366338/14860041/b3c7ebe4-0c5b-11e6-9687-6dfd6f01437a.png">
