### PR TITLE
Update path to theme

### DIFF
--- a/troposphere/views/allocations.py
+++ b/troposphere/views/allocations.py
@@ -16,7 +16,7 @@ def allocations(request):
     # populate with values `site_metadata` in the future
     template_params = {}
 
-    template_params['THEME_URL'] = "/themes/%s" % settings.THEME_NAME
+    template_params['THEME_URL'] = "/assets/theme"
     template_params['ORG_NAME'] = settings.ORG_NAME
 
     if hasattr(settings, "BASE_URL"):


### PR DESCRIPTION
The theme url got changed here: b94635567b8c1b53ccfc07d. But this template used the old theme url. 

This should prevent jetstream users from getting a themeless "You have an allocation source issue", once they're on a version with the new theme url.


