### PR TITLE
btn index to be above event blocking element

### DIFF
--- a/troposphere/static/css/app/layout.scss
+++ b/troposphere/static/css/app/layout.scss
@@ -418,6 +418,8 @@
 
 // Table styles
 .td-sub-menu {
+  position: relative;
+  z-index: 9999;
   float: left;
   margin-right: 10px;
   margin-top: 10px;


### PR DESCRIPTION
Content wrapper was above the button blocking the event in Fire Fox on Ubuntu.
This sets the z-index above the blocking element