### PR TITLE
Provide "Web Desktop" _link action_ only for noVNC capable instances.

### DIFF
--- a/troposphere/static/js/components/projects/resources/instance/details/actions/InstanceActionsAndLinks.react.js
+++ b/troposphere/static/js/components/projects/resources/instance/details/actions/InstanceActionsAndLinks.react.js
@@ -176,6 +176,7 @@ export default React.createClass({
                   this,
                   ip_address,
                   this.props.instance),
+              openInNewWindow: true,
               isDisabled: webLinksDisabled
           });
       }

--- a/troposphere/static/js/components/projects/resources/instance/details/actions/InstanceActionsAndLinks.react.js
+++ b/troposphere/static/js/components/projects/resources/instance/details/actions/InstanceActionsAndLinks.react.js
@@ -98,6 +98,7 @@ export default React.createClass({
       var webShellUrl = this.props.instance.shell_url(),
           remoteDesktopUrl = this.props.instance.vnc_url(),
           usesRemoteDesktop = !!(this.props.instance && this.props.instance.get('vnc')),
+          webDesktopCapable = !!(this.props.instance && this.props.instance.get('web_desktop')),
           status = this.props.instance.get('state').get('status'),
           activity = this.props.instance.get('state').get('activity'),
           ip_address = this.props.instance.get('ip_address'),
@@ -157,7 +158,7 @@ export default React.createClass({
         }
       ]);
 
-      if (usesRemoteDesktop && !featureFlags.WEB_DESKTOP) {
+      if (usesRemoteDesktop) {
         linksArray = linksArray.concat([{
           label: 'Remote Desktop',
           icon: 'sound-stereo',
@@ -167,13 +168,15 @@ export default React.createClass({
         }]);
       }
 
-      if (featureFlags.WEB_DESKTOP) {
+      if (webDesktopCapable && featureFlags.WEB_DESKTOP) {
           linksArray.push({
               label: 'Web Desktop',
               icon: 'sound-stereo',
-              onClick: this.onWebDesktop.bind(this,
-                ip_address,
-                this.props.instance),
+              onClick: this.onWebDesktop.bind(
+                  this,
+                  ip_address,
+                  this.props.instance),
+              isDisabled: webLinksDisabled
           });
       }
 


### PR DESCRIPTION
The feature providing a "zero-plugin" remote desktop via HTML5 (thanks to [noVNC](http://kanaka.github.io/noVNC/noVNC/vnc.html)) requires that the "Instance Detail" view within Troposphere only show the "link" when an instance *has* the _capability. 

*Web Desktop* _capable_ instances are indicated by the `v2/instances/:instance_alias` endpoint as follows:
```javascript
{
   // ... snippet
    "ip_address": "128.196.65.168",
    "shell": false,
    "vnc": false,
    "web_desktop": false,
    "identity": { /* ... */ },
    // ...
}
```

>Note: the Remote Desktop link will appear, as well, for those who use a VNC plugin