### PR TITLE
ATMO-1571 fix delete instance header

### DIFF
--- a/troposphere/static/js/components/modals/instance/InstanceDeleteModal.react.js
+++ b/troposphere/static/js/components/modals/instance/InstanceDeleteModal.react.js
@@ -14,44 +14,56 @@ export default React.createClass({
         onConfirm: React.PropTypes.func.isRequired,
     },
 
-    confirm: function() {
+    confirm() {
         this.hide();
         this.props.onConfirm();
     },
 
-    renderBody: function() {
+    renderBody() {
         var instance = this.props.instance;
 
         return (
         <div>
             <p className="alert alert-danger">
                 <Glyphicon name="warning-sign" />
-                <strong>WARNING</strong>
-                {' Data will be'}
-                <strong>{' lost.'}</strong>
+                <strong>
+                    WARNING
+                </strong>
+                    {' Data will be'}
+                <strong>
+                    {' lost.'}
+                </strong>
             </p>
             <div>
                 <p>
-                    {"The following instance " +
-                     "will be shut down and all data will be permanently lost:"}
+                    {
+                        "The following instance " +
+                        "will be shut down and all data will be permanently lost:"
+                    }
                 </p>
                 <ul>
                     <li>
-                        <strong>{instance.get("name") + " #" + instance.get("id")}</strong>
+                        <strong>
+                            {instance.get("name") + " #" + instance.get("id")}
+                        </strong>
                     </li>
                 </ul>
             </div>
             <p>
-                <em>Note:</em>
-                {" Your resource usage charts will not reflect changes until the " +
-                 "instance is completely deleted and has disappeared " +
-                 "from your list of instances."}
+                <em>
+                    Note:
+                </em>
+                {
+                    " Your resource usage charts will not reflect changes until the " +
+                    "instance is completely deleted and has disappeared " +
+                    "from your list of instances."
+                }
             </p>
         </div>
         );
     },
 
-    render: function() {
+    render() {
         let instance = this.props.instance,
             disable = !instance && instance.get("id");
 
@@ -61,13 +73,15 @@ export default React.createClass({
                 <div className="modal-content">
                     <div className="modal-header">
                         {this.renderCloseButton()}
-                        <strong>Delete Instance</strong>
+                        <h1 className="t-title">
+                            Delete Instance
+                        </h1>
                     </div>
                     <div className="modal-body">
                         {this.renderBody()}
                     </div>
                     <div className="modal-footer">
-                        <button type="button" className="btn btn-danger" onClick={this.hide}>
+                        <button type="button" className="btn btn-default" onClick={this.hide}>
                             Cancel
                         </button>
                         <button disabled={disable}


### PR DESCRIPTION
This PR resolves ATMO-1571 

The header on the DeleteInstance was using the wrong font size.
Also, changed the cancel button danger to default as cancel should be something a user feels safe to use. 
### Before

<img width="860" alt="delete-instance" src="https://cloud.githubusercontent.com/assets/7366338/19814843/e14905c4-9cf4-11e6-833f-7dc2faf2a561.png">
### After

<img width="911" alt="screen shot 2016-10-26 at 4 09 56 pm" src="https://cloud.githubusercontent.com/assets/7366338/19814819/c45ca7ae-9cf4-11e6-97ec-dce16241dc3b.png">
