### PR TITLE
Fix dashboard graphs

### DIFF
--- a/troposphere/static/js/collections/AllocationSourceCollection.js
+++ b/troposphere/static/js/collections/AllocationSourceCollection.js
@@ -32,7 +32,7 @@ export default Backbone.Collection.extend({
         return results;
     },
 
-    sync: globals.USE_MOCK_DATA 
+    sync: true 
           ? mockSync(api)
           : Backbone.sync
 });

--- a/troposphere/static/js/collections/AllocationSourceCollection.js
+++ b/troposphere/static/js/collections/AllocationSourceCollection.js
@@ -32,7 +32,7 @@ export default Backbone.Collection.extend({
         return results;
     },
 
-    sync: true 
+    sync: globals.USE_MOCK_DATA 
           ? mockSync(api)
           : Backbone.sync
 });

--- a/troposphere/static/js/components/common/ui/PercentageGraph.react.js
+++ b/troposphere/static/js/components/common/ui/PercentageGraph.react.js
@@ -53,7 +53,7 @@ export default React.createClass({
         if (seriesData.length === 0) {
           return;
         }
-        var height = (categories.length * (seriesData.length * 40)) + 85;
+        var height = (categories.length * (seriesData.length * 50)) + 100;
 
         var plotLines = [],
             plotBands = [];
@@ -118,7 +118,7 @@ export default React.createClass({
                 formatter: function (tooltip) {
                     var limits = this.series.options.limits;
                     var currentLimit = limits[this.x];
-                    var currentUsage = Math.round(currentLimit * this.y / 100);
+                    var currentUsage = currentLimit * this.y / 100;
                     var appendMessages = this.series.options.appendMessages;
                     var appendMessage = appendMessages[this.x];
 

--- a/troposphere/static/js/components/dashboard/plots/AllocationSourcePlot.react.js
+++ b/troposphere/static/js/components/dashboard/plots/AllocationSourcePlot.react.js
@@ -35,8 +35,8 @@ export default React.createClass({
     },
 
     seriesData: function(item) {
-        let percentage = Math.round(item.get('compute_used') / item.get('compute_allowed') * 100);
-
+        let percentage = item.get('compute_used') / item.get('compute_allowed') * 100;
+        debugger;
         return {
             name: item.get('name'),
             data: [percentage],

--- a/troposphere/static/js/components/dashboard/plots/AllocationSourcePlot.react.js
+++ b/troposphere/static/js/components/dashboard/plots/AllocationSourcePlot.react.js
@@ -36,7 +36,6 @@ export default React.createClass({
 
     seriesData: function(item) {
         let percentage = item.get('compute_used') / item.get('compute_allowed') * 100;
-        debugger;
         return {
             name: item.get('name'),
             data: [percentage],


### PR DESCRIPTION
Was rounding to nearest int in both the tooltip and the graph label.
Also, was hiding the label when two graph bars were close to same length.

Both issues have been fixed, see screenshots. 

The problem was that the bar width was just under the width HighCharts will allow for two labels to show next to each other.  


![bwql8u4mcu](https://cloud.githubusercontent.com/assets/7366338/18107978/1fbcd2a4-6ebf-11e6-9629-da2637fe9c45.gif)
