### PR TITLE
Add no-unreachable to travis-lint

### DIFF
--- a/.eslintrc.travis
+++ b/.eslintrc.travis
@@ -6,6 +6,7 @@
         ],
         "no-debugger": 2,
         "no-mixed-spaces-and-tabs": 2,
+        "no-unreachable": "error"
     },
     "env": {
         "es6": true,

--- a/troposphere/static/js/constants/HelpLinkConstants.js
+++ b/troposphere/static/js/constants/HelpLinkConstants.js
@@ -1,4 +1,0 @@
-export default {
-    ADD_LINK: "ADD_LINK",
-    UPDATE_LINK: "UPDATE_LINK",
-};

--- a/troposphere/static/js/stores/HelpLinkStore.js
+++ b/troposphere/static/js/stores/HelpLinkStore.js
@@ -18,25 +18,11 @@ Dispatcher.register(function (dispatch) {
     var payload = dispatch.action.payload;
     var options = dispatch.action.options || options;
 
-    switch (actionType) {
-/*
-        case HelpLinkConstants.ADD_LINK:
-            store.add(payload.external_link);
-            break;
-
-        case HelpLinkConstants.UPDATE_LINK:
-            store.update(payload.external_link);
-            break;
- */
-        default:
-            return true;
-    }
-
     if (!options.silent) {
-      store.emitChange();
+        store.emitChange();
     }
 
     return true;
-  });
+});
 
 export default store;


### PR DESCRIPTION
This is part of the effort to make `npm run travis-lint` more strict.
See #426.