### PR TITLE
Address instance link cid issue

### DIFF
--- a/troposphere/static/js/components/Header.react.js
+++ b/troposphere/static/js/components/Header.react.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import Backbone from 'backbone';
-import actions from 'actions';
 import modals from 'modals';
 import MaintenanceMessageBanner from './MaintenanceMessageBanner.react';
 import context from 'context';
@@ -20,7 +19,7 @@ let links = [
       href: "/application/dashboard",
       icon: "stats",
       requiresLogin: true,
-      isEnabled: true,
+      isEnabled: true
     },
     {
       name: "Projects",

--- a/troposphere/static/js/components/modals/instance/InstanceDeleteModal.react.js
+++ b/troposphere/static/js/components/modals/instance/InstanceDeleteModal.react.js
@@ -19,7 +19,7 @@ export default React.createClass({
         this.props.onConfirm();
       },
 
-      renderBody: function () {
+      renderBody: function() {
         var instance = this.props.instance;
 
         return (
@@ -50,10 +50,12 @@ export default React.createClass({
         );
       },
 
-      render: function () {
+    render: function() {
+        let instance = this.props.instance,
+            disable = !instance && instance.get("id");
 
         return (
-          <div className="modal fade">
+        <div className="modal fade">
             <div className="modal-dialog">
               <div className="modal-content">
                 <div className="modal-header">
@@ -67,13 +69,16 @@ export default React.createClass({
                   <button type="button" className="btn btn-danger" onClick={this.hide}>
                     Cancel
                   </button>
-                  <button type="button" className="btn btn-primary" onClick={this.confirm}>
+                  <button disabled={disable}
+                        type="button"
+                        className="btn btn-primary"
+                        onClick={this.confirm}>
                     Yes, delete this instance
                   </button>
                 </div>
               </div>
             </div>
-          </div>
+        </div>
         );
-      }
+    }
 });

--- a/troposphere/static/js/components/projects/detail/resources/SelectableRow.react.js
+++ b/troposphere/static/js/components/projects/detail/resources/SelectableRow.react.js
@@ -33,7 +33,7 @@ export default React.createClass({
     },
 
     render: function () {
-      var rowClassName = this.props.isActive ? "selected" : null;
+      var rowClassName = this.props.isActive ? "selected" : "";
 
       return (
         <tr className={"sm-row " + rowClassName} style={{cursor:"pointer"}} onClick={this.previewResource}>

--- a/troposphere/static/js/components/projects/detail/resources/tableData/instance/Name.react.js
+++ b/troposphere/static/js/components/projects/detail/resources/tableData/instance/Name.react.js
@@ -15,7 +15,7 @@ export default React.createClass({
       var instance = this.props.instance,
           name = instance.get('name').trim() || "[no instance name]";
 
-      if (!instance.id) {
+      if (!instance && !instance.get('id')) {
         return (
           <span>{instance.get('name')}</span>
         );


### PR DESCRIPTION
It appears that we were previous depending on `instance.id` being `undefined` and the Instance.js model was altered such that a temporary _child_ identifier (`cid`) is now returned when accessing `instance.id`. 

Using the `get("<attribute-name>")` interface to the Backbone model appears to preserve the expectations.