### PR TITLE
Fix emulation for Web Shell and Web Desktop

### DIFF
--- a/troposphere/views/emulation.py
+++ b/troposphere/views/emulation.py
@@ -69,6 +69,7 @@ def emulate(request, username):
     logger.info("[EMULATE]User %s (Token: %s) has emulated User %s (Token:%s)"
                 % (emulator, old_token, username, new_token))
 
+    request.session["username"] = username
     request.session["emulator"] = emulator
     request.session['emulator_token'] = old_token
     request.session['access_token'] = new_token

--- a/troposphere/views/web_desktop.py
+++ b/troposphere/views/web_desktop.py
@@ -32,7 +32,6 @@ def web_desktop(request):
     template_params = {}
 
     logger.info("POST body: %s" % request.POST)
-
     if request.user.is_authenticated():
         logger.info("user is authenticated, well done.")
         sig = None


### PR DESCRIPTION
After making the changes below, web shell and web desktop are both accessible for staff users emulating regular users.

![Proof of emulation working on web shell and desktop](http://recordit.co/MMk9lBp8Iu.gif)