### PR TITLE
Allow space in images search

### DIFF
--- a/troposphere/static/js/components/images/list/ImageListView.react.js
+++ b/troposphere/static/js/components/images/list/ImageListView.react.js
@@ -29,7 +29,7 @@ export default React.createClass({
     },
 
     updateState: function() {
-        let query = this.state.query;
+        let query = this.state.query.trim();
 
         let images;
 
@@ -100,20 +100,12 @@ export default React.createClass({
     //
 
     onSearchChange: function(e) {
-        var input = e.target.value.trim();
-
-        // If input is empty string, don't bother with delay
-        if (!input) {
-            this.setState({
-                query: input
-            }, this.updateState);
-        } else {
-            this.setState({
-                query: input
-            }, () => {
-                this.callIfNotInterruptedAfter(500 /* ms */ , this.updateState);
-            });
-        }
+        var input = e.target.value;
+        this.setState({
+            query: input
+        }, () => {
+            this.callIfNotInterruptedAfter(500 /* ms */ , this.updateState);
+        });
     },
 
     onChangeViewType: function() {


### PR DESCRIPTION
Now, the text box always renders the user's raw input. Before the request is
passed to the stores, the query is trimmed. If the user searches: "apple_" and
"apple___", only a single request is fired for "apple".

TODO:
- [ ] merge into downstream