### PR TITLE
Remove SECRET_KEY from settings

### DIFF
--- a/scripts/fix_migrations.sh
+++ b/scripts/fix_migrations.sh
@@ -2,7 +2,11 @@
 
 #Clear troposphere
 su - postgres -c 'psql -d troposphere -c "delete from django_migrations where app='"'troposphere';\""
+su - postgres -c 'psql -d troposphere -c "delete from django_migrations where app='"'iplantauth';\""
 su - postgres -c "psql -d troposphere -c 'drop table troposphere_user cascade;'"
+su - postgres -c "psql -d troposphere -c 'drop table iplantauth_accesstoken cascade;'"
+su - postgres -c "psql -d troposphere -c 'drop table iplantauth_token cascade;'"
+su - postgres -c "psql -d troposphere -c 'drop table iplantauth_userproxy cascade;'"
 su - postgres -c "psql -d troposphere -c 'drop table troposphere_user_groups cascade;'"
 su - postgres -c "psql -d troposphere -c 'drop table troposphere_user_user_permissions cascade;'"
 

--- a/troposphere/settings/local.py.j2
+++ b/troposphere/settings/local.py.j2
@@ -10,7 +10,6 @@ if len(TEMPLATES) > 0 and 'OPTIONS' in TEMPLATES[0]:
         TEMPLATES[0]['OPTIONS']['debug'] = {{ DEBUG }}
 {%- endif %}
 
-SECRET_KEY="{{ SECRET_KEY }}"
 SERVER_URL="{{ SERVER_URL }}"
 BASE_URL= "{{ BASE_URL }}"
 ALLOWED_HOSTS = [SERVER_URL.replace("https://",""), "localhost"]


### PR DESCRIPTION
This is clean-up from the previous pull request (#398). The effort was to make the operation of Troposphere's `SECRET_KEY` generation mirror that of Atmosphere's `SECRET_KEY`. 

See [ATMO-1470](https://pods.iplantcollaborative.org/jira/browse/ATMO-1470).