### PR TITLE
Change refs calls to remove getDOMNode()

### DIFF
--- a/troposphere/static/js/components/modals/instance/launch/steps/ImageSelectStep.react.js
+++ b/troposphere/static/js/components/modals/instance/launch/steps/ImageSelectStep.react.js
@@ -247,7 +247,7 @@ export default React.createClass({
     },
 
     focusSearchInput: function() {
-        this.refs.searchField.getDOMNode().focus();
+        this.refs.searchField.focus();
     },
 
     renderSearchInput: function() {


### PR DESCRIPTION
With React 0.14, they saw that when you got a DOM node from a ref
you were almost always manipulation that node,

```
this.refs.element.getDOMNode()
```

So, `this.refs.elements` is *now* the node element.

See commit 9c8ebcda2d6f32e0d0f612cc9ae322d1298e0e10