### PR TITLE
Initial JavaScript error logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "moment": "^2.10.6",
     "moment-timezone": "^0.4.0",
     "q": "^1.4.1",
+    "raven-js": "^3.0.4",
     "react": "^0.13.0",
     "react-router": "^0.13.0",
     "react-tools": "^0.13.0",

--- a/troposphere/static/js/main.js
+++ b/troposphere/static/js/main.js
@@ -1,4 +1,9 @@
 import bootstrapper from "bootstrapper";
 import "css/app/app.scss";
+import Raven from 'raven-js';
+
+let sentryDSN = 'https://27643f06676048be96ad6df686c17da3@app.getsentry.com/73366';
+
+Raven.config(sentryDSN, {release: '6a34f86c188811e698eb0242ac130001'}).install();
 
 bootstrapper.run();

--- a/troposphere/static/js/public_site/main.js
+++ b/troposphere/static/js/public_site/main.js
@@ -1,3 +1,8 @@
 import bootstrapper from 'public_site/bootstrapper.react';
+import Raven from 'raven-js';
+
+let sentryDSN = 'https://27643f06676048be96ad6df686c17da3@app.getsentry.com/73366';
+
+Raven.config(sentryDSN, {release: '6a34f86c188811e698eb0242ac130001'}).install();
 
 bootstrapper.run();


### PR DESCRIPTION
Currently, we have an organization (CyVerse) & project (Troposphere) in
the Free plan with Sentry:

https://app.getsentry.com/cyverse/troposphere

This only allows 1 member - me, @lenards; we will be evaluate this &
consider "hosted vs on-site" options.