### PR TITLE
ATMO-1319 Bugfixes for `add image to project`

### DIFF
--- a/extras/logrotate.troposphere
+++ b/extras/logrotate.troposphere
@@ -1,0 +1,9 @@
+/opt/dev/troposphere/logs/troposphere.log {
+    daily
+    rotate 10
+    missingok
+    compress
+    delaycompress
+    notifempty
+    copytruncate
+}

--- a/troposphere/static/js/components/modals/project/ProjectAddImageModal.react.js
+++ b/troposphere/static/js/components/modals/project/ProjectAddImageModal.react.js
@@ -18,7 +18,9 @@ define(function (require) {
       getInitialState: function() {
           //Note: This should be available already. But we have a 'fallback' in render()
           projects = stores.ProjectStore.getAll();
-          if(projects) {
+          existing_projects = stores.ProjectImageStore.getProjectsFor(
+              this.props.image.id);
+          if(projects != null && projects.length > 0) {
               projectId = projects.models[0].id;
           } else {
               projectId = 0;
@@ -26,11 +28,26 @@ define(function (require) {
           return {
             projectId: projectId,
             projects: projects,
+            existing: existing_projects,
           }
+      },
+      updateState: function() {
+        let updatedState = {};
+        if(this.state.projects == null) {
+            projects = stores.ProjectStore.getAll();
+            updatedState.projects = projects;
+        }
+        if(this.state.existing == null) {
+            existing = stores.ProjectImageStore.getProjectsFor(
+            this.props.image.id);
+            updatedState.existing = existing;
+        }
+        this.setState(updatedState);
       },
 
       isSubmittable: function () {
-        var hasProject = !!this.state.projectId;
+        let projects = this.filterRemainingProjects();
+        let hasProject = !!this.state.projectId && projects.length > 0;
         return hasProject;
       },
 
@@ -41,10 +58,12 @@ define(function (require) {
 
       componentDidMount: function () {
         stores.ProjectStore.addChangeListener(this.updateState);
+        stores.ProjectImageStore.addChangeListener(this.updateState);
       },
 
       componentWillUnmount: function () {
         stores.ProjectStore.removeChangeListener(this.updateState);
+        stores.ProjectImageStore.removeChangeListener(this.updateState);
       },
 
       //
@@ -85,20 +104,73 @@ define(function (require) {
           <p> {this.props.image.get('name')} </p>
         );
       },
-      renderProjects: function () {
-          if(this.state.projects == null) {
-              projects = stores.ProjectStore.getAll();
+      renderExistingProjects: function () {
+          if(this.state.existing == null) {
               return (<div className='loading' />);
           }
-          if(this.state.projectId == 0) {
-              this.state.projectId = this.state.projects.models[0].id;
+          project_divs = this.state.existing.map(function(existing_project) {
+              return (
+                <div id={existing_project.cid}>
+                  {existing_project.get('project').name}
+                </div>
+              );
+          });
+
+          return (
+             <div className='form-group'>
+               <label htmlFor='existing-project'>Added to Project(s)</label>
+               <div id='existing-project'>
+                 {project_divs}
+                </div>
+             </div>
+          );
+      },
+      filterRemainingProjects: function() {
+          if(this.state.projects == null || this.state.existing == null) {
+              return [];
           }
+          var self = this;
+          var project_arr = this.state.projects.filter(function(project) {
+              needle = project.id;
+              haystack_matches = self.state.existing.filter(
+                  function(existing_project) {
+                      project_id = existing_project.get('project').id;
+                      return project_id == needle;
+              });
+              return haystack_matches.length == 0;
+          });
+          projects = new Backbone.Collection(project_arr);
+          return projects;
+      },
+      renderProjects: function () {
+          if(this.state.projects == null || this.state.existing == null) {
+              return (<div className='loading' />);
+          }
+          let projects = this.filterRemainingProjects();
+          if( projects.length == 0) {
+              //NOTE: This could be better achieved by handling the 'empty case' (Exception message)
+              //separately from the 'null case' (loading)..
+              //Because the component re-used was not in 'common' I will leave this as an exercise
+              //for the reader.
+              return (
+                <div className='form-group'>
+                  <label htmlFor='project'>Project</label>
+                  <select className='form-control' id='project'>
+                    <option value="-1">No Project Available.</option>
+                  </select>
+               </div>
+              );
+          } else if(this.state.projectId == 0) {
+              //Zero represents a value that has not yet been set.
+              this.state.projectId = projects.first().id;
+          }
+
           return (
              <div className='form-group'>
                <label htmlFor='project'>Project</label>
                <ProjectSelect
                  projectId={this.state.projectId}
-                 projects={this.state.projects}
+                 projects={projects}
                  onChange={this.onProjectChange}
                  />
              </div>
@@ -117,6 +189,7 @@ define(function (require) {
                </ul>
              </div>
              {this.renderProjects()}
+             {this.renderExistingProjects()}
 
 
            </div>

--- a/troposphere/static/js/modals/project/addImage.js
+++ b/troposphere/static/js/modals/project/addImage.js
@@ -2,6 +2,7 @@ define(function (require) {
 
   var actions = require('actions'),
     ModalHelpers = require('components/modals/ModalHelpers'),
+    NotificationController = require('controllers/NotificationController'),
     ProjectAddImageModal = require('components/modals/project/ProjectAddImageModal.react');
 
   return {
@@ -15,6 +16,10 @@ define(function (require) {
       ModalHelpers.renderModal(ProjectAddImageModal, props, function (project, image) {
         // Call the ProjectAction directly after confirmation.
         actions.ProjectActions.addResourceToProject(image, project, {silent: false});
+        // Delete the cached query - Its results are invalid now.
+        delete stores.ProjectImageStore.queryModels["?application__id="+image.id];
+        // Notify the user of the successful addition.
+        NotificationController.success(null, "Image " + image.get('name') + " added to Project " + project.get('name') + ".");
 
       });
     }

--- a/troposphere/static/js/stores/ImageStore.js
+++ b/troposphere/static/js/stores/ImageStore.js
@@ -64,6 +64,20 @@ define(function (require) {
 
         return project_images;
     },
+    getProjects: function(imageId) {
+        /**
+         * Returns the list of projects *OR* null && Starts the 'fetch' process.
+         */
+        var _projects = stores.ProjectImageStore.fetchWhere({
+            application__id: imageId
+        });
+        //TODO: _projects is returning an OBJECT instead of an array?!?!
+        if(!_projects) {
+            return null;
+        }
+
+        return _projects;
+    },
     getVersions: function(imageId) {
         /**
          * Returns the list of versions *OR* null && Starts the 'fetch' process.

--- a/troposphere/static/js/stores/ProjectImageStore.js
+++ b/troposphere/static/js/stores/ProjectImageStore.js
@@ -67,6 +67,14 @@ define(function (require) {
         return allImages.get(project_image.get('image').id);
       });
       return new ImageCollection(images);
+    },
+
+    getProjectsFor: function (imageId) {
+      var allProjects = stores.ImageStore.getProjects(imageId);
+      if (!imageId) return;
+      if (!allProjects) return;
+
+      return allProjects;
     }
   });
 


### PR DESCRIPTION
- [x] No longer fails when users with 0 projects click 
- [x] Remove existing projects from the list when they are 
- [x] Notify the user of the successful addition
- [x] Provide a list of existing projects in the modal.
- [x] Provide methods to query for list of projects an image is a member of.

See [ATMO-1319](https://pods.iplantcollaborative.org/jira/browse/ATMO-1319).