### PR TITLE
ATMO-1560 add zero values to Provider Resources

### DIFF
--- a/troposphere/static/js/components/dashboard/plots/ProviderSummaryLinePlot.react.js
+++ b/troposphere/static/js/components/dashboard/plots/ProviderSummaryLinePlot.react.js
@@ -76,7 +76,7 @@ export default React.createClass({
                     if (this.y != 0) {
                         return (Math.round(this.y * 100) / 100) + "%";
                     } else {
-                        return null;
+                        return "0%";
                     }
                 }
             },


### PR DESCRIPTION
This work was partially done by @lenards in [this PR](https://github.com/iPlantCollaborativeOpenSource/troposphere/pull/480) 

The bottom graph was missed, now it is also happy

Before:
![screen shot 2016-10-18 at 10 04 42 am](https://cloud.githubusercontent.com/assets/7366338/19531133/696f4082-95eb-11e6-9898-1697032845a5.png)

After:
<img width="737" alt="screen shot 2016-10-19 at 10 54 36 am" src="https://cloud.githubusercontent.com/assets/7366338/19531157/7b894be6-95eb-11e6-8dbd-5bb1dc33cc15.png">

