### PR TITLE
ATMO-1561 Filter list before handing to text

### DIFF
--- a/troposphere/static/js/components/modals/instance/launch/components/ImageList.react.js
+++ b/troposphere/static/js/components/modals/instance/launch/components/ImageList.react.js
@@ -2,7 +2,6 @@ import React from "react";
 import Image from "./Image.react";
 import Backbone from "backbone";
 
-import { filterEndDate } from "utilities/filterCollection";
 
 
 export default React.createClass({
@@ -20,7 +19,7 @@ export default React.createClass({
     },
 
     render: function() {
-        let images = this.props.images.cfilter(filterEndDate);
+        let images = this.props.images;
         return (
         <ul className="app-card-list modal-list">
             {images.map(this.renderImage)}

--- a/troposphere/static/js/components/modals/instance/launch/steps/ImageSelectStep.react.js
+++ b/troposphere/static/js/components/modals/instance/launch/steps/ImageSelectStep.react.js
@@ -7,6 +7,8 @@ import ImageList from "../components/ImageList.react";
 import ComponentHandleInputWithDelay from "components/mixins/ComponentHandleInputWithDelay";
 import InstanceLaunchFooter from "../components/InstanceLaunchFooter.react";
 
+import { filterEndDate } from "utilities/filterCollection";
+
 export default React.createClass({
     displayName: "InstanceLaunchWizardModal-ImageSelectStep",
     mixins: [ComponentHandleInputWithDelay],
@@ -244,7 +246,9 @@ export default React.createClass({
 
     renderSearchInput: function() {
         return (
-        <input ref="searchField"
+        <input
+            style={{ marginBottom: "20px" }}
+            ref="searchField"
             type="text"
             placeholder="Search across image name, tag or description"
             className="form-control search-input"
@@ -288,16 +292,24 @@ export default React.createClass({
         }
 
         let numberOfResults = this.state.page * this.RESULTS_PER_PAGE;
-        let shownImages = new ImageCollection(images.first(numberOfResults));
+        let pagedImages = new ImageCollection(images.first(numberOfResults));
+
+        // Check if we should display the show more button
+        let isMoreImages = images.length > pagedImages.length;
+
+        // Filter out endated images from render
+        let shownImages = pagedImages.cfilter(filterEndDate);
 
         return (
         <div>
             {this.renderSearchInput()}
             {this.renderFilterDescription(shownImages, images.length)}
             <ImageList images={shownImages} onSelectImage={this.props.onSelectImage}>
-                {images.length > shownImages.length
-                 ? this.renderMoreImagesButton()
-                 : null}
+                {       
+                    isMoreImages
+                    ? this.renderMoreImagesButton()
+                    : null
+                }
             </ImageList>
         </div>
         );


### PR DESCRIPTION
Resolves ATMO-1561 
The image list filters out End-dated images while the text representing the number of results did not. This caused the wrong number of items to be shown in the text.

Also, some space was added between the search field and results text to make it not suck.

Before
![screen shot 2016-10-18 at 9 08 03 am](https://cloud.githubusercontent.com/assets/7366338/19529770/2be6302c-95e6-11e6-8f90-f20f89936473.png)

After
<img width="1225" alt="screen shot 2016-10-19 at 9 11 08 am" src="https://cloud.githubusercontent.com/assets/7366338/19529792/3983c014-95e6-11e6-93d2-57c292f19930.png">
