### PR TITLE
Incorporate troposphere-ui with npm-link

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,5 +86,8 @@
     "webpack-bundle-tracker": "0.0.93",
     "webpack-dev-server": "^1.14.1",
     "yuglify": "~0.1.4"
+  },
+  "engines": {
+      "npm": "3.*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "format": "esformatter -c .esformatter -i $(git ls-files troposphere/static/js*js)"
   },
   "dependencies": {
+    "troposphere-ui":"git://github.com/cyverse/troposphere-ui.git#master",
     "babel-polyfill": "^6.16.0",
     "backbone": "^1.2.1",
     "bootstrap-sass": "^3.3.6",
@@ -43,8 +44,8 @@
     "moment-timezone": "^0.5.1",
     "q": "^1.4.1",
     "raven-js": "^3.0.4",
-    "react": "^0.14.7",
-    "react-dom": "^0.14.7",
+    "react": "^15.*.*",
+    "react-dom": "^15.*.*",
     "react-router": "^0.13.0",
     "react-tooltip": "^3.0.10",
     "showdown": "^1.2.1",
@@ -77,7 +78,7 @@
     "node-sass": "^3.8.0",
     "postcss-loader": "^0.9.1",
     "precss": "^1.4.0",
-    "react-addons-test-utils": "^0.14.7",
+    "react-addons-test-utils": "^15.*.*",
     "sass-loader": "^1.0.3",
     "style-loader": "^0.12.3",
     "url-loader": "^0.5.6",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "format": "esformatter -c .esformatter -i $(git ls-files troposphere/static/js*js)"
   },
   "dependencies": {
-    "troposphere-ui":"git://github.com/cyverse/troposphere-ui.git#master",
+    "troposphere-ui": "1.0.2",
     "babel-polyfill": "^6.16.0",
     "backbone": "^1.2.1",
     "bootstrap-sass": "^3.3.6",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -113,8 +113,7 @@ module.exports = {
     alias: {
       css: path.join(__dirname, "/troposphere/static/css/"),
       images: path.join(__dirname, "/troposphere/static/images/"),
-      highcharts: "highcharts-commonjs",
-      react: path.join(__dirname, "/node_modules/react")
+      highcharts: "highcharts-commonjs"
     },
     root: [
       PATHS.context,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -109,6 +109,7 @@ module.exports = {
   },
   plugins: plugins,
   resolve: {
+    fallback: [path.join(__dirname, "/node_modules")],
     alias: {
       css: path.join(__dirname, "/troposphere/static/css/"),
       images: path.join(__dirname, "/troposphere/static/images/"),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -113,7 +113,8 @@ module.exports = {
     alias: {
       css: path.join(__dirname, "/troposphere/static/css/"),
       images: path.join(__dirname, "/troposphere/static/images/"),
-      highcharts: "highcharts-commonjs"
+      highcharts: "highcharts-commonjs",
+      react: path.join(__dirname, "/node_modules/react")
     },
     root: [
       PATHS.context,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -120,6 +120,9 @@ module.exports = {
     ],
     extensions: ["", ".js", ".scss", ".sass"]
   },
+  resolveLoader: {
+      root: path.join(__dirname, 'node_modules')
+  },
   // defined the PostCSS plugins to be used
   postcss: function() {
     return [precss, autoprefixer({ browsers: ['last 2 versions'] })]


### PR DESCRIPTION
Troposphere-ui can now be used with npm-link:

To check it out apply the following diff (after building/installing):

``` diff
diff --git a/troposphere/static/js/components/Master.react.js b/troposphere/static/js/components/Master.react.js
index 5bc03e1..99ac04f 100644
--- a/troposphere/static/js/components/Master.react.js
+++ b/troposphere/static/js/components/Master.react.js
@@ -7,6 +7,8 @@ import Header from "./Header.react";
 import Footer from "./Footer.react";
 import actions from "actions";
 import modals from "modals";
+
+import { Loader } from "troposphere-ui";
 import modernizrTest from "components/modals/unsupported/modernizrTest.js";
 import NullProject from "models/NullProject";
 import noAllocationSource from "modals/allocationSource/noAllocationSource.js";
@@ -130,6 +132,7 @@ export default React.createClass({
             <Header profile={ context.profile }
                     currentRoute={ ['projects'] }
                     maintenanceMessages={ maintenanceMessages } />
+            <Loader color="#ff0000" />
             <div id="main" style={ { 'marginTop': marginTop } }>
                 <RouteHandler/>
             </div>
```
