### PR TITLE
[ATMO-1314] Format version change log to preserve line breaks

### DIFF
--- a/troposphere/static/js/components/images/detail/versions/Version.react.js
+++ b/troposphere/static/js/components/images/detail/versions/Version.react.js
@@ -2,14 +2,15 @@ define(function (require) {
 
   var React = require('react/addons'),
       Backbone = require('backbone'),
-      Time = require('components/common/Time.react'),
-      Gravatar = require('components/common/Gravatar.react'),
-      AvailabilityView = require('../availability/AvailabilityView.react'),
+      moment = require('moment'),
+      momentTZ = require('moment-timezone'),
       CryptoJS = require('crypto-js'),
+      showdown = require('showdown'),
       stores = require('stores'),
       globals = require('globals'),
-      moment = require('moment'),
-      momentTZ = require('moment-timezone');
+      Time = require('components/common/Time.react'),
+      Gravatar = require('components/common/Gravatar.react'),
+      AvailabilityView = require('../availability/AvailabilityView.react');
 
   return React.createClass({
     displayName: 'Version',
@@ -93,6 +94,8 @@ define(function (require) {
           type = stores.ProfileStore.get().get('icon_set'),
           owner = image.get('created_by').username,
           changeLog = this.props.version.get('change_log');
+          converter = new showdown.Converter(),
+          changeLogHTML = converter.makeHtml(changeLog);
 
       return (
         <li className="app-card">
@@ -108,7 +111,7 @@ define(function (require) {
                 {isRecommended ? <span className="recommended-tag">Recommended</span> : null}
 
                 {this.renderDateString(version)} by {owner} <br />
-                <p>{changeLog}</p>
+                <div dangerouslySetInnerHTML={{__html: changeLogHTML}}/>
               </div>
                 {this.renderEditLink()}
                 {this.renderAvailability()}


### PR DESCRIPTION
The the version change log is not preserving line breaks included by the author when writing the change log. This is because the value is passed as a string. The showdown module is used to parse the string and wrap paragraph tags where line breaks are present. 

Since JSX would pass this new value as a string making the `<p>` visible in the browser, we use the `dangerouslySetInnerHTM` attribute. _(now i get why it exists 😄 )_

<img width="1288" alt="screen shot 2016-04-27 at 11 19 29 am" src="https://cloud.githubusercontent.com/assets/7366338/14863749/deeb8f1e-0c6b-11e6-94a5-7e324ffd4028.png">
