### PR TITLE
Small visual fixes

### DIFF
--- a/troposphere/static/css/app/common.scss
+++ b/troposphere/static/css/app/common.scss
@@ -281,6 +281,6 @@ tr td.sm-cell:last-child {
     width:90%;
 }
 
-tr td {
+tr td, tr th {
     white-space: nowrap;
 }

--- a/troposphere/static/js/components/projects/detail/resources/tableData/instance/Activity.react.js
+++ b/troposphere/static/js/components/projects/detail/resources/tableData/instance/Activity.react.js
@@ -13,7 +13,7 @@ var Activity = React.createClass({
             stylez = {
                 textTransform: "capitalize"
             },
-            activity = instance.get('state').get('activity');
+            activity = instance.get('state').get('activity') || "N/A";
 
         return (
           <span style={stylez}>{activity}</span>

--- a/troposphere/static/js/components/settings/advanced/SSHConfiguration.react.js
+++ b/troposphere/static/js/components/settings/advanced/SSHConfiguration.react.js
@@ -71,7 +71,7 @@ export default React.createClass({
         return (
             <tr key={ sshKey.get( 'id') }>
                 <td>{ sshKey.get('name') }</td>
-                <td style={{ wordWrap: "break-word" }}>{ sshKey.get('pub_key').replace(/\n/g, " ") }</td>
+                <td style={{ wordWrap: "break-word", whiteSpace: "normal" }}>{ sshKey.get('pub_key').replace(/\n/g, " ") }</td>
                 <td>
                     <a onClick={ this.destroySSHKey.bind(this, sshKey) }>
                         <i style={{ color: "crimson"}} className="glyphicon glyphicon-trash" />
@@ -109,8 +109,6 @@ export default React.createClass({
                                         <i className="glyphicon glyphicon-plus" />
                                     </a>
                                 </td>
-                                <td></td>
-                                <td></td>
                             </tr>
                         </tbody>
                     </table>


### PR DESCRIPTION
Here are some important visual changes i've been meaning to include in the quasi-quail release.

@1765924 Apply no wrap to header like rows
**OLD:**
![screen shot 2016-07-14 at 8 48 57 am](https://cloud.githubusercontent.com/assets/3847314/16846444/58574d80-49a1-11e6-82fe-12127fc01bf8.png)
**NEW:**
![screen shot 2016-07-14 at 8 50 13 am](https://cloud.githubusercontent.com/assets/3847314/16846456/68cc4f58-49a1-11e6-9e59-29855c79ef20.png)

@53ebecb Fix empty activity
**NEW:**
![screen shot 2016-07-14 at 8 51 33 am](https://cloud.githubusercontent.com/assets/3847314/16846493/7d7b9396-49a1-11e6-8676-a66950756fac.png)

@4d03e32 Add whitespace exception for ssh key table
**OLD:**
![screen shot 2016-07-14 at 8 52 44 am](https://cloud.githubusercontent.com/assets/3847314/16846506/8715cfe8-49a1-11e6-816e-96113e873bc6.png)

**NEW:**
![screen shot 2016-07-14 at 8 53 46 am](https://cloud.githubusercontent.com/assets/3847314/16846508/8b346792-49a1-11e6-8122-46dbd4f80457.png)
