### PR TITLE
Enable HTTP/2 module in Nginx site configuration

### DIFF
--- a/extras/nginx/site.conf.j2
+++ b/extras/nginx/site.conf.j2
@@ -4,7 +4,7 @@ server {
 }
 
 server {
-    listen   443;
+    listen   443 {% if ENABLE_HTTP2 -%}ssl http2{%- endif %};
 
     server_name {{ SERVER_URL }};
     charset utf-8;

--- a/variables.ini.dist
+++ b/variables.ini.dist
@@ -4,6 +4,7 @@ ASSETS_PATH =
 THEME_PATH =
 
 [nginx]
+ENABLE_HTTP2 = ; enable if http2 module available in nginx build
 BUNDLE_FILE =
 TROPOSPHERE_PATH =
 LOCATIONS_DIR =


### PR DESCRIPTION
Uses a variable, `ENABLE_HTTP2`, within `[nginx]` section to alter the `site.conf` produced. 

See [ATMO-1372](https://pods.iplantcollaborative.org/jira/browse/ATMO-1372)