### PR TITLE
Fix incorrect import for volume actions

### DIFF
--- a/troposphere/static/js/actions/InstanceVolumeActions.js
+++ b/troposphere/static/js/actions/InstanceVolumeActions.js
@@ -1,6 +1,7 @@
-import InstanceVolume from './instanceVolume/attach';
+import VolumeAttach from './instanceVolume/attach';
+import VolumeDetach from './instanceVolume/detach';
 
 export default {
-    attach: InstanceVolume.attach,
-    detach: InstanceVolume.detach
+    attach: VolumeAttach.attach,
+    detach: VolumeDetach.detach
 };


### PR DESCRIPTION
Currently in petrified-penguin, volume detach throws an exception:
```
InstanceVolumeActions.detach is not a function
```
The import was incorrect.

TODO
- [ ] ~~add attach/detach in atmosphere-ansible @steve-gregory~~
- [ ] merge into qq/master

@lenards in prod i was able to successfully detach a volume through the api. It does not appear there is actually any issue with atmo. 