### PR TITLE
Allow enable/disable of ProviderMachines when using the "Edit Version" modal.

### DIFF
--- a/troposphere/static/js/actions/ProviderMachineActions.js
+++ b/troposphere/static/js/actions/ProviderMachineActions.js
@@ -26,24 +26,16 @@ define(function (require) {
     update: function(machine, newAttributes) {
         if(!machine) throw new Error("Missing ProviderMachine");
 
-        if(typeof machine == "object") {
-          machine = new ProviderMachine(machine);
-        }
-
         if(!newAttributes) throw new Error("No attributes to be updated");
 
         machine.set(newAttributes);
-        stores.ProviderMachineStore.removeVersionCache(machine.get('version'));
         Utils.dispatch(ProviderMachineConstants.UPDATE_PROVIDER_MACHINE, machine);
 
         machine.save(newAttributes, {
             patch:true,
         }).done(function(){
-          // UPDATE_MACHINE here if we do NOT want 'optimistic updating'
-          // Othewise, do nothing..
-          stores.ProviderMachineStore.removeVersionCache(machine.get('version'));
+          stores.ProviderMachineStore.removeCache(machine);
           Utils.dispatch(ProviderMachineConstants.UPDATE_PROVIDER_MACHINE, machine);
-
         }).fail(function(){
           var message = "Error updating ProviderMachine " + machine.get('name') + ".";
           NotificationController.error(null, message);

--- a/troposphere/static/js/components/images/detail/launch/ImageLaunchCard.react.js
+++ b/troposphere/static/js/components/images/detail/launch/ImageLaunchCard.react.js
@@ -6,9 +6,10 @@ define(
     'backbone',
     'components/images/common/Bookmark.react',
     'context',
+    'moment',
     'stores'
   ],
-  function (React, Gravatar, Backbone, Bookmark, context, stores) {
+  function (React, Gravatar, Backbone, Bookmark, context, moment, stores) {
 
     // Note:
     // -----
@@ -56,6 +57,15 @@ define(
           bookmark = (
             <Bookmark image={image}/>
           );
+        }
+        if (versions) {
+          var now = moment();
+          version_arr = versions.filter(function(ver) {
+              var end_date = ver.get('end_date');
+
+              return end_date == null || end_date.isAfter(now);
+          });
+          versions = new Backbone.Collection(version_arr);
         }
         //When versions is 'not loaded' OR 'has length > 0', you can launch.
         var canLaunch = (versions !== null && versions.length !== 0) ? true : false;

--- a/troposphere/static/js/components/modals/image_version/ImageVersionEditModal.react.js
+++ b/troposphere/static/js/components/modals/image_version/ImageVersionEditModal.react.js
@@ -47,9 +47,9 @@ define(function (require) {
         versionLicenses: null,
         versionScripts: null,
         versionMemberships: null,
-        versionMinCPU: version.get('min_cpu'),
+        versionMinCPU: (version.get('min_cpu') == null) ? 0 : version.get('min_cpu'),
         // display memory as GB
-        versionMinMem: version.get('min_mem') / 1024
+        versionMinMem: (version.get('min_mem') == null) ? 0 : version.get('min_mem') / 1024
       }
     },
 

--- a/troposphere/static/js/components/modals/image_version/availability/EditAvailabilityView.react.js
+++ b/troposphere/static/js/components/modals/image_version/availability/EditAvailabilityView.react.js
@@ -25,7 +25,7 @@ define(function (require) {
         },
         render: function () {
             var version = this.props.version,
-            provider_machines = stores.ImageVersionStore.getMachines(version.id);
+            provider_machines = stores.ProviderMachineStore.getMachinesForVersion(version);
 
             if (!provider_machines) {
                 return (<div className="loading" />);

--- a/troposphere/static/js/components/modals/image_version/availability/ProviderMachineEditItem.react.js
+++ b/troposphere/static/js/components/modals/image_version/availability/ProviderMachineEditItem.react.js
@@ -21,9 +21,10 @@ define(function (require) {
           };
         },
         getInitialState: function() {
-          var enabled;
+          let enabled,
+          end_date = this.props.provider_machine.get('end_date');
 
-          if (this.props.provider_machine.end_date.isValid()) {
+          if (end_date && end_date.isValid()) {
             enabled = false;
           } else {
             enabled = true;
@@ -52,6 +53,8 @@ define(function (require) {
 
         render: function () {
           var provider_machine = this.props.provider_machine,
+              provider = provider_machine.get('provider'),
+              end_date = provider_machine.get('end_date'),
               classes, activateText, availableText, isDisabled;
           //TODO: Stylize this component
           if (this.state.machineEnabled == true) {
@@ -59,10 +62,10 @@ define(function (require) {
             activateText = "Disable Provider";
             classes = "list-group-item";
           } else {
-            if(! provider_machine.end_date.isValid()) {
+            if(! end_date.isValid()) {
               availableText = "Archiving ..."
             } else {
-              availableText = "Archived as of " + provider_machine.end_date.format("MMM D, YYYY hh:mm a");
+              availableText = "Archived as of " + end_date.format("MMM D, YYYY hh:mm a");
             }
             classes = "list-group-item list-group-item-danger"
             activateText = "Re-Enable Provider";
@@ -71,9 +74,9 @@ define(function (require) {
           isDisabled = (this.allow_edits() == false);
             //NOTE: Machines should be unique per provider..
             return (
-                <li className={classes} key={provider_machine.provider.id}>
+                <li className={classes} key={provider.id}>
                   <div className="container-fluid container-edit-provider-machine">
-                    <div className="col-sm-6" >{provider_machine.provider.name}</div>
+                    <div className="col-sm-6" >{provider.name}</div>
                     <div className="col-sm-3">{availableText}</div>
                     <div className="col-sm-3">
                       <button className="btn btn-xs btn-primary" style={{padding: "1px 5px"}} onClick={this.updateAvailability} disabled={isDisabled} >

--- a/troposphere/static/js/components/modals/image_version/requirements/EditMinimumRequirementsView.react.js
+++ b/troposphere/static/js/components/modals/image_version/requirements/EditMinimumRequirementsView.react.js
@@ -3,6 +3,8 @@ import React from 'react/addons';
 export default React.createClass({
 
   propTypes: {
+    cpu: React.PropTypes.number.isRequired,
+    mem: React.PropTypes.number.isRequired,
     minCPU: React.PropTypes.number,
     minMem: React.PropTypes.number,
     onCPUChange: React.PropTypes.func.isRequired,

--- a/troposphere/static/js/components/modals/instance/InstanceLaunchWizardModal.react.js
+++ b/troposphere/static/js/components/modals/instance/InstanceLaunchWizardModal.react.js
@@ -101,7 +101,9 @@ export default React.createClass({
 
         let providerList;
         if (imageVersion) {
-            providerList = stores.ProviderMachineStore.getMachinesForVersion(imageVersion.id);
+            // FIXME: Querying the PM store to return *providers* based on *version* is Not ideal.
+            //  TODO: stores.ProviderStore.forVersion(imageVersion);
+            providerList = stores.ProviderMachineStore.getProvidersForVersion(imageVersion);
         }
 
         let provider = this.state.provider;
@@ -194,7 +196,9 @@ export default React.createClass({
 
         let providerList;
         if (imageVersion) {
-            providerList = stores.ProviderMachineStore.getMachinesForVersion(imageVersion.id);
+            // FIXME: Querying the PM store to return *providers* based on *version* is Not ideal.
+            //  TODO: stores.ProviderStore.forVersion(imageVersion);
+            providerList = stores.ProviderMachineStore.getProvidersForVersion(imageVersion);
         };
 
         let provider, providerSizeList, identityProvider;
@@ -238,7 +242,9 @@ export default React.createClass({
     },
 
     onVersionChange: function(imageVersion) {
-        let providerList = stores.ProviderMachineStore.getMachinesForVersion(imageVersion.id);
+        // FIXME: Querying the PM store to return *providers* based on *version* is Not ideal.
+        //  TODO: stores.ProviderStore.forVersion(imageVersion);
+        let providerList = stores.ProviderMachineStore.getProvidersForVersion(imageVersion);
         let providerSizeList;
         let providerSize;
         let provider;
@@ -505,7 +511,9 @@ export default React.createClass({
 
         let providerList;
         if (imageVersion) {
-            providerList = stores.ProviderMachineStore.getMachinesForVersion(imageVersion.id);
+            // FIXME: Querying the PM store to return *providers* based on *version* is Not ideal.
+            //  TODO: stores.ProviderStore.forVersion(imageVersion);
+            providerList = stores.ProviderMachineStore.getProvidersForVersion(imageVersion);
         }
 
         let providerSizeList, resourcesUsed;

--- a/troposphere/static/js/stores/BaseStore.js
+++ b/troposphere/static/js/stores/BaseStore.js
@@ -332,6 +332,13 @@ define(function (require) {
         }.bind(this));
       }
     },
+    appendModels: function(moreModels) {
+        if(!this.models) {
+            this.models = moreModels;
+            return;
+        }
+        this.models.add(moreModels.models, { merge: true });
+    },
 
     fetchWhere: function(queryParams) {
       queryParams = queryParams || {};
@@ -349,6 +356,7 @@ define(function (require) {
         }).done(function () {
           this.isFetchingQuery[queryString] = false;
           this.queryModels[queryString] = models;
+          this.appendModels(models);
           this.emitChange();
         }.bind(this));
       }

--- a/troposphere/static/js/stores/ProviderMachineStore.js
+++ b/troposphere/static/js/stores/ProviderMachineStore.js
@@ -33,6 +33,20 @@ define(function (require) {
         }
     },
 
+    getProvidersForVersion: function(version) {
+        var version_key = "version=" + version.id,
+            use_query = "?version_id="+ version.id;
+
+        if(!this.queryModels[version_key]) {
+            this.fetchModelsFor(version_key, use_query);
+        } else {
+            return new Backbone.Collection(
+                            this.queryModels[version_key]
+                            .map((ver) => ver.get('provider'))
+                        );
+        }
+    },
+
     getMachinesForVersion: function(version) {
         var version_key = "version=" + version.id,
             use_query = "?version_id="+ version.id;
@@ -42,7 +56,6 @@ define(function (require) {
         } else {
             return new Backbone.Collection(
                             this.queryModels[version_key]
-                            .map((ver) => ver)
                         );
         }
     },

--- a/troposphere/static/js/stores/ProviderMachineStore.js
+++ b/troposphere/static/js/stores/ProviderMachineStore.js
@@ -10,8 +10,8 @@ define(function (require) {
   var ProviderMachineStore = BaseStore.extend({
     collection: ProviderMachineCollection,
 
-    removeVersionCache: function(version) {
-      var queryParams = {version_id: version.id},
+    removeCache: function(machine) {
+      var queryParams = {machine_id: machine.id},
           queryString = this.generateQueryString(queryParams);
 
       this.queryModels[queryString] = null;
@@ -27,21 +27,22 @@ define(function (require) {
         var image_key = "image=" + image.id;
         var use_query = "?image_id="+image.id
         if(!this.queryModels[image_key]) {
-            this.fetchModelsFor(image_key, use_query);
+            this.fetchWhere(use_query);
         } else {
             return this.queryModels[image_key];
         }
     },
 
     getMachinesForVersion: function(version) {
-        var version_key = "machine=" + version;
-        var use_query = "?version_id="+ version;
+        var version_key = "version=" + version.id,
+            use_query = "?version_id="+ version.id;
+
         if(!this.queryModels[version_key]) {
             this.fetchModelsFor(version_key, use_query);
         } else {
             return new Backbone.Collection(
                             this.queryModels[version_key]
-                            .map((ver) => ver.get('provider'))
+                            .map((ver) => ver)
                         );
         }
     },


### PR DESCRIPTION
Prior to this commit, attempting to end date or un-end date a ProviderMachine would cause console errors.

After this commit, enabling and disabling of ProviderMachines works as expected:
![Highlight Video](http://recordit.co/BiuVwi47P6.gif)

**NOTE:**There was an error when 'saving' the image version (not the provider machines) at the very end of the video.. This was fixed in the final commit (75d50a6)