### PR TITLE
Remove unused code and comments related to Maintenance Screen

### DIFF
--- a/troposphere/static/js/bootstrapper.js
+++ b/troposphere/static/js/bootstrapper.js
@@ -4,7 +4,6 @@ import Backbone from "backbone";
 import React from "react";
 import ReactDOM from "react-dom";
 import SplashScreen from "components/SplashScreen.react";
-import MaintenanceScreen from "components/MaintenanceScreen.react";
 import FunctionalCollection from "collections/FunctionalCollection";
 
 // Important:
@@ -135,43 +134,12 @@ export default {
         // up to chain.
         var originalSync = Backbone.sync;
         Backbone.sync = function(attrs, textStatus, xhr) {
-            // NOTE: a conceptually simpler solution would be to do this:
-            //
-            //    var xhr = originalSync.apply(this, arguments).catch(function(response){
-            //      if(response.status === 503) {
-            //        $('.splash-image').remove();
-            //        var MaintenanceComponent = React.createFactory(MaintenanceScreen);
-            //        ReactDOM.render(MaintenanceComponent(), document.getElementById('application'));
-            //      }
-            //    });
-            //
-            //    return xhr;
-            //
-            // However, since we're using jQuery deferred objects for the promise chain, and they
-            // don't have a way to cancel promise propagation, we can end up in a scenario where we
-            // display a toast with an error on the maintenance splash screen (because other error
-            // handlers can still get called).  To get around that, we need to create our own promise
-            // and, based on the result of the AJAX request, either manually resolve or reject it.
-
-
             var dfd = $.Deferred();
 
             originalSync.apply(this, arguments).then(function() {
                 dfd.resolve.apply(this, arguments);
             }).fail(function(response) {
                 if (response.status === 503) {
-                    // need to make sure we remove the splash-image element is included in the HTML
-                    // template by default but re-apply the splash screen-class to body so that the
-                    // splash page displays correctly
-                    //FIXME: Either a. make this page look good or b. remove the entire snippet in favor of window.location below
-                    //$(".splash-image").remove();
-                    //$("body").addClass("splash-screen");
-
-                    //// replace the current view with the
-                    //var MaintenanceComponent = React.createFactory(MaintenanceScreen);
-                    //ReactDOM.render(MaintenanceComponent(), document.getElementById("application"));
-
-                    //END-FIXME:
                     window.location = '/maintenance'
                 } else {
                     dfd.reject.apply(this, arguments);


### PR DESCRIPTION
Steve had commented out the logic to show the "react maintenance screen" favoring the static maintenance screen during deploy because the react version was "all busted up". The import definition was still present causing our integration tests to fail. 

Since, Steve has decided that using the static maintenance is a better way to go, this PR is removing the related code so that other PRs against T-T can pass integration tests. 