### PR TITLE
Select instance row fix

### DIFF
--- a/troposphere/static/js/components/modals/instance/InstanceDeleteModal.react.js
+++ b/troposphere/static/js/components/modals/instance/InstanceDeleteModal.react.js
@@ -30,13 +30,17 @@ export default React.createClass({
               {' Data will be'}
               <strong>{ ' lost.' }</strong>
             </p>
-            <p>
-                {'The following instance ' +
-                 'will be shut down and all data will be permanently lost:'}
+            <div>
+                <p>
+                    {'The following instance ' +
+                     'will be shut down and all data will be permanently lost:'}
+                </p>
                 <ul>
-                <strong>{instance.get('name') + ' #' + instance.get('id')}</strong>
+                    <li>
+                      <strong>{instance.get('name') + ' #' + instance.get('id')}</strong>
+                    </li>
                 </ul>
-            </p>
+            </div>
 
             <p>
               <em>Note:</em>

--- a/troposphere/static/js/components/projects/detail/resources/SelectableRow.react.js
+++ b/troposphere/static/js/components/projects/detail/resources/SelectableRow.react.js
@@ -17,7 +17,7 @@ export default React.createClass({
 
     toggleCheckbox: function (e) {
       e.stopPropagation();
-      if (!this.props.resource.id) return;
+      if (this.props.resource && this.props.resource.isNew()) return;
 
       if (this.props.isSelected) {
         this.props.onResourceDeselected(this.props.resource);
@@ -33,11 +33,17 @@ export default React.createClass({
     },
 
     render: function () {
-      var rowClassName = this.props.isActive ? "selected" : "";
+      let resource = this.props.resource,
+          diminish = resource && resource.isNew() ? 0.32 : 1,
+          rowClassName = this.props.isActive ? "selected" : "";
 
       return (
-        <tr className={"sm-row " + rowClassName} style={{cursor:"pointer"}} onClick={this.previewResource}>
-          <td className="sm-cell hidden-xs" onClick={this.toggleCheckbox}>
+        <tr className={"sm-row " + rowClassName}
+            style={{cursor:"pointer"}}
+            onClick={this.previewResource}>
+          <td className="sm-cell hidden-xs"
+              style={{opacity: diminish}}
+              onClick={this.toggleCheckbox}>
             <Checkbox isChecked={this.props.isSelected}/>
           </td>
           {this.props.children}

--- a/troposphere/static/js/components/projects/detail/resources/tableData/instance/Name.react.js
+++ b/troposphere/static/js/components/projects/detail/resources/tableData/instance/Name.react.js
@@ -17,12 +17,13 @@ export default React.createClass({
 
       if (instance && !instance.get('id')) {
         return (
-          <span>{instance.get('name')}</span>
+          <span style={{opacity: 0.57}}>{instance.get('name')}</span>
         );
       }
 
       return (
-        <Router.Link to="project-instance-details" params={{projectId: this.getParams().projectId, instanceId: instance.id}}>
+        <Router.Link to="project-instance-details"
+                     params={{projectId: this.getParams().projectId, instanceId: instance.id}}>
           {name}
         </Router.Link>
       );

--- a/troposphere/static/js/globals.js
+++ b/troposphere/static/js/globals.js
@@ -3,7 +3,7 @@ import jstz from 'jstz';
 
 let timezone = jstz.determine();
 let tz_region = timezone ? timezone.name() : 'America/Phoenix';
-let shell_proxy = 'https://atmo-proxy.iplantcollaborative.org/';
+let shell_proxy = 'https://atmo-proxy.cyverse.org/';
 
 export default {
     API_ROOT: window.API_ROOT || '/api/v1',


### PR DESCRIPTION
An instance that is in "Build ..." status can be _selected_ and any following actions taken with that instance will fail because that model has that to be persisted via the API. This throws an uncaught exception when the action attempts to use the `this.props.resource`:
```
Cannot read property 'id' of undefined
```
We have seen at least 52 of these events experienced by 40 community members over the last 2 months. Given the general nature of the error - we cannot assume all occurrences are from this scenario. 

Also, following this error, children components may throw an error like: 
```
Cannot read property '_currentElement' of null
```