### PR TITLE
Improve eslint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+troposphere/static/js/lib

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,17 +1,22 @@
 {
+    "extends": ["eslint:recommended", "plugin:react/recommended"],
     "rules": {
+        
+        // See docs here: http://eslint.org/docs/rules/
         "linebreak-style": [
-            2,
+            "error",
             "unix"
         ],
-/*
-        "semi": [
-            2,
-            "always"
-        ],
- */
-        "no-debugger": 2,
-        "no-mixed-spaces-and-tabs": 2,
+        "no-mixed-spaces-and-tabs": "error",
+        "comma-dangle": "off",
+
+        // See docs here: https://github.com/yannickcr/eslint-plugin-react/tree/master/docs/rules
+        "react/no-is-mounted": "off",
+        "react/display-name": "off",
+        "react/no-danger": "off",
+        "react/no-did-mount-set-state": "off",
+        "react/no-direct-mutation-state": "off",
+        "react/prop-types": "off",
     },
     "env": {
         "es6": true,

--- a/.eslintrc.strict
+++ b/.eslintrc.strict
@@ -1,0 +1,21 @@
+{
+    "extends": ["eslint:recommended", "plugin:react/recommended"],
+    "rules": {
+        "linebreak-style": [
+            "error",
+            "unix"
+        ],
+        "no-mixed-spaces-and-tabs": "error",
+    },
+    "env": {
+        "es6": true,
+        "browser": true
+    },
+    "parser": "babel-eslint",
+    "ecmaFeatures": {
+        "jsx": true,
+    },
+    "plugins": [
+        "react"
+    ]
+}

--- a/.eslintrc.travis
+++ b/.eslintrc.travis
@@ -1,0 +1,21 @@
+{
+    "rules": {
+        "linebreak-style": [
+            2,
+            "unix"
+        ],
+        "no-debugger": 2,
+        "no-mixed-spaces-and-tabs": 2,
+    },
+    "env": {
+        "es6": true,
+        "browser": true
+    },
+    "parser": "babel-eslint",
+    "ecmaFeatures": {
+        "jsx": true,
+    },
+    "plugins": [
+        "react"
+    ]
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ node_js:
   - "4.2"
 script:
   - "npm run build"
-  - "npm run lint"
+  - "npm run travis-lint"

--- a/LINT.md
+++ b/LINT.md
@@ -1,0 +1,47 @@
+LINT.md
+=======
+
+This is a document to aid in linting of the project.
+
+### Conventions
+
+.eslintrc
+  - Should make you happy when it fails
+  - Shouldn't get in the way
+  - Blacklist anything nit-picky
+
+.eslintrc.strict
+  - Should make you happy when it mostly succeeds
+  - Ideal for subset of the codebase, i.e. changes in a feature branch
+
+.eslintrc.travis
+  - Should rarely error out
+
+### Documentation
+- [eslint](http://eslint.org/docs/rules/)
+- [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react/tree/master/docs/rules)
+
+### Running the linters
+
+This is a quick way to get the eslint command
+```bash
+npm i -g npm-run
+alias eslint=npm-run eslint
+```
+
+Basic lint commands
+```bash
+eslint troposphere/static/js
+eslint -c .eslintrc.strict troposphere/static/js
+```
+
+Run the strict linter on current feature branch
+```bash
+TRUNC=master
+FEATURE="$(git rev-parse --abbrev-ref HEAD)"
+FILES=$(git diff $TRUNC..$FEATURE --name-only | grep 'troposphere/static/js.*js$')
+eslint -c .eslintrc.strict $FILES
+```
+**Note:** `eslint` will **always** use the `.eslintrc` despite the use of the
+`-c` flag.  The `--no-eslintrc` option will disable this. To be sure which
+rules are being included use `--print-config`.

--- a/README.md
+++ b/README.md
@@ -29,3 +29,7 @@ Finally run:
 ```bash
 npm run server
 ```
+
+### Linting
+
+See `LINT.md`

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "jenkins": "webpack --profile --colors --",
     "test": "echo \"Error: no test specified\" && exit 1",
     "stats": "webpack --profile --json > stats.json",
-    "lint": "eslint --ignore-pattern './troposphere/static/js/lib/**/*.js' troposphere/static/js",
+    "lint": "eslint troposphere/static/js",
+    "travis-lint": "eslint -c .eslintrc.travis --no-eslintrc troposphere/static/js",
     "lint-pre-commit": "eslint --stdin",
     "format-check": "esformatter -c .esformatter --diff $(git diff --diff-filter=M --name-only | grep js$) || exit 0",
     "format": "esformatter -c .esformatter -i $(git diff --diff-filter=M --name-only | grep js$)"


### PR DESCRIPTION
The main purpose of this PR is to improve linting. This should have no effect on `travis-ci`. But running `npm run lint` will produce errors. I think it would be good to keep _style_ stuff in `.esformatter` and _semantic_ stuff in `.eslintrc`. Because this doesn't break existing stuff it should be fine to merge in, and pr's can be made for meeting everyones preferences.

See [LINT.md](https://github.com/iPlantCollaborativeOpenSource/troposphere/blob/f37f04d64eb3ffabb4e848f91766c00ea686c3a1/LINT.md) for more thoughts.