### PR TITLE
Included Delete/"X" on single select resource

### DIFF
--- a/troposphere/static/js/components/projects/detail/resources/InstanceActionButtons.react.js
+++ b/troposphere/static/js/components/projects/detail/resources/InstanceActionButtons.react.js
@@ -100,7 +100,10 @@ export default React.createClass({
               />
           );
         }
-      } else if (!this.props.multipleSelected) {
+      }
+
+
+      if (!this.props.multipleSelected) {
           // Include "Delete" if only one resource
           // is currently selected - regardless of
           // the state of that resource


### PR DESCRIPTION
This was a bit of silly mistake included in PR 460; the delete button
was _excluded_ for Instances when *that* Instance was in a _FINAL_
state. Final states are "Error", "Active", etc (complete list [1]).

Sanity prevails thanks to last minute testing :bomb:

[1] https://github.com/iPlantCollaborativeOpenSource/troposphere/blob/554dc3cd987d916c4772b7c1e5068c731d5acf5b/troposphere/static/js/models/InstanceState.js#L9-L17