### PR TITLE
Removed deprecated variable TEMPLATE_DEBUG

### DIFF
--- a/troposphere/settings/default.py
+++ b/troposphere/settings/default.py
@@ -18,8 +18,6 @@ SERVER_URL="https://localhost"
 
 DEBUG = False
 
-TEMPLATE_DEBUG = False
-
 APPEND_SLASH = False
 
 ALLOWED_HOSTS = []
@@ -87,6 +85,7 @@ TEMPLATES = [
                 'django.template.context_processors.tz',
                 'django.contrib.messages.context_processors.messages',
             ],
+            'debug': False
         },
     }
 ]

--- a/troposphere/settings/local.py.j2
+++ b/troposphere/settings/local.py.j2
@@ -3,7 +3,10 @@ import sys
 globals().update(vars(sys.modules['troposphere.settings']))
 
 DEBUG = {{ DEBUG }}
-TEMPLATE_DEBUG = {{ DEBUG }}
+
+if len(TEMPLATES) > 0 and 'OPTIONS' in TEMPLATES[0]:
+    if 'debug' in TEMPLATES[0]['OPTIONS']:
+        TEMPLATES[0]['OPTIONS']['debug'] = {{ DEBUG }}
 
 SECRET_KEY="{{ SECRET_KEY }}"
 SERVER_URL="{{ SERVER_URL }}"

--- a/troposphere/settings/local.py.j2
+++ b/troposphere/settings/local.py.j2
@@ -4,9 +4,11 @@ globals().update(vars(sys.modules['troposphere.settings']))
 
 DEBUG = {{ DEBUG }}
 
+{% if DEBUG -%}
 if len(TEMPLATES) > 0 and 'OPTIONS' in TEMPLATES[0]:
     if 'debug' in TEMPLATES[0]['OPTIONS']:
         TEMPLATES[0]['OPTIONS']['debug'] = {{ DEBUG }}
+{%- endif %}
 
 SECRET_KEY="{{ SECRET_KEY }}"
 SERVER_URL="{{ SERVER_URL }}"


### PR DESCRIPTION
This pull request eliminates a warning related to changes in the Django Template from the 1.8 to 1.9 release. 

> If it sets TEMPLATE_DEBUG to a value that differs from DEBUG, include that value under the 'debug' key in 'OPTIONS'.

source: https://docs.djangoproject.com/en/1.9/ref/templates/upgrading/