### PR TITLE
Fix tag component not loading

### DIFF
--- a/troposphere/static/js/components/modals/instance/InstanceImageWizardModal.react.js
+++ b/troposphere/static/js/components/modals/instance/InstanceImageWizardModal.react.js
@@ -43,7 +43,6 @@ define(function (require) {
         step: 1,
         title: "Image Info", // Identical to first breadcrumb name
         name: this.props.instance.get('image').name,
-        description: this.props.instance.get('image').description,
         versionName: this.props.versionName || "1.0",
         versionChanges: "",
         imageTags: null,
@@ -174,13 +173,15 @@ define(function (require) {
           helpLink = stores.HelpLinkStore.get('request-image'),
           activeScripts = this.state.activeScripts;
 
+      let description = instance.get('image').description;
+
       switch(step) {
         case IMAGE_INFO_STEP:
           return (
             <ImageInfoStep
               name={this.state.name}
-              description={this.state.description}
               imageTags={this.state.imageTags}
+              description={description}
               instance={instance}
               imageOwner={this.props.imageOwner}
               onPrevious={this.onPrevious}

--- a/troposphere/static/js/components/modals/instance/InstanceImageWizardModal.react.js
+++ b/troposphere/static/js/components/modals/instance/InstanceImageWizardModal.react.js
@@ -67,12 +67,17 @@ define(function (require) {
       };
     },
 
-    getState: function () {
-      return this.state;
-    },
-
     updateState: function () {
-      if (this.isMounted()) this.setState(this.getState());
+        let instance = this.props.instance;
+
+        let imageTags = this.state.imageTags;
+        if (instance) {
+            imageTags = stores.InstanceTagStore.getTagsFor(instance);
+        }
+
+        this.setState({
+            imageTags,    
+        });
     },
 
     componentDidMount: function () {

--- a/troposphere/static/js/components/modals/instance/image/components/Tags.react.js
+++ b/troposphere/static/js/components/modals/instance/image/components/Tags.react.js
@@ -18,6 +18,7 @@ define(function (require) {
 
     getInitialState: function () {
       return {
+        tags: null,
         query: "",
                 newTagName: "",
                 newTagDescription: "",
@@ -25,7 +26,23 @@ define(function (require) {
       }
     },
 
-        createTagAndAddToImage: function(){
+    componentDidMount: function() {
+        stores.TagStore.addChangeListener(this.updateState);
+        this.updateState();
+    },
+
+    componentWillUnmount: function() {
+        stores.TagStore.removeChangeListener(this.updateState);
+    },
+
+    updateState: function() {
+        this.setState({
+            tags: stores.TagStore.getAll(),
+        });
+    },
+
+
+        createTagAndAddToImage: function() {
             var newTag = actions.TagActions.create({name: this.state.newTagName, description: this.state.newTagDescription});
             this.props.onTagAdded(newTag);
             this.setState({newTagName: "", newTagDescription: "", showTagCreateForm: false});
@@ -56,7 +73,7 @@ define(function (require) {
 
     render: function () {
       var imageTags = this.props.imageTags,
-        tags = stores.TagStore.getAll(),
+        tags = this.state.tags,
         query = this.state.query,
                 tagCreateForm = null;
 

--- a/troposphere/static/js/components/modals/instance/image/steps/ImageInfoStep.react.js
+++ b/troposphere/static/js/components/modals/instance/image/steps/ImageInfoStep.react.js
@@ -159,7 +159,7 @@ define(function (require) {
             onTagAdded={this.onTagAdded}
             onTagRemoved={this.onTagRemoved}
             onTagCreated={this.onTagCreated}
-            imageTags={this.state.imageTags}
+            imageTags={new Backbone.Collection(this.state.imageTags)}
             />
         </div>
       );


### PR DESCRIPTION
Navigate to an active instance, click image, scroll to bottom of modal. `Tags` component loads after infinity seconds.

![](http://recordit.co/E3dqaUqcLG.gif)

Now it loads properly. I abstained from formatting these commits/files to reduce conflict with later releases.