### PR TITLE
Handled valid account; no allocation case

### DIFF
--- a/extras/nginx/locations/tropo.conf.j2
+++ b/extras/nginx/locations/tropo.conf.j2
@@ -10,7 +10,7 @@ location /themes {
     alias {{ THEME_PATH }};
 }
 
-location ~^/(application|maintenance|login|globus_login|oauth2.0/callbackAuthorize|logout|forbidden|version|cf2|tropo-admin|tropo-api|web_shell|web_desktop) {
+location ~^/(application|maintenance|login|globus_login|oauth2.0/callbackAuthorize|logout|forbidden|version|cf2|tropo-admin|tropo-api|web_shell|web_desktop|allocations) {
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
     uwsgi_pass unix:///tmp/troposphere.sock;

--- a/troposphere/static/js/components/modals/allocationSource/NoAllocationSourceModal.react.js
+++ b/troposphere/static/js/components/modals/allocationSource/NoAllocationSourceModal.react.js
@@ -323,6 +323,14 @@ const ModalBackend = React.createClass({
             ? <LoadingModalView />
             : <DefaultModalView { ...props } />
 
+        if (allocationSources && allocationSources.length == 0) {
+            // we've entered an edge case, they have a valid
+            // account - but that account does not appear to
+            // have any allocationSources - redirect to a
+            // a templated error view/page
+            window.location = '/allocations';
+        }
+
         return (
         <div className="modal fade">
             <div className="modal-dialog">

--- a/troposphere/templates/allocations.html
+++ b/troposphere/templates/allocations.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>
+    Atmosphere | {{ ORG_NAME }}
+  </title>
+  <link rel="shortcut icon" href="{{THEME_URL}}/images/favicon.ico" />
+  <link rel="stylesheet" href="{{ THEME_URL }}/css/login.css"/>
+</head>
+<body>
+    <div id="wrapper" class="center">
+        <div id="imgcontainer">
+            <img src="{{ THEME_URL }}/images/large_logo.png">
+        </div>
+        <div class="message-wrapper">
+
+            <h1>Your account does not currently have a valid Allocation Source.</h1>
+
+            <p>Your  will need a valid allocation in order to use Jetstream.</p>
+
+            <p>Jetstream allocations are done exclusively through the <a href="https://www.xsede.org/overview">eXtreme Science and Engineering Discovery Environment (XSEDE)</a>. You can read the <a href="https://www.xsede.org/getting-started">Getting Started guide</a> to learn about the process of getting onto XSEDE and applying for allocations and using XSEDE resources.</p>
+
+            <p>For more information on how to apply for an Allocation please visit the <a href="https://iujetstream.atlassian.net/wiki/display/JWT/Jetstream+Allocations">Jetstream Wiki</a>.</p>
+
+        </div>
+    </div>
+</body>
+</html>

--- a/troposphere/urls.py
+++ b/troposphere/urls.py
@@ -31,6 +31,7 @@ ui_urlpatterns = [
         name='cas_oauth_service'),
     url(r'^tests$', views.tests),
     url(r'^tropo-api/', include('api.urls')),
+    url(r'^allocations/', views.allocations, name='allocations'),
     url(r'^web_shell$', views.web_shell),
     url(r'^web_desktop$', views.web_desktop)
 ]

--- a/troposphere/views/__init__.py
+++ b/troposphere/views/__init__.py
@@ -1,6 +1,7 @@
 from .app import root, application, forbidden, version, tests, application_backdoor
 from .web_shell import web_shell
 from .web_desktop import web_desktop
+from .allocations import allocations
 from .auth import login, logout, cas_oauth_service
 from .emulation import emulate, unemulate
 from .maintenance import get_maintenance, maintenance, atmo_maintenance

--- a/troposphere/views/allocations.py
+++ b/troposphere/views/allocations.py
@@ -1,0 +1,31 @@
+
+import logging
+
+from django.conf import settings
+from django.shortcuts import render, redirect, render_to_response
+from django.template import RequestContext
+
+logger = logging.getLogger(__name__)
+
+
+def allocations(request):
+    """
+    View that is shown if a community member has XSEDE/Globus access,
+    but is missing allocation-sources (no way to charge activity).
+    """
+    # populate with values `site_metadata` in the future
+    template_params = {}
+
+    template_params['THEME_URL'] = "/themes/%s" % settings.THEME_NAME
+    template_params['ORG_NAME'] = settings.ORG_NAME
+
+    if hasattr(settings, "BASE_URL"):
+        template_params['BASE_URL'] = settings.BASE_URL
+
+    response = render_to_response(
+        'allocations.html',
+        template_params,
+        context_instance=RequestContext(request)
+    )
+
+    return response


### PR DESCRIPTION
For Troposphere installations using the _Allocation Source_ plugin, this adds a URL that is a landing page for community members that have a valid account without having an active/current allocation source to associated with running or new instances. 

This is an implementation done on short notice. Please offer ideas for improvement to be included as this is refined.