### PR TITLE
ATMO-1584 Add uuid to versions

### DIFF
--- a/troposphere/static/js/components/common/ui/Code.react.js
+++ b/troposphere/static/js/components/common/ui/Code.react.js
@@ -1,0 +1,25 @@
+import React, { PropTypes } from 'react';
+
+const Code = ({ children, mb }) => {
+        return (
+            <div style={{
+                    marginBottom: mb,
+                    lineHeight: "1.5",
+                    fontSize: "10px",
+                    fontWeight: "100",
+                    fontFamily: "Consolas,Monaco,Lucida Console,Liberation Mono,DejaVu Sans Mono,Bitstream Vera Sans Mono,Courier New",
+                    color: "crimson",
+                    paddingRight: "3px",
+                    paddingLeft: "4px", 
+                    border: "solid 1px #d6d4d4",
+                    display: "table",
+                    background: "#efefef",
+                    borderRadius: "2px",
+                }}
+            >
+                { children }
+            </div> 
+        );
+};
+
+export default Code

--- a/troposphere/static/js/components/common/ui/Code.react.js
+++ b/troposphere/static/js/components/common/ui/Code.react.js
@@ -1,25 +1,43 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
 
-const Code = ({ children, mb }) => {
-        return (
-            <div style={{
-                    marginBottom: mb,
-                    lineHeight: "1.5",
-                    fontSize: "10px",
-                    fontWeight: "100",
-                    fontFamily: "Consolas,Monaco,Lucida Console,Liberation Mono,DejaVu Sans Mono,Bitstream Vera Sans Mono,Courier New",
-                    color: "crimson",
-                    paddingRight: "3px",
-                    paddingLeft: "4px", 
-                    border: "solid 1px #d6d4d4",
-                    display: "table",
-                    background: "#efefef",
-                    borderRadius: "2px",
-                }}
-            >
-                { children }
-            </div> 
-        );
+const Code = ({ children, ...rest }) => {
+    let styles = computeStyles(rest);
+
+    return (
+        <div style={ styles.container }>
+            { children }
+        </div>
+    );
+};
+
+const computeStyles = ({ mb }) => {
+    let styles= {};
+    let fontStack = [
+        "Consolas",
+        "Monaco",
+        "Lucida Console",
+        "Liberation Mono",
+        "DejaVu Sans Mono",
+        "Bitstream Vera Sans Mono",
+        "Courier New",
+    ];
+
+    styles.container = {
+        fontFamily: fontStack.join(),
+        marginBottom: mb,
+        lineHeight: "1.5",
+        fontSize: "10px",
+        fontWeight: "100",
+        color: "crimson",
+        paddingRight: "3px",
+        paddingLeft: "4px",
+        border: "solid 1px #d6d4d4",
+        display: "table",
+        background: "#efefef",
+        borderRadius: "2px",
+    };
+
+    return styles
 };
 
 export default Code

--- a/troposphere/static/js/components/common/ui/MediaCard.react.js
+++ b/troposphere/static/js/components/common/ui/MediaCard.react.js
@@ -61,9 +61,6 @@ export default React.createClass({
         let styles = {};
 
         // card
-        let cardCursor = onCardClick 
-            ? "pointer" : "default";
-
         let cardMargin;
         if (isOpen) {
             cardMargin = {
@@ -73,7 +70,6 @@ export default React.createClass({
         }
         styles.card = {
             position: "relative",
-            cursor: cardCursor,
             padding: "10px",
             boxShadow: "0 -1px 0 #e5e5e5,0 0 2px rgba(0,0,0,.12), 0 2px 4px rgba(0,0,0,.24)",
             background: 'white',
@@ -88,9 +84,13 @@ export default React.createClass({
                 marginBottom: "20px"
             } : {};
 
+        let headerCursor = onCardClick 
+            ? "pointer" : "default";
+
         styles.header = {
             display: "flex",
             flexWrap: "wrap",
+            cursor: headerCursor,
             ...openHeader
         };
 

--- a/troposphere/static/js/components/common/ui/MediaCard.react.js
+++ b/troposphere/static/js/components/common/ui/MediaCard.react.js
@@ -10,18 +10,23 @@ export default React.createClass({
             avatar,
             title,
             subheading,
-            description,
+            summary,
+            detail,
         } = this.props;
 
         return (
             <div
-                onClick={ onCardClick }
+                className="MediaCard"
                 style={ style.card }
-            >
-                <div style={ style.avatar }>
-                    { avatar }
-                </div>
-                <div style={ style.content } >
+            >   
+                <div    
+                    className="MediaCard_header"
+                    style={ style.header }
+                    onClick={ onCardClick }
+                >
+                    <div style={ style.avatar }>
+                        { avatar }
+                    </div>
                     <div style={ style.titleSection } >
                         <h2
                             className="t-body-2"
@@ -30,60 +35,100 @@ export default React.createClass({
                             { title }
                         </h2>
                         <div style={ style.subheading } >
-                                { subheading}
+                            { subheading}
                         </div>
                     </div>
-                    <div style={ style.description } >
-                        { description }
+                    <div 
+                        className="MediaCard_summary" 
+                        style={ style.summary } 
+                    >
+                        { summary }
                     </div>
+                </div>
+                <div
+                    className="MediaCard_description"
+                    style={ style.description } 
+                >
+                    { detail }
                 </div>
             </div>
         );
     },
 
     style() {
-        let cardCursor = this.props.onCardClick ?
+        
+        let { onCardClick, isOpen } = this.props;
+        let styles = {};
+
+        // card
+        let cardCursor = onCardClick ?
             "pointer" : "default";
-        return {
-            card: {
-                display: "flex",
-                position: "relative",
-                cursor: cardCursor,
-                padding: "10px",
-                boxShadow: "0 -1px 0 #e5e5e5,0 0 2px rgba(0,0,0,.12),0 2px 4px rgba(0,0,0,.24)",
-                background: 'white',
-            },
 
-            avatar: {
-                display: "table",
-                borderRadius: "50%",
-                overflow: "hidden",
-                marginRight: "20px",
-            },
+        styles.card = {
+            position: "relative",
+            cursor: cardCursor,
+            padding: "10px",
+            boxShadow: "0 -1px 0 #e5e5e5,0 0 2px rgba(0,0,0,.12), 0 2px 4px rgba(0,0,0,.24)",
+            background: 'white',
+        }; 
 
-            content: {
-                display: "flex",
-                flexFlow: "wrap",
-                flex: "1",
-            },
+        // header
+        let openHeader = isOpen 
+            ? { 
+                paddingBottom: "10px",
+                borderBottom: "solid 1px #EFEFEF",
+                marginBottom: "20px"
+            } : {};
 
-            titleSection: {
-                minWidth: "220px",
-                marginRight: "40px"
-            },
+        styles.header = {
+            display: "flex",
+            flexWrap: "wrap",
+            ...openHeader
+        };
 
-            title: {
-                marginBottom: "0",
-            },
+        // avitar
+        styles.avatar = {
+            display: "table",
+            borderRadius: "50%",
+            overflow: "hidden",
+            marginRight: "20px",
+        };
 
-            subheading: {
-                 fontSize: "12px",
-            },
+        // title section
+        styles.titleSection = {
+            minWidth: "200px",
+            marginRight: "40px"
+        };
 
-            description: {
-                minWidth: "250px",
-                flex: "1"
-            },
-        }
+        // title
+        styles.title = {
+            marginBottom: "0",
+        };
+
+        // subheading
+        styles.subheading = {
+             fontSize: "12px",
+        };
+
+        // summary
+        let sumDisplay = isOpen 
+            ? "none" : "block";
+
+        styles.summary = {
+            flex: "1",
+            width: "100%",
+            paddingRight: "35px",
+            display: sumDisplay 
+        };
+        
+        // description
+        let descDisplay = isOpen 
+            ? "block" : "none";
+
+        styles.description = {
+            display: descDisplay
+        };
+       
+        return styles
     },
 });

--- a/troposphere/static/js/components/common/ui/MediaCard.react.js
+++ b/troposphere/static/js/components/common/ui/MediaCard.react.js
@@ -61,15 +61,23 @@ export default React.createClass({
         let styles = {};
 
         // card
-        let cardCursor = onCardClick ?
-            "pointer" : "default";
+        let cardCursor = onCardClick 
+            ? "pointer" : "default";
 
+        let cardMargin;
+        if (isOpen) {
+            cardMargin = {
+                marginTop: "20px",
+                marginBottom: "20px",
+            };
+        }
         styles.card = {
             position: "relative",
             cursor: cardCursor,
             padding: "10px",
             boxShadow: "0 -1px 0 #e5e5e5,0 0 2px rgba(0,0,0,.12), 0 2px 4px rgba(0,0,0,.24)",
             background: 'white',
+            ...cardMargin,
         }; 
 
         // header

--- a/troposphere/static/js/components/images/detail/availability/AvailabilityView.react.js
+++ b/troposphere/static/js/components/images/detail/availability/AvailabilityView.react.js
@@ -13,7 +13,7 @@ export default React.createClass({
 
     renderProviderMachine( provider ) {
         let { isSummary } = this.props;
-        debugger;
+
         // Hide 'end-dated' provider_machines
         let endDate = provider.get( "end_date" );
         if (endDate && endDate.isValid()) return;

--- a/troposphere/static/js/components/images/detail/availability/AvailabilityView.react.js
+++ b/troposphere/static/js/components/images/detail/availability/AvailabilityView.react.js
@@ -1,32 +1,56 @@
 import React from "react";
 import Backbone from "backbone";
 import stores from "stores";
-
+import Code from "components/common/ui/Code.react.js";
 
 export default React.createClass({
     displayName: "AvailabilityView",
 
     propTypes: {
-        version: React.PropTypes.instanceOf(Backbone.Model).isRequired
+        version: React.PropTypes
+            .instanceOf( Backbone.Model ).isRequired
     },
 
-    renderProviderMachine: function(provider_machine) {
+    renderProviderMachine( provider ) {
+        let { isSummary } = this.props;
+
         // Hide 'end-dated' provider_machines
-        let endDate = provider_machine.get("end_date");
+        let endDate = provider( "end_date" );
         if (endDate && endDate.isValid()) return;
 
+        // Assign strings for render
+        let machineID = provider.get( "uuid" );
+        let providerName = provider.get( "provider" ).name;
+
+        // Optionally render the UUID if not set as
+        // summary by parent
+        let optMachineID = isSummary ? null
+            : (
+                <Code mb="10px" >
+                    { machineID }
+                </Code>
+            );
+
+        let key = `${providerName}-${machineID}`;
         return (
-            <div key={provider_machine.get("id")}>
-                {provider_machine.get("provider").name}
+            <div key={ key }>
+                { providerName }
+                { optMachineID }
             </div>
         )
     },
 
-    render: function() {
-        let machines = stores.ProviderMachineStore
-            .getMachinesForVersion(this.props.version);
+    render() {
+        let { version } = this.props;
 
-        let providers = machines ? machines.map(this.renderProviderMachine)
+        // Get providers this version is available on
+        let machines = stores.ProviderMachineStore
+            .getMachinesForVersion(version);
+
+        // If there are any providers for this machine
+        // map to render the list
+        let providers = machines
+            ? machines.map(this.renderProviderMachine)
             : null;
 
         return (
@@ -35,11 +59,10 @@ export default React.createClass({
                     className="t-body-2"
                     style={{ marginBottom: "5px" }}
                 >
-                Available on:
+                    Available on
                 </h4>
                 { providers }
             </div>
         );
-
-    }
+    },
 });

--- a/troposphere/static/js/components/images/detail/availability/AvailabilityView.react.js
+++ b/troposphere/static/js/components/images/detail/availability/AvailabilityView.react.js
@@ -13,9 +13,9 @@ export default React.createClass({
 
     renderProviderMachine( provider ) {
         let { isSummary } = this.props;
-
+        debugger;
         // Hide 'end-dated' provider_machines
-        let endDate = provider( "end_date" );
+        let endDate = provider.get( "end_date" );
         if (endDate && endDate.isValid()) return;
 
         // Assign strings for render

--- a/troposphere/static/js/components/images/detail/availability/AvailabilityView.react.js
+++ b/troposphere/static/js/components/images/detail/availability/AvailabilityView.react.js
@@ -24,12 +24,14 @@ export default React.createClass({
 
         // Optionally render the UUID if not set as
         // summary by parent
-        let optMachineID = isSummary ? null
-            : (
+        let optMachineID;
+        if (!isSummary) {
+            optMachineID = (
                 <Code mb="10px" >
                     { machineID }
                 </Code>
             );
+        }
 
         let key = `${providerName}-${machineID}`;
         return (
@@ -49,9 +51,11 @@ export default React.createClass({
 
         // If there are any providers for this machine
         // map to render the list
-        let providers = machines
-            ? machines.map(this.renderProviderMachine)
-            : null;
+        let providers;
+        if ( machines ) {
+            providers = machines
+                .map(this.renderProviderMachine);
+        }
 
         return (
             <div>

--- a/troposphere/static/js/components/images/detail/versions/Version.react.js
+++ b/troposphere/static/js/components/images/detail/versions/Version.react.js
@@ -34,7 +34,6 @@ export default React.createClass({
     },
 
     onCardClick() {
-        console.log('clicked')
         let isOpen = this.state.isOpen
             ? false : true;
 

--- a/troposphere/static/js/components/images/detail/versions/Version.react.js
+++ b/troposphere/static/js/components/images/detail/versions/Version.react.js
@@ -34,8 +34,7 @@ export default React.createClass({
     },
 
     onCardClick() {
-        let isOpen = this.state.isOpen
-            ? false : true;
+        let isOpen = !this.state.isOpen;
 
         this.setState({
             isOpen
@@ -150,6 +149,10 @@ export default React.createClass({
             </span>
         );
 
+        // Note: we are passing 'renderDetail' to both 'detail' and 'summary'
+        // This is because we are toggling the render of 'Availability' based on 'isOpen'
+        // In many cases we would rather pass two different components or are not controling 'isOpen
+        // In this case, the cahnge is so small and we are controlling 'isOpen'
         return (
             <MediaCard
                 onCardClick={ this.onCardClick }
@@ -189,14 +192,14 @@ export default React.createClass({
                 width: "100%",
                 maxWidth: "700px"
             } : {};
-        
+
         styles.description = {
             marginRight: "40px",
             flex: "1",
             ...descriptionWidth
         };
 
-        // availability 
+        // availability
         let availabilityWidth = isOpen
             ? {
                 width: "100%",

--- a/troposphere/static/js/components/images/detail/versions/Version.react.js
+++ b/troposphere/static/js/components/images/detail/versions/Version.react.js
@@ -9,7 +9,6 @@ import globals from "globals";
 import moment from "moment";
 import showdown from "showdown";
 
-
 export default React.createClass({
     displayName: "Version",
 
@@ -139,7 +138,6 @@ export default React.createClass({
     render() {
         // todo: figure out if anything is ever recommended, or if it's just a concept idea
         let { version, image } = this.props;
-        let styles = this.styles();
 
         let versionHash = CryptoJS.MD5(version.id.toString()).toString();
         let type = stores.ProfileStore.get().get("icon_set");
@@ -152,6 +150,7 @@ export default React.createClass({
                 { this.renderEditLink() }
             </span>
         );
+
         return (
             <MediaCard
                 onCardClick={ this.onCardClick }
@@ -175,41 +174,45 @@ export default React.createClass({
         let isOpen = this.state.isOpen;
         let styles = {}
 
-            let contentDisplay = isOpen
-                ? "block" : "flex";
-            styles.content = {
-                display: contentDisplay,
-                flexWrap: "wrap",
-                justifyContent: "space-between",
+        // content
+        let contentDisplay = isOpen
+            ? "block" : "flex";
+
+        styles.content = {
+            display: contentDisplay,
+            flexWrap: "wrap",
+            justifyContent: "space-between",
+        };
+
+        // description
+        let descriptionWidth = isOpen
+            ? {
+                width: "100%",
+                maxWidth: "700px"
+            } : {};
+        
+        styles.description = {
+            marginRight: "40px",
+            flex: "1",
+            ...descriptionWidth
+        };
+
+        // availability 
+        let availabilityWidth = isOpen
+            ? {
+                width: "100%",
+            }
+            : {
+                width: "30%",
+                minWidth: "200px",
             };
 
-            let descriptionWidth = isOpen
-                ? {
-                    width: "100%",
-                    maxWidth: "700px"
-                } : {};
+        styles.availability = {
+            fontSize: "12px",
+            ...availabilityWidth,
+        };
 
-            styles.description = {
-                marginRight: "40px",
-                flex: "1",
-                ...descriptionWidth
-            };
-
-
-            let availabilityWidth = isOpen
-                ? {
-                    width: "100%",
-                }
-                : {
-                    width: "30%",
-                    minWidth: "200px",
-                };
-
-            styles.availability = {
-                fontSize: "12px",
-                ...availabilityWidth,
-            };
-
+        // return result
         return styles;
     }
 });

--- a/troposphere/static/js/components/images/detail/versions/Version.react.js
+++ b/troposphere/static/js/components/images/detail/versions/Version.react.js
@@ -152,7 +152,7 @@ export default React.createClass({
         // Note: we are passing 'renderDetail' to both 'detail' and 'summary'
         // This is because we are toggling the render of 'Availability' based on 'isOpen'
         // In many cases we would rather pass two different components or are not controling 'isOpen
-        // In this case, the cahnge is so small and we are controlling 'isOpen'
+        // In this case, the change is so small and we are controlling 'isOpen'
         return (
             <MediaCard
                 onCardClick={ this.onCardClick }

--- a/troposphere/static/js/components/images/list/common/ImageListCard.react.js
+++ b/troposphere/static/js/components/images/list/common/ImageListCard.react.js
@@ -114,7 +114,7 @@ export default React.createClass({
                         <strong> { image.get("created_by").username }</strong>
                     </span>
                 }
-                description={
+                summary={
                     <span>
                         { this.renderEndDated() }
                         { bookmark }


### PR DESCRIPTION


The UUID was originally removed from the Version Card Summary as it was secondary information and detracted from the core information on the card. However, this UUID is used for troubleshooting and a user might be asked to provide it. 

This PR adds a detail view on the card by clicking it, revealing the UUID's in a new Code component for better readability. 

_Note: If we still want this to go onto S-S let me know and I can rebase and make a separate PR_ 


<details>


### Changes

- All files touched change React class methods to use property short hand syntax ( this gives us named functions for better debugging and is easer to read). 
```
funcName: function() { ... }
 
// Is equal to  
funcName() { ... }

// Is equal to
let funcName = function() { ... }
funcName:  funcName
``` 
- Refactored `MediaCard` component 
    - optionally display more detail when clicked.
    - Added isOpen prop
    - Changed `description` prop to `summary` and `detail`
- Updated ImageListsCard to use `summary` prop
- Changed `AvailabilityView` component
    - Add optional UUID block
    - Add `isSummary` prop
-  Refactored `Version` component
    - Pull version details out into own method
    - Handle `onCardClick`
- New `Code` component`
</details>

![with-two](https://cloud.githubusercontent.com/assets/7366338/20121240/97d6e398-a5cd-11e6-80a6-17d8829b716e.gif)

![version-card](https://cloud.githubusercontent.com/assets/7366338/20065318/e73e6e6e-a4ca-11e6-877a-638e59e6329f.gif)

