### PR TITLE
Removed extra elements within "Settings>SSH" Conf component

### DIFF
--- a/troposphere/static/js/components/settings/advanced/SSHConfiguration.react.js
+++ b/troposphere/static/js/components/settings/advanced/SSHConfiguration.react.js
@@ -118,8 +118,6 @@ export default React.createClass({
         var ssh_keys = this.state.ssh_keys;
 
         return (
-        <div>
-            <h3>SSH Configuration</h3>
             <div>
                 <h3>SSH Configuration</h3>
                 <div style={{maxWidth: "600px"}}>
@@ -142,7 +140,7 @@ export default React.createClass({
                             { ssh_keys ? ssh_keys.map(this.renderSSHKeyRow) : [] }
                             <tr>
                                 <td>
-                                    <a onClick={ this.launchSSHKeyUploadModal.bind(this, profile.get( 'user')) }>
+                                    <a onClick={ this.launchSSHKeyUploadModal.bind(this, profile.get("user")) }>
                                         <i className="glyphicon glyphicon-plus" />
                                     </a>
                                 </td>
@@ -151,30 +149,6 @@ export default React.createClass({
                     </table>
                 </div>
             </div>
-            <div>
-                <table className="clearfix table" style={{ tableLayout: "fixed" }}>
-                    <thead>
-                        <tr>
-                            <th style={{ width: "100px" }}>
-                                name
-                            </th>
-                            <th>
-                                public key
-                            </th>
-                            <th style={{ width: "30px" }}></th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {ssh_keys ? ssh_keys.map(this.renderSSHKeyRow) : []}
-                        <tr>
-                            <td>
-                                <a onClick={this.launchSSHKeyUploadModal.bind(this, profile.get("user"))}><i className="glyphicon glyphicon-plus" /></a>
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
-        </div>
         );
     }
 


### PR DESCRIPTION
Reported by community member @xuhang57, a malformed conflict resolution appear to create a rendering of the "Add SSH Key" elements. 

This pull requests removed those extra elements and returns the component to the expected rendering:

<img width="978" alt="screen shot 2016-09-30 at 10 13 04 am" src="https://cloud.githubusercontent.com/assets/5923/19000374/0b6e7776-86f7-11e6-9f93-aa603e793358.png">

<details>
Full view of the user settings page after this fix was applied:
<img width="1033" alt="screen shot 2016-09-30 at 10 13 13 am" src="https://cloud.githubusercontent.com/assets/5923/19000373/0b6ace6e-86f7-11e6-8e26-3eb80a1b8158.png">
</details>