### PR TITLE
Quasi Quail Final Tweaks 

### DIFF
--- a/troposphere/static/js/AppRoutes.react.js
+++ b/troposphere/static/js/AppRoutes.react.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import Router from 'react-router';
+import globals from 'globals';
 
 let Route = Router.Route,
     Redirect = Router.Redirect,
@@ -70,11 +71,14 @@ let AppRoutes = (
         <Route name="image-details" path=":imageId" handler={ImageDetailsPage}/>
       </Route>
 
-      <Route name="providers" handler={ProvidersMaster}>
-        <DefaultRoute handler={ProviderListSection} />
-        <Route name="provider" path=":id" handler={ProviderDetail}/>
-        <Route name="all-providers" path="/" handler={ProviderListSection} />
-      </Route>
+      {   /* Don't include route if globals.USE_ALLOCATION_SOURCES */
+          globals.USE_ALLOCATION_SOURCES ? null : (
+          <Route name="providers" handler={ProvidersMaster}>
+            <DefaultRoute handler={ProviderListSection} />
+            <Route name="provider" path=":id" handler={ProviderDetail}/>
+            <Route name="all-providers" path="/" handler={ProviderListSection} />
+          </Route>
+      ) } 
 
       <Route name="help" handler={HelpPage}/>
       <Route name="settings" handler={SettingsPage}/>

--- a/troposphere/static/js/components/Header.react.js
+++ b/troposphere/static/js/components/Header.react.js
@@ -73,6 +73,11 @@ let links = [
     }
 ];
 
+// Don't show Providers link if globals.USE_ALLOCATION_SOURCES
+if ( globals.USE_ALLOCATION_SOURCES ) {
+    links = links.filter( link => link.name !== "Providers");
+};
+
 let LoginLink = React.createClass({
     render: function () {
       let redirect_path = window.location.pathname+"?beta=true";

--- a/troposphere/static/js/components/dashboard/plots/ProviderAllocationPlot.react.js
+++ b/troposphere/static/js/components/dashboard/plots/ProviderAllocationPlot.react.js
@@ -101,9 +101,9 @@ export default React.createClass({
         return (
             <div>
                 <h2 className="t-title">
-                    Provider Resources
+                    Provider Allocation
                 </h2>
-                <PercentageGraph
+                <PercentageGraph        
                     seriesData={ this.getChartData() }
                     categories={ ['Allocation'] }
                 />

--- a/troposphere/static/js/components/dashboard/plots/ProviderAllocationPlot.react.js
+++ b/troposphere/static/js/components/dashboard/plots/ProviderAllocationPlot.react.js
@@ -103,7 +103,7 @@ export default React.createClass({
                 <h2 className="t-title">
                     Provider Allocation
                 </h2>
-                <PercentageGraph        
+                <PercentageGraph
                     seriesData={ this.getChartData() }
                     categories={ ['Allocation'] }
                 />


### PR DESCRIPTION
- Don't show Provider views if using Allocation Sources 
- Title for Allocation Graph on the dashboard said "Provider Resources",
now it says "Provider Allocation"

**After Changes**
No Providers Link
<img width="1610" alt="screen shot 2016-08-24 at 11 11 32 am" src="https://cloud.githubusercontent.com/assets/7366338/17942284/9172dbd8-69eb-11e6-823f-c25720ec71bb.png">
Correct Title
<img width="876" alt="screen shot 2016-08-24 at 8 54 45 am" src="https://cloud.githubusercontent.com/assets/7366338/17937996/01367ec4-69d9-11e6-9ebf-144e81a5cfbb.png">


