### PR TITLE
Avoid "Uncaught Error" when attempting to attach

### DIFF
--- a/troposphere/static/js/components/modals/volume/VolumeAttachModal.react.js
+++ b/troposphere/static/js/components/modals/volume/VolumeAttachModal.react.js
@@ -64,17 +64,20 @@ export default React.createClass({
 
         this.state = this.state || {};
 
-        // Use selected instance or default to the first one
+        // Use selected instance or default to the first one (when available)
         if (next.instances) {
           var volume = this.props.volume,
-            InstanceCollection = next.instances.constructor;
+              firstInstanceId = null,
+              InstanceCollection = next.instances.constructor;
 
           // Filter out instances not in the same provider as the volume
           next.instances = next.instances.filter(function (i) {
             return i.get('identity').provider === volume.get('identity').provider;
           });
           next.instances = new InstanceCollection(next.instances);
-          next.instanceId = this.state.instanceId || next.instances.first().id;
+          // if the collection has a first, use that instance's id
+          firstInstanceId = next.instances.first() ? next.instances.first().id : null;
+          next.instanceId = this.state.instanceId || firstInstanceId;
         }
 
         return next;

--- a/troposphere/static/js/components/modals/volume/VolumeAttachModal.react.js
+++ b/troposphere/static/js/components/modals/volume/VolumeAttachModal.react.js
@@ -67,8 +67,7 @@ export default React.createClass({
         // Use selected instance or default to the first one (when available)
         if (next.instances) {
           var volume = this.props.volume,
-              firstInstanceId = null,
-              InstanceCollection = next.instances.constructor;
+              firstInstanceId = null;
 
           // Filter out instances not in the same provider as the volume
           next.instances = next.instances.cfilter(function (i) {

--- a/troposphere/static/js/components/modals/volume/VolumeAttachModal.react.js
+++ b/troposphere/static/js/components/modals/volume/VolumeAttachModal.react.js
@@ -56,8 +56,8 @@ export default React.createClass({
 
         var project = this.props.project;
 
-        // TODO: remove ambiguity between state/this.state
-        var state = {
+        // prepare to build out the `next` state for the component
+        var next = {
             instances: stores.ProjectInstanceStore.getInstancesFor(project),
             instanceId: null
         };
@@ -65,19 +65,19 @@ export default React.createClass({
         this.state = this.state || {};
 
         // Use selected instance or default to the first one
-        if (state.instances) {
+        if (next.instances) {
           var volume = this.props.volume,
-            InstanceCollection = state.instances.constructor;
+            InstanceCollection = next.instances.constructor;
 
           // Filter out instances not in the same provider as the volume
-          state.instances = state.instances.filter(function (i) {
+          next.instances = next.instances.filter(function (i) {
             return i.get('identity').provider === volume.get('identity').provider;
           });
-          state.instances = new InstanceCollection(state.instances);
-          state.instanceId = this.state.instanceId || state.instances.first().id;
+          next.instances = new InstanceCollection(next.instances);
+          next.instanceId = this.state.instanceId || next.instances.first().id;
         }
 
-        return state;
+        return next;
       },
 
       getInitialState: function () {

--- a/troposphere/static/js/components/modals/volume/VolumeAttachModal.react.js
+++ b/troposphere/static/js/components/modals/volume/VolumeAttachModal.react.js
@@ -71,10 +71,9 @@ export default React.createClass({
               InstanceCollection = next.instances.constructor;
 
           // Filter out instances not in the same provider as the volume
-          next.instances = next.instances.filter(function (i) {
+          next.instances = next.instances.cfilter(function (i) {
             return i.get('identity').provider === volume.get('identity').provider;
           });
-          next.instances = new InstanceCollection(next.instances);
           // if the collection has a first, use that instance's id
           firstInstanceId = next.instances.first() ? next.instances.first().id : null;
           next.instanceId = this.state.instanceId || firstInstanceId;


### PR DESCRIPTION
Handled empty collection case when attaching volume.
    
If you have a volume within a provider that has no instances to 'target', then the previous handling of `...first().id` will result in an Uncaught Error.

Here are defaulting to `null`, and only allow the `id` of the first instance to be used when it is available to be _targeted_.
    
[see ATMO-1275](https://pods.iplantcollaborative.org/jira/browse/ATMO-1275)