### PR TITLE
Show a label for "zero usage" scenario

### DIFF
--- a/troposphere/static/js/components/dashboard/plots/AllocationSourcePlot.react.js
+++ b/troposphere/static/js/components/dashboard/plots/AllocationSourcePlot.react.js
@@ -27,7 +27,7 @@ export default React.createClass({
                     if (this.y != 0) {
                         return (Math.round(this.y * 100) / 100) + '%';
                     } else {
-                        return null;
+                        return '0%';
                     }
                 }
             },

--- a/troposphere/static/js/components/dashboard/plots/ProviderAllocationPlot.react.js
+++ b/troposphere/static/js/components/dashboard/plots/ProviderAllocationPlot.react.js
@@ -13,7 +13,7 @@ export default React.createClass({
 
     //
     // Helper Methods
-    // 
+    //
 
     getChartData: function () {
         var summaries = [];
@@ -43,14 +43,14 @@ export default React.createClass({
             },
             borderWidth: 0,
             dataLabels: {
-            enabled: true,
-            formatter: function() {
-                if (this.y != 0) {
-                    return (Math.round(this.y * 100) / 100) + '%';
-                } else {
-                    return null;
+                enabled: true,
+                formatter: function() {
+                    if (this.y != 0) {
+                        return (Math.round(this.y * 100) / 100) + '%';
+                    } else {
+                        return '0%';
+                    }
                 }
-            }
             },
             animation: false
         };


### PR DESCRIPTION
The lack of a label for "no usage" was causing confusion for community members. This work uses a label & tooltip for this scenario.

<img width="611" alt="screen shot 2016-10-13 at 3 04 09 pm" src="https://cloud.githubusercontent.com/assets/5923/19368748/615aef3e-9156-11e6-9ede-0b928f82abe8.png">

<img width="432" alt="screen shot 2016-10-13 at 3 04 20 pm" src="https://cloud.githubusercontent.com/assets/5923/19368747/6156d7aa-9156-11e6-870e-9f0ea25b6235.png">

See [ATMO-1525](https://pods.iplantcollaborative.org/jira/browse/ATMO-1525)