### PR TITLE
Add a stealth way to collect uniform information about an instance

### DIFF
--- a/troposphere/static/js/components/projects/resources/instance/details/sections/InstanceInfoSection.react.js
+++ b/troposphere/static/js/components/projects/resources/instance/details/sections/InstanceInfoSection.react.js
@@ -36,6 +36,32 @@ export default React.createClass({
       actions.InstanceActions.update(this.props.instance, {name: text});
     },
 
+    onDebugInfo: function(e) {
+        /**
+         * Including as a way to facilitate collecting information without getting UI elements
+         *
+         * suggested format:
+         *  <image-name> - <instance-GUID> - <provider> - <deploy-date-time> - <ip-address>
+         *
+         * altered format:
+         *  <image-name> - <instance-GUID> - <provider> - <ip-address> - <deploy-date-time>
+         *
+         * I thought swapping the order would make _seeing_ the IP address easier than it
+         * getting lost in the various bits of date-time info
+         */
+
+        let instance = this.props.instance,
+            imageName = instance.get("image") ? instance.get("image").name : "...",
+            uuid = instance.get("uuid") || "...",
+            provider = instance.get("provider") ? instance.get("provider").name : "...",
+            ip = instance.get("ip_address") || "x.x.x.x",
+            startDate = instance.get("start_date") || "<no-start-date>";
+
+        /* eslint-disable no-console */
+        console.log(`${imageName} - ${uuid} - ${provider} - ${ip} - ${startDate}`);
+        /* eslint-enable no-console */
+    },
+
     render: function () {
       var instance = this.props.instance,
         instanceHash = CryptoJS.MD5((instance.id || instance.cid).toString()).toString(),
@@ -62,8 +88,10 @@ export default React.createClass({
       return (
         <div className="resource-info-section section clearfix">
 
-          <div className="resource-image">
-            <Gravatar hash={instanceHash} size={iconSize} type={type}/>
+          <div className="resource-image" onClick={this.onDebugInfo}>
+            <Gravatar hash={instanceHash}
+                      size={iconSize}
+                      type={type}/>
           </div>
 
           <div className="resource-info">


### PR DESCRIPTION
If you click on the `<div>` containing the "gravatar" (whatever you've chosen) will output the information in the DevTools console in the following format:

```
<image-name> - <instance-GUID> - <provider> - <ip-address> - <deploy-date-time> 
```

## Demo
<img src="http://g.recordit.co/VTDAoJh0tK.gif" />