### PR TITLE
Clear favorites list on Instance Launch Wizard

### DIFF
--- a/troposphere/static/js/components/admin/SecondaryAdminNavigation.react.js
+++ b/troposphere/static/js/components/admin/SecondaryAdminNavigation.react.js
@@ -22,7 +22,8 @@ export default React.createClass({
     },
 
     render: function () {
-      var requests = stores.ResourceRequestStore.findWhere({
+      var request_count = null,
+          requests = stores.ResourceRequestStore.findWhere({
           'status.name': 'pending'
         });
       if (!requests) {

--- a/troposphere/static/js/components/modals/instance/launch/steps/ImageSelectStep.react.js
+++ b/troposphere/static/js/components/modals/instance/launch/steps/ImageSelectStep.react.js
@@ -20,6 +20,7 @@ export default React.createClass({
     ALL_VIEW: 2,
 
     getInitialState: function() {
+        stores.ImageStore.clearCacheWhere({bookmarked: true});
         return {
             images: null,
             query: null,

--- a/troposphere/static/js/stores/BaseStore.js
+++ b/troposphere/static/js/stores/BaseStore.js
@@ -472,6 +472,20 @@ _.extend(Store.prototype, Backbone.Events, {
     pollUntilBuildIsFinished: function(model) {
         setTimeout(this.pollNowUntilBuildIsFinished.bind(this, model), this.pollingFrequency);
     },
+
+    clearCache: function() {
+        this.pollingModels = {};
+        this.models = null;
+        this.queryModels = {};
+    },
+    clearCacheWhere: function(queryParams) {
+        queryParams = queryParams || {};
+        var queryString = buildQueryStringFromQueryParams(queryParams);
+
+        if (this.queryModels[queryString]) {
+            delete this.queryModels[queryString];
+        }
+    },
 });
 
 Store.extend = Backbone.Model.extend;


### PR DESCRIPTION
Fixed a bug where Favorites tab would not update after user-initiated changes were made. This hotfix solves the problem by clearing the 'favorites' cache key on each creation of the InstanceLaunchWizard.