### PR TITLE
Altered if Delete resource button available

### DIFF
--- a/troposphere/static/js/components/projects/detail/resources/InstanceActionButtons.react.js
+++ b/troposphere/static/js/components/projects/detail/resources/InstanceActionButtons.react.js
@@ -100,17 +100,21 @@ export default React.createClass({
               />
           );
         }
+      } else if (!this.props.multipleSelected) {
+          // Include "Delete" if only one resource
+          // is currently selected - regardless of
+          // the state of that resource
+          linksArray.push(
+              <Button
+                  key="Delete"
+                  icon="remove"
+                  tooltip="Delete"
+                  onClick={this.onDelete}
+                  isVisible={true}
+              />
+          );
       }
 
-      linksArray.push(
-        <Button
-          key="Delete"
-          icon="remove"
-          tooltip="Delete"
-          onClick={this.onDelete}
-          isVisible={true}
-          />
-      );
 
       return (
         <div className="clearfix u-md-pull-right">


### PR DESCRIPTION
This work removes the "Delete" resource button multiple resources are
selected in the ProjectDetail view.

Background:
-----------
Currently, we do *not* support a smooth "batch" delete interaction.
Prior to this commit, we deleted the _last_ selected resource. In
an effort to avoid confusing affordances, this is no longer visible
while buttons that can be used in "multi-select" remain (notable here
is "Move selected resources" - which is why the "checkbox"/multi-select
remains in the UI at all; otherwise, a simplification would be to pull
the checkboxes out altogether).

Future Work:
------------
The move to a MediaCard interface will present the opportunity to
address the topic of "Batch Actions" again. It is important that
we offer this is a manner that makes organization within Projects
beneficial.

See JIRA tickets: ATMO-981, ATMO-1467