### PR TITLE
Fix small UI bugs related to empty version name

### DIFF
--- a/troposphere/static/js/actions/ImageVersionActions.js
+++ b/troposphere/static/js/actions/ImageVersionActions.js
@@ -23,8 +23,11 @@ export default {
             let err_message = error_json;
             if (error_json.hasOwnProperty("non_field_errors")) {
                 err_message = error_json.non_field_errors.join(" , ");
+                if(err_message.name  != null && err_message.name[0] != null) {
+                    err_message = err_message.name[0]
+                }
             }
-            var message = "Error updating Image Version " + version.get("name") + ": " + err_message;
+            var message = "Error updating Image Version '" + version.get("name") + "': " + err_message;
             NotificationController.error(null, message);
             Utils.dispatch(ImageVersionConstants.REMOVE_IMAGE_VERSION, {
                 version: version

--- a/troposphere/static/js/components/modals/image_version/ImageVersionEditModal.react.js
+++ b/troposphere/static/js/components/modals/image_version/ImageVersionEditModal.react.js
@@ -174,7 +174,10 @@ export default React.createClass({
         let orig_version = this.props.version,
             versions = image.get("versions");
         name = (name == null) ? "" : name.trim().toLowerCase();
-
+        //No-name is always invalid.
+        if (name == "") {
+            return false;
+        }
         versions = versions.filter(function(version) {
             return (version.id !== orig_version.id &&
             (version.name && version.name.toLowerCase() === name));


### PR DESCRIPTION
- Fix error message to show the version name and error reported from the
API (This likely needs to be fixed elsewhere..)
- (Bugfix) Troposphere UI will let you update an image version with no
name, but the API fails.