### PR TITLE
Add trimming to input for all network requests

### DIFF
--- a/troposphere/static/js/components/images/list/ImageListView.react.js
+++ b/troposphere/static/js/components/images/list/ImageListView.react.js
@@ -20,7 +20,7 @@ export default React.createClass({
 
     getInitialState: function() {
         return {
-            query: null,
+            query: "",
             images: null,
             isLoadingMoreResults: false,
             nextUrl: null,
@@ -67,7 +67,7 @@ export default React.createClass({
     },
 
     onLoadMoreImages: function() {
-        var query = this.state.query,
+        var query = this.state.query.trim(),
             images;
 
         // Get the current collection
@@ -222,7 +222,7 @@ export default React.createClass({
     },
 
     renderBody: function() {
-        var query = this.state.query,
+        var query = this.state.query.trim(),
             title = '';
 
         let images;


### PR DESCRIPTION
#420 didn't trim the query when it need to, also when I did trim I didn't make sure i was trimming a string object.

A subtle change is that the `getInitialState: query` is "" rather than null. That way we
can do:

    var query = this.state.query.trim()

Rather than have to do:

    // Make sure query is a string and has a trim method
    if (this.state.query) {
        query = this.state.query.trim()
    }

Both "" and null are falsy.