### PR TITLE
fix wrong list item selector

### DIFF
--- a/troposphere/static/js/components/modals/instance/InstanceLaunchWizardModal.react.js
+++ b/troposphere/static/js/components/modals/instance/InstanceLaunchWizardModal.react.js
@@ -101,7 +101,7 @@ export default React.createClass({
         let imageVersion = this.state.imageVersion;
         if (imageVersionList && !imageVersion) {
             imageVersionList = imageVersionList.cfilter(filterEndDate);
-            imageVersion = imageVersionList.first();
+            imageVersion = imageVersionList.last();
         }
 
         let providerList;


### PR DESCRIPTION
The problem was the when the launch was selected from the image detail the version selected was the most recent, however from the project details the version selected was the fist version.

Before
![bad_sort_instance_launch](https://cloud.githubusercontent.com/assets/7366338/18019131/9494b76e-6b8f-11e6-917d-226395e96151.gif)

After
![after](https://cloud.githubusercontent.com/assets/7366338/18019262/0dc2281a-6b90-11e6-932d-b875a8a40935.gif)


