### PR TITLE
ATMO-1562 Part 2, Add Glyphycon

### DIFF
--- a/troposphere/static/js/components/images/detail/ViewImageDetails.react.js
+++ b/troposphere/static/js/components/images/detail/ViewImageDetails.react.js
@@ -6,6 +6,7 @@ import RemovedView from "./removed/RemovedView.react";
 import AuthorView from "./author/AuthorView.react";
 import DescriptionView from "./description/DescriptionView.react";
 import stores from "stores";
+import Gravatar from "components/common/Gravatar.react";
 
 export default React.createClass({
     displayName: "ViewImageDetails",
@@ -40,26 +41,43 @@ export default React.createClass({
 
     render: function() {
         let { image, tags } = this.props;
+        let type = stores.ProfileStore.get().get("icon_set");
         let style = {
             wrapper: {
+                display: "flex",
+                alignItems: "flex-start",
                 marginBottom: "80px",
-                maxWidth: "600px",
+            },
+            img: {
+                borderRadius: "999px",
+                overflow: "hidden",
+                marginRight: "20px",
+                minWidth: "50px",
             },
             details: {
                 marginBottom: "20px",
+                minWidth: "600px",
             }
         };
 
         return (
             <div style={ style.wrapper }>
-                <div style={ style.details }>
-                    <CreatedView image={ image } />
-                    <RemovedView image={ image } />
-                    <AuthorView image={ image } />
-                    <DescriptionView image={ image } />
-                    <TagsView image={ image } tags={ tags } />
+                <div style={ style.img }>
+                    <Gravatar 
+                        hash={image.get("uuid_hash")} 
+                        size={ 50 } type={type} 
+                    />
                 </div>
-                {this.renderEditLink()}
+                <div>
+                    <div style={ style.details }>
+                        <CreatedView image={ image } />
+                        <RemovedView image={ image } />
+                        <AuthorView image={ image } />
+                        <DescriptionView image={ image } />
+                        <TagsView image={ image } tags={ tags } />
+                    </div>
+                    {this.renderEditLink()}
+                </div>
             </div>
         );
     }

--- a/troposphere/static/js/components/images/detail/removed/RemovedView.react.js
+++ b/troposphere/static/js/components/images/detail/removed/RemovedView.react.js
@@ -28,7 +28,7 @@ export default React.createClass({
 
         return (
         <div className="image-info-segment row">
-            <h4 className="t-body-2 col-md-2">Removed from Image List</h4>
+            <h4 className="t-body-2 col-md-2">Removed:</h4>
             <p className="content col-md-10">
                 {endDate}
             </p>


### PR DESCRIPTION
Part 2 of ATMO-1562 asked that the Glyphycon be put back on the Image detail page. This is a good idea as it helps connect the detail to the image clicked. 

<img width="1306" alt="screen shot 2016-10-19 at 3 05 54 pm" src="https://cloud.githubusercontent.com/assets/7366338/19539547/c628ca14-960e-11e6-8ef1-6256498c423a.png">

