### PR TITLE
Fix store not updating, because incorrect event string

### DIFF
--- a/troposphere/static/js/stores/AllocationStore.js
+++ b/troposphere/static/js/stores/AllocationStore.js
@@ -2,7 +2,7 @@ import _ from 'underscore';
 import BaseStore from 'stores/BaseStore';
 import Dispatcher from 'dispatchers/Dispatcher';
 import Store from 'stores/Store';
-import AllocationConstants from 'constants/ResourceRequestConstants';
+import AllocationConstants from 'constants/AllocationConstants';
 import AllocationCollection from 'collections/AllocationCollection';
 import stores from 'stores';
 


### PR DESCRIPTION
In production, volume create throws this exception:
"Uncaught TypeError: Cannot use 'in' operator to search for 'at' in undefined"

This PR fixes that error.