### PR TITLE
[ATMO-1286] Including asterisks to indicate required fields

### DIFF
--- a/troposphere/static/js/components/modals/link/ExternalLinkCreateModal.react.js
+++ b/troposphere/static/js/components/modals/link/ExternalLinkCreateModal.react.js
@@ -196,13 +196,13 @@ export default React.createClass({
                 </p>
             );
         }
+        let requiredLabel = ( <span style={{color: "red"}}>*</span> );
 
         return (
-            <div role='form'>
-
+            <div className="clearfix" style={{marginBottom: "50px"}} role='form'>
             <div className='form-group'>
                 <label htmlFor='linkName'>
-                    Link Title
+                    Link Title {requiredLabel}
                 </label>
                 <input
                     type="text"
@@ -215,7 +215,7 @@ export default React.createClass({
 
             <div className='form-group'>
                 <label htmlFor='linkSize'>
-                    Link Description
+                    Link Description {requiredLabel}
                 </label>
                 <textarea
                     id='project-description'
@@ -229,7 +229,9 @@ export default React.createClass({
             </div>
 
             <div className='form-group'>
-                <label htmlFor='linkName'>Link URL</label>
+                <label htmlFor='linkName'>
+                    Link URL {requiredLabel}
+                </label>
                 <input
                     type="text"
                     className="form-control"
@@ -239,6 +241,9 @@ export default React.createClass({
                 {formattedLinkError}
             </div>
 
+              <div style={{float: "right"}}>
+                {requiredLabel} Required
+              </div>
             </div>
         );
     },
@@ -266,9 +271,9 @@ export default React.createClass({
                     <div className="modal-content">
                         <div className="modal-header">
                             {this.renderCloseButton()}
-                            <strong>
+                            <h2 className="t-headline">
                                 Create ExternalLink
-                            </strong>
+                            </h2>
                         </div>
                         <div className="modal-body">
                             {this.renderBody()}


### PR DESCRIPTION
## Resolves [ATMO-1286](https://pods.iplantcollaborative.org/jira/browse/ATMO-1286)
Added Asterisks and definition to Create External Link Modal to mark required fields.

<img width="678" alt="screen shot 2016-05-05 at 1 20 54 pm" src="https://cloud.githubusercontent.com/assets/7366338/15056026/8489ba5a-12c4-11e6-8bc9-6d622616b522.png">