### PR TITLE
Fix hooks pointing to broken paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The hooks below give helpful hints about common tasks like migrating, or
 installing dependencies.
 
 Link the following hook to get these hints after pulling in code.
+From the root of the project:
 ```bash
-ln -s extras/hooks/post-merge.hook .git/hooks/post-merge
+ln -fs ../../extras/hooks/post-merge.hook .git/hooks/post-merge
 ```

--- a/extras/hooks/post-merge.hook
+++ b/extras/hooks/post-merge.hook
@@ -1,21 +1,21 @@
 #!/bin/bash
 
 # Warn when requirements.txt changes
-if [ -e contrib/requirements-warning.rb ]; then
-    ruby contrib/requirements-warning.rb;
+if [ -e extras/hooks/requirements-warning.rb ]; then
+    ruby extras/hooks/requirements-warning.rb;
 fi
 
 # Warn on new migration files
-if [ -e contrib/migrations-warning.rb ]; then
-    ruby contrib/migrations-warning.rb;
+if [ -e extras/hooks/migrations-warning.rb ]; then
+    ruby extras/hooks/migrations-warning.rb;
 fi
 
 # Warn when package.json changes
-if [ -e contrib/package-json-warning.rb ]; then
-    ruby contrib/package-json-warning.rb;
+if [ -e extras/hooks/package-json-warning.rb ]; then
+    ruby extras/hooks/package-json-warning.rb;
 fi
 
 # Warn when there is a configure error
-if [ -e contrib/configure-warning.sh ]; then
-    bash contrib/configure-warning.sh;
+if [ -e extras/hooks/configure-warning.sh ]; then
+    bash extras/hooks/configure-warning.sh;
 fi


### PR DESCRIPTION
1) The readme had an incorrect command for installing 
2) The paths in the post-merge were based on the old hook directories