### PR TITLE
ATMO-1570 Fix overflow issue, apply conventions

### DIFF
--- a/troposphere/static/css/app/applications.scss
+++ b/troposphere/static/css/app/applications.scss
@@ -234,10 +234,6 @@
 }
 
 /* Search */
-#search-container {
-  text-align: center;
-}
-
 .search-input {
   margin-bottom: 5px;
 }

--- a/troposphere/static/css/app/applications.scss
+++ b/troposphere/static/css/app/applications.scss
@@ -247,14 +247,6 @@
   text-align: left;
 }
 
-.image-tag-list {
-  table {
-    .t-body-2 {
-      min-height: 30px;
-    }
-  }
-}
-
 .tag-title {
   margin-bottom: 10px;
 }

--- a/troposphere/static/css/app/common.scss
+++ b/troposphere/static/css/app/common.scss
@@ -276,7 +276,3 @@ $chosen-sprite-retina-path: $chosen-sprite-path;
         content: attr(data-label);
     }
 }
-
-tr td, tr th {
-    white-space: nowrap;
-}

--- a/troposphere/static/js/bootstrapper.js
+++ b/troposphere/static/js/bootstrapper.js
@@ -4,7 +4,8 @@ import Backbone from "backbone";
 import React from "react";
 import ReactDOM from "react-dom";
 import SplashScreen from "components/SplashScreen.react";
-import MaintenanceScreen from "components/MaintenanceScreen.react";
+// See FIXME below where MaintenanceScreen would have been used
+//import MaintenanceScreen from "components/MaintenanceScreen.react";
 import FunctionalCollection from "collections/FunctionalCollection";
 
 // Important:

--- a/troposphere/static/js/components/images/ImageTagsPage.react.js
+++ b/troposphere/static/js/components/images/ImageTagsPage.react.js
@@ -123,12 +123,17 @@ export default React.createClass({
             <h1 className="t-display-1">
                 Image Tags
             </h1>
-            <div style={{ marginBottom: "30px" }}>
-                <input type="text"
+            <div 
+                id="search-container" 
+                style={{ marginBottom: "30px" }}
+            >
+                <input 
+                    type="text"
                     className="form-control search-input"
                     placeholder="Filter by tag name or description"
                     value={this.state.searchTerm}
-                    onChange={this.handleFilterChange} />
+                    onChange={this.handleFilterChange} 
+                />
                 <h3 className="t-body-2" >
                     { text }
                 </h3>

--- a/troposphere/static/js/components/images/ImageTagsPage.react.js
+++ b/troposphere/static/js/components/images/ImageTagsPage.react.js
@@ -5,59 +5,67 @@ import Router from "react-router";
 export default React.createClass({
     displayName: "ImageTagsPage",
 
-    getState: function() {
+    getState() {
         return {
             images: stores.ImageStore.getAll(),
             tags: stores.TagStore.getAll()
         };
     },
 
-    getInitialState: function() {
+    getInitialState() {
         var state = this.getState();
         state.searchTerm = "";
         return state;
     },
 
-    updateState: function() {
+    updateState() {
         if (this.isMounted()) this.setState(this.getState());
     },
 
-    componentDidMount: function() {
+    componentDidMount() {
         stores.ImageStore.addChangeListener(this.updateState);
         stores.TagStore.addChangeListener(this.updateState);
     },
 
-    componentWillUnmount: function() {
+    componentWillUnmount() {
         stores.ImageStore.removeChangeListener(this.updateState);
         stores.TagStore.removeChangeListener(this.updateState);
     },
 
-    handleFilterChange: function(e) {
+    handleFilterChange(e) {
         var searchTerm = e.target.value;
         this.setState({
             searchTerm: searchTerm
         });
     },
 
-    renderTagRow: function(tag) {
+    renderTagRow(tag) {
         var name = tag.get("name"),
             description = tag.get("description");
 
         return (
-        <tr key={tag.id || tag.cid}>
-            <td style={{ "verticalAlign": "top", "width": "117px" }}>
-                <h4 className="t-body-2" style={{ "margin": "0", "color": "#5A5A5A", "fontSize": "18px" }}><Router.Link to="search" query={{ q: name }}> {name} </Router.Link></h4>
+        <tr key={tag.id || tag.cid}
+            className="card"
+        >
+            <td style={{ paddingRight: "20px", border: "none" }}>
+                <h4 
+                    className="t-body-2" 
+                    style={{ "margin": "0", "color": "#5A5A5A" }}
+                >
+                    <Router.Link to="search" query={{ q: name }}>
+                        {name}
+                    </Router.Link></h4>
             </td>
-            <td>
-                <p style={{ "fontSize": "14px" }}>
+            <td style={{ border: "none" }}>
+                <span style={{ maxWidth: "550px", display: "block" }}>
                     {description}
-                </p>
+                </span>
             </td>
         </tr>
         )
     },
 
-    getFilteredTags: function(tags, searchTerm) {
+    getFilteredTags(tags, searchTerm) {
         var filteredTags = tags;
         searchTerm = searchTerm.trim().toLowerCase();
 
@@ -75,7 +83,7 @@ export default React.createClass({
         return filteredTags;
     },
 
-    renderTagsAsTable: function(tags) {
+    renderTagsAsTable(tags) {
         if (tags) {
             return (
             <table className="table">
@@ -91,7 +99,7 @@ export default React.createClass({
         )
     },
 
-    render: function() {
+    render() {
         var tags = this.state.tags,
             searchTerm = this.state.searchTerm,
             text = "";
@@ -112,20 +120,23 @@ export default React.createClass({
 
         return (
         <div className="container">
-            <div id="search-container">
+            <h1 className="t-display-1">
+                Image Tags
+            </h1>
+            <div style={{ marginBottom: "30px" }}>
                 <input type="text"
                     className="form-control search-input"
                     placeholder="Filter by tag name or description"
                     value={this.state.searchTerm}
                     onChange={this.handleFilterChange} />
-                <hr/>
-                <h3 style={{ textAlign: "left", fontSize: "24px" }}>{text}</h3>
+                <h3 className="t-body-2" >
+                    { text }
+                </h3>
             </div>
             <div className="image-tag-list">
-                {this.renderTagsAsTable(tags)}
+                { this.renderTagsAsTable(tags) }
             </div>
         </div>
         );
-
     }
 });


### PR DESCRIPTION
This PR resolves ATMO-1570 
The Image Tag List was overflowing beyond the view port horizontally.

This PR also fixes some Typography issues and applies some general conventions established on the image search page.
### List Before

![tags-before](https://cloud.githubusercontent.com/assets/7366338/19740156/858ed368-9b72-11e6-96ea-ace357dbfb23.gif)
### List After

![tags-after](https://cloud.githubusercontent.com/assets/7366338/19740161/89a1714a-9b72-11e6-930a-7728374087e1.gif)
### Header Before

<img width="1275" alt="screen shot 2016-10-26 at 11 58 17 am" src="https://cloud.githubusercontent.com/assets/7366338/19740467/a1e7a3b8-9b73-11e6-838c-8321c8e450dd.png">
### Header After

<img width="1255" alt="screen shot 2016-10-26 at 11 58 35 am" src="https://cloud.githubusercontent.com/assets/7366338/19740473/a6defa10-9b73-11e6-8e3f-f2beda3feca5.png">
