### PR TITLE
Make SSH key names wrap, not overlap other content

### DIFF
--- a/troposphere/static/js/components/settings/advanced/SSHConfiguration.react.js
+++ b/troposphere/static/js/components/settings/advanced/SSHConfiguration.react.js
@@ -97,13 +97,23 @@ export default React.createClass({
         }, function() {});
     },
 
+    style() {
+        return {
+            td: {
+                wordWrap: "break-word",
+                whiteSpace: "normal"
+            }
+        }
+    },
+
     renderSSHKeyRow: function(sshKey) {
+        let { td } = this.style();
         return (
         <tr key={sshKey.get("id")}>
-            <td>
+            <td style={td}>
                 {sshKey.get("name")}
             </td>
-            <td style={{ wordWrap: "break-word", whiteSpace: "normal" }}>
+            <td style={td}>
                 {sshKey.get("pub_key").replace(/\n/g, " ")}
             </td>
             <td>


### PR DESCRIPTION

This pr addresses: https://pods.iplantcollaborative.org/jira/browse/ATMO-1463
It is ready for review.

![screen shot 2016-11-07 at 3 39 29 pm](https://cloud.githubusercontent.com/assets/3847314/20079165/b5dab3d8-a500-11e6-9c24-d2450b4dc024.png)

Here is the diff (the one below has highlight issues):
```diff
diff --git a/troposphere/static/js/components/settings/advanced/SSHConfiguration.react.js b/troposphere/static/js/components/settings/advanced/SSHConfiguration.react.js
index 3f6004b..bd53357 100644
--- a/troposphere/static/js/components/settings/advanced/SSHConfiguration.react.js
+++ b/troposphere/static/js/components/settings/advanced/SSHConfiguration.react.js
@@ -97,13 +97,23 @@ export default React.createClass({
         }, function() {});
     },
 
+    style() {
+        return {
+            td: {
+                wordWrap: "break-word",
+                whiteSpace: "normal"
+            }
+        }
+    },
+
     renderSSHKeyRow: function(sshKey) {
+        let { td } = this.style();
         return (
         <tr key={sshKey.get("id")}>
-            <td>
+            <td style={td}>
                 {sshKey.get("name")}
             </td>
-            <td style={{ wordWrap: "break-word", whiteSpace: "normal" }}>
+            <td style={td}>
                 {sshKey.get("pub_key").replace(/\n/g, " ")}
             </td>
             <td>
```