### PR TITLE
[ATMO-1366] Avoid session cookie clobber

### DIFF
--- a/troposphere/settings/default.py
+++ b/troposphere/settings/default.py
@@ -7,7 +7,7 @@ https://docs.djangoproject.com/en/1.6/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/1.6/ref/settings/
 """
-UI_VERSION = "Larping Loon"
+UI_VERSION = "Nautical Nighthawk"
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os

--- a/troposphere/settings/default.py
+++ b/troposphere/settings/default.py
@@ -98,8 +98,10 @@ SESSION_ENGINE = 'django.contrib.sessions.backends.signed_cookies'
 # code execution vulnerability. So keep this.
 SESSION_SERIALIZER = 'django.contrib.sessions.serializers.JSONSerializer'
 
+SESSION_COOKIE_NAME = 'tropo_sessionid'
+
 # default cookie age to # of seconds in 2 days
-#SESSION_COOKIE_AGE = (2 * 24 * 60 * 60)
+SESSION_COOKIE_AGE = (2 * 24 * 60 * 60)
 
 # default an emulated session to # of seconds in 3 hours
 EMULATED_SESSION_COOKIE_AGE = (3 * 60 * 60)


### PR DESCRIPTION
This uses `settings.SESSION_COOKIE_NAME` to rename the session cookie for Troposphere and avoid clobbering by any subsequent responses following `api/v1/profile`.

## Disappearing Session Cookie
![atmo1366-session-cookie-woes](https://cloud.githubusercontent.com/assets/5923/15550619/2164fab8-2267-11e6-9857-a002c7a67f1c.gif)

## DevTools Network Tab Discovery
![atmo1366-set-cookie](https://cloud.githubusercontent.com/assets/5923/15550581/ea910fea-2266-11e6-8507-d65d226f4be6.gif)


See \[[ATMO-1366](https://pods.iplantcollaborative.org/jira/browse/ATMO-1366)\]