### PR TITLE
Added static CSS `id`s to resource submenu

### DIFF
--- a/troposphere/static/js/components/projects/detail/resources/SubMenu.react.js
+++ b/troposphere/static/js/components/projects/detail/resources/SubMenu.react.js
@@ -39,22 +39,22 @@ export default React.createClass({
         return (
           <div className="sub-menu">
             <div className="dropdown">
-              <button className="btn btn-primary dropdown-toggle" data-toggle="dropdown">New</button>
+              <button id="res-new-menu" className="btn btn-primary dropdown-toggle" data-toggle="dropdown">New</button>
               <ul className="dropdown-menu">
                 <li>
-                  <a href="#" onClick={this.onCreateInstance}>
+                  <a id="res-create-instance" href="#" onClick={this.onCreateInstance}>
                     <i className={'glyphicon glyphicon-tasks'}/>
                     Instance
                   </a>
                 </li>
                 <li>
-                  <a href="#" onClick={this.onCreateVolume}>
+                  <a id="res-create-volume" href="#" onClick={this.onCreateVolume}>
                     <i className={'glyphicon glyphicon-hdd'}/>
                     Volume
                   </a>
                 </li>
                 <li>
-                  <a href="#" onClick={this.onCreateExternalLink}>
+                  <a id="res-create-link" href="#" onClick={this.onCreateExternalLink}>
                     <i className={'glyphicon glyphicon-globe'}/>
                     Link
                   </a>


### PR DESCRIPTION
This work adds CSS `id` attributes to the NEW resource menu within the _project resouces_ view along with specific `id`s for _NEW > Instance_, _NEW > Volume_, & _NEW > Link_. 

Reason: for a Selenium test, the ability to select by `id` improves the overall easy of writing tests. 