### PR TITLE
ATMO-1562 fix star

### DIFF
--- a/troposphere/static/css/app/applications.scss
+++ b/troposphere/static/css/app/applications.scss
@@ -189,19 +189,6 @@
   }
 }
 
-/* Bookmarks */
-.bookmark {
-  position: absolute;
-  top: 8px;
-  right: 8px;
-
-  img {
-    height: 24px;
-    width: 24px;
-    display: block;
-  }
-}
-
 /* View selector for cards, as list or as cards */
 .view-selector {
   float: right;

--- a/troposphere/static/js/components/images/common/Bookmark.react.js
+++ b/troposphere/static/js/components/images/common/Bookmark.react.js
@@ -34,9 +34,12 @@ export default React.createClass({
         let img = isFavorited ? filled_star : empty_star;
 
         return (
-        <a className="bookmark" href="#" onClick={this.toggleFavorite}>
+        <span 
+            style={{ cursor: "pointer" }} 
+            onClick={this.toggleFavorite}
+        >
             <img width={ this.props.width } src={ img }/>
-        </a>
+        </span>
         );
     }
 });


### PR DESCRIPTION
A class was mistakingly introduced to the bookmark star. This PR removes that class and associated styles. Also, since this is toggling an action not navigating the anchor was replaced with a span. 

The other half of ATMO-1562 is to add the identicon back to the detail page... 
I will be doing this in a different PR after I tackle other blocking issues. 

<img width="1289" alt="screen shot 2016-10-18 at 2 00 45 pm" src="https://cloud.githubusercontent.com/assets/7366338/19498293/ebe4f7d4-9544-11e6-9d47-b7ba026935d6.png">
