### PR TITLE
Validate name when changing versionName or Image

### DIFF
--- a/troposphere/static/js/components/modals/image_version/ImageSelect.react.js
+++ b/troposphere/static/js/components/modals/image_version/ImageSelect.react.js
@@ -21,7 +21,7 @@ export default React.createClass({
       let username = stores.ProfileStore.get().get('username'),
           images = stores.ImageStore.fetchWhere({
               created_by__username: username
-          })
+          });
       return images;
     },
 

--- a/troposphere/static/js/components/modals/image_version/ImageSelect.react.js
+++ b/troposphere/static/js/components/modals/image_version/ImageSelect.react.js
@@ -11,12 +11,18 @@ export default React.createClass({
     },
 
     handleChange: function(e){
-      let image_id = e.target.value;
-      let username = stores.ProfileStore.get().get('username'),
-          image = stores.ImageStore.fetchWhere({
-          created_by__username: username
-      }).get(image_id);
+      let image_id = e.target.value,
+          images = this.getUserImages(),
+          image = images.get(image_id);
       this.props.onChange(image);
+    },
+
+    getUserImages: function() {
+      let username = stores.ProfileStore.get().get('username'),
+          images = stores.ImageStore.fetchWhere({
+              created_by__username: username
+          })
+      return images;
     },
 
     renderImage: function(image){
@@ -29,10 +35,7 @@ export default React.createClass({
 
     render: function () {
       var imageId = this.props.imageId,
-          username = stores.ProfileStore.get().get('username'),
-          images = stores.ImageStore.fetchWhere({
-            created_by__username: username
-          }),
+          images = this.getUserImages(),
           options;
 
       if(!images) return <div className="loading"/>;

--- a/troposphere/static/js/components/modals/image_version/ImageSelect.react.js
+++ b/troposphere/static/js/components/modals/image_version/ImageSelect.react.js
@@ -11,7 +11,12 @@ export default React.createClass({
     },
 
     handleChange: function(e){
-      this.props.onChange(e.target.value)
+      let image_id = e.target.value;
+      let username = stores.ProfileStore.get().get('username'),
+          image = stores.ImageStore.fetchWhere({
+          created_by__username: username
+      }).get(image_id);
+      this.props.onChange(image);
     },
 
     renderImage: function(image){

--- a/troposphere/static/js/components/modals/image_version/ImageVersionEditModal.react.js
+++ b/troposphere/static/js/components/modals/image_version/ImageVersionEditModal.react.js
@@ -148,10 +148,8 @@ export default React.createClass({
     },
 
     onImageSelected: function (image) {
-      let versionNameError = "";
-      if(image) {
-        versionNameError = this.validateName(image, this.state.versionName) ? "" : "There already exists a version named '"+this.state.versionName+"' in application '"+image.get('name')+"'.";
-      }
+      let versionNameError = this.getVersionNameError(image, this.state.versionName);
+
       this.setState({
           versionImage: image,
           versionNameError: versionNameError
@@ -169,17 +167,30 @@ export default React.createClass({
     //
     validateName: function(image, name) {
         let orig_version = this.props.version,
-        versions = image.get('versions');
+            versions = image.get('versions');
+        name = (name == null) ? "" : $.trim(name).toLowerCase();
 
-        name = $.trim(name).toLowerCase();
         versions = versions.filter(function(version) {
-            return (version.id !== orig_version.id && version.name.toLowerCase() === name);
+            return (version.id !== orig_version.id &&
+                (version.name && version.name.toLowerCase() === name) );
         });
         return versions.length == 0;
     },
+    getVersionNameError: function(image, name) {
+        if(image == null) {
+            return "";
+        }
+        if(name == null) {
+            return "";
+        }
+        let versionNameError = this.validateName(image, name) ? ""
+            : `There already exists a version named '${name}' in application '${image.get('name')}'.`;
+        return versionNameError;
+    },
     handleNameChange: function(name){
       let image = this.state.versionImage;
-      let versionNameError = this.validateName(image, name) ? "" : "There already exists a version named '"+name+"' in application '"+image.get('name')+"'.";
+      let versionNameError = this.getVersionNameError(image,name);
+
       this.setState({
           versionName: name,
           versionNameError: versionNameError
@@ -311,10 +322,7 @@ export default React.createClass({
         ended = this.state.versionEndDate;
       }
 
-      if(name == null) {
-          return (<div className="loading"/>);
-      }
-      if(images == null) {
+      if(name == null || images == null) {
           return (<div className="loading" />);
       }
       licensesView = (

--- a/troposphere/static/js/components/modals/image_version/ImageVersionEditModal.react.js
+++ b/troposphere/static/js/components/modals/image_version/ImageVersionEditModal.react.js
@@ -177,10 +177,7 @@ export default React.createClass({
         return versions.length == 0;
     },
     getVersionNameError: function(image, name) {
-        if(image == null) {
-            return "";
-        }
-        if(name == null) {
+        if(image == null || name == null) {
             return "";
         }
         let versionNameError = this.validateName(image, name) ? ""

--- a/troposphere/static/js/components/modals/instance/image/components/VersionName.react.js
+++ b/troposphere/static/js/components/modals/instance/image/components/VersionName.react.js
@@ -12,7 +12,7 @@ export default React.createClass({
     },
     getDefaultProps: function() {
       return {
-        create: true,
+        create: false,
         update: false,
       };
     },


### PR DESCRIPTION
Allowing the user to avoid submitting a "valid form" only to receive an API conflict.

Example provided: ![Example Recorded](http://g.recordit.co/vVHPRaDhic.gif)

---
**NOTE:** The modal was not submittable because there was no description set for the version, and that is required in Troposphere.

**NOTE2:** I have commented out the `EditAvailabilityView` and replaced it with the Text `Coming Soon` because it rendered the `Advanced Option` portion of the screen inoperable. @cdosborn has volunteered to take a look at that as a bugfix for the P release.