### PR TITLE
Fix ./manage.py collectstatic

### DIFF
--- a/extras/nginx/locations/tropo.conf.j2
+++ b/extras/nginx/locations/tropo.conf.j2
@@ -3,11 +3,11 @@ location /assets {
 }
 
 location /assets/bundles {
-    alias {{ ASSETS_PATH }}/bundles/;
+    alias {{ ASSETS_PATH }}/bundles;
 }
 
-location /themes {
-    alias {{ THEME_PATH }};
+location /assets/theme {
+    alias {{ THEME_PATH }}/{{ THEME_NAME }};
 }
 
 location ~^/(application|maintenance|login|globus_login|oauth2.0/callbackAuthorize|logout|forbidden|version|cf2|tropo-admin|tropo-static|tropo-api|web_shell|web_desktop) {

--- a/troposphere/settings/default.py
+++ b/troposphere/settings/default.py
@@ -142,12 +142,11 @@ LOGGING = {
 API_ROOT    = SERVER_URL + "/api/v1"
 API_V2_ROOT = SERVER_URL + "/api/v2"
 
-# The ROOT PATH for ALL (app + dependencies) static files.
-STATIC_ROOT = os.path.join(BASE_DIR, "assets")
-# The SERVER PATH for ALL (app + dependencies) static files.
+# The endpoint in troposphere for generated assets
 STATIC_URL = '/assets/'
 
-#STATIC generated files from troposphere to be added to STATIC_ROOT
+# The target location where static files are moved
+STATIC_ROOT = os.path.join(BASE_DIR, "assets")
 
 REST_FRAMEWORK = {
     # 'DEFAULT_RENDERER_CLASSES': (

--- a/troposphere/settings/local.py.j2
+++ b/troposphere/settings/local.py.j2
@@ -48,6 +48,13 @@ THEME_NAME="{{ THEME_NAME }}"
 THEME_NAME= "troposphere_theme"
 {% endif %}
 
+# The location from where static files are aggregated
+# ./manage.py collectstatic moves files from STATICFILES_DIRS to STATIC_ROOT
+STATICFILES_DIRS = [
+    ("theme", "{{ THEME_PATH }}/{{ THEME_NAME }}"),
+    ("resources", os.path.join(BASE_DIR, "static", "resources"))
+]
+
 ORG_NAME= "{{ ORG_NAME }}"
 
 {% if INTERCOM_APP_ID is defined and not INTERCOM_APP_ID == "" %}

--- a/troposphere/views/app.py
+++ b/troposphere/views/app.py
@@ -112,12 +112,8 @@ def _populate_template_params(request, maintenance_records, notice_t, disabled_l
     template_params['SUPPORT_EMAIL'] = settings.SUPPORT_EMAIL
     template_params['UI_VERSION'] = settings.UI_VERSION
     template_params['BADGE_HOST'] = getattr(settings, "BADGE_HOST", None)
-
-    #TODO: Replace this line when theme support is re-enabled.
-    #template_params["THEME_URL"] = "assets/"
-    template_params['THEME_URL'] = "/themes/%s" % settings.THEME_NAME
+    template_params['THEME_URL'] = "/assets/theme"
     template_params['ORG_NAME'] = settings.ORG_NAME
-
     template_params['DYNAMIC_ASSET_LOADING'] = settings.DYNAMIC_ASSET_LOADING
 
     if hasattr(settings, "BASE_URL"):


### PR DESCRIPTION
Now the theme can be managed by either nginx/django. Also, calling
`./manage.py collectstatic` takes care of the cf2 stuff that `make cf2` did.

I verified that this works for nginx. Given the settings on beta, this should just work.