### PR TITLE
Define a utility function to track actions

### DIFF
--- a/troposphere/static/js/actions/HelpActions.js
+++ b/troposphere/static/js/actions/HelpActions.js
@@ -7,6 +7,7 @@ import Constants from 'constants/ResourceRequestConstants';
 import actions from 'actions';
 import stores from 'stores';
 
+import { trackAction } from 'utilities/userActivity';
 
 export default {
     sendFeedback: function (feedback) {
@@ -38,6 +39,7 @@ export default {
         contentType: 'application/json',
         success: function (data) {
           NotificationController.info("Thanks for your feedback!", "Support has been notified.");
+          trackAction('sent-feedback');
         },
         error: function (response) {
           var errorMessage,

--- a/troposphere/static/js/components/Header.react.js
+++ b/troposphere/static/js/components/Header.react.js
@@ -6,7 +6,7 @@ import MaintenanceMessageBanner from './MaintenanceMessageBanner.react';
 import globals from 'globals';
 import Router from 'react-router';
 
-
+import { trackAction } from 'utilities/userActivity';
 import { hasLoggedInUser } from 'utilities/profilePredicate';
 
 let Link = Router.Link;
@@ -167,12 +167,10 @@ let Header = React.createClass({
     renderBetaToggle: function () {
       if (!window.show_troposphere_only) {
         let trackEvent = (e) => {
-            if (window.Intercom) {
-                window.Intercom('trackEvent', 'switch-ui', {
+            trackAction('switch-ui', {
                     user_interface: 'troposphere-to-airport'
-                });
-                window.Intercom('trackEvent', 'switch-to-airport');
-            }
+            });
+            trackAction('switch-to-airport');
         };
         return (
           <div className="beta-toggle">

--- a/troposphere/static/js/utilities/userActivity.js
+++ b/troposphere/static/js/utilities/userActivity.js
@@ -1,0 +1,42 @@
+
+/**
+ * Sends an event to Intercom to record a action done by a user
+ *
+ * Disabling this function is possible by setting `intercom_app_id` to `null`.
+ *
+ * "Events are information on what a user did and when they did it" [1].
+ *
+ * Advice on `actionName`:
+ *
+ * "We also recommmend sending event names that combine a past tense verb and
+ *  nouns, such as 'created-project'." [1]
+ *
+ * So a good event name is the combination of _'past_tense_verb-noun' to
+ * provide readability:
+ * - 'reported-volume'
+ * - 'sent-feedback'
+ * - 'launched-instance'
+ * - 'rebooted-instance'
+ *
+ *
+ * @param {string} actionName - name of the event performed, should be a
+ *  combination of past tense verb and noun
+ * @param {object} details - any information associated with the event; this
+ *  can be simple objects, strings, numbers, dates, links [2]
+ *
+ * [1] https://developers.intercom.io/reference#events
+ * [2] https://developers.intercom.io/reference#event-metadata-types
+ */
+const trackAction = (actionName, details) => {
+    try {
+        if (window.intercom_app_id && window.Intercom) {
+            window.Intercom('trackEvent', actionName, details);
+        }
+    } catch (e) {
+        // optionally - can call out to Raven
+        // ... this operation is not a critical path, so swallowing the error
+        //     for now is not as objectionable as it normally would be
+    }
+}
+
+export { trackAction };


### PR DESCRIPTION
Using Intercom to note actions, we are looking to capture meaningful
actions in a way to guide usability & user experience design. This
is *not* just a clickstream of "events", but actions that help carry
out the completion of goals and provide an opportunity for support
staff to intervene/assist.

Detailed usage comments for `trackAction` are provided within the
module. Notable, `actionName`s should be a past tense verb joined
together with a noun by a delimiter:

- 'created-project', 'reported-instance', 'sent-feedback'

These actions can be used to segment and define a community cohort.