### PR TITLE
Remove ambiguity in duplicate call to renderDetail 

### DIFF
--- a/troposphere/static/js/components/images/detail/versions/Version.react.js
+++ b/troposphere/static/js/components/images/detail/versions/Version.react.js
@@ -129,6 +129,8 @@ export default React.createClass({
                     isSummary={ !isOpen }
                     version={ version } />
             );
+        } else {
+            providerAvailability = "Please login to view available providers.";
         }
 
         return (

--- a/troposphere/static/js/components/images/detail/versions/Version.react.js
+++ b/troposphere/static/js/components/images/detail/versions/Version.react.js
@@ -23,12 +23,10 @@ export default React.createClass({
         version: React.PropTypes.instanceOf(Backbone.Model).isRequired,
         onEditClicked: React.PropTypes.func,
         editable: React.PropTypes.bool,
-        showAvailability: React.PropTypes.bool
     },
 
     getDefaultProps() {
         return {
-            showAvailability: true,
             editable: true
         }
     },

--- a/troposphere/static/js/components/images/detail/versions/Version.react.js
+++ b/troposphere/static/js/components/images/detail/versions/Version.react.js
@@ -5,6 +5,7 @@ import MediaCard from "components/common/ui/MediaCard.react";
 import AvailabilityView from "../availability/AvailabilityView.react";
 import CryptoJS from "crypto-js";
 import stores from "stores";
+import context from "context";
 import globals from "globals";
 import moment from "moment";
 import showdown from "showdown";
@@ -41,21 +42,6 @@ export default React.createClass({
 
     onEditClicked() {
         return this.props.onEditClicked(this.props.version);
-    },
-
-    renderAvailability() {
-        let isOpen = this.state.isOpen;
-        let version = this.props.version;
-        if (!this.props.showAvailability) {
-            return;
-        }
-
-        return (
-        <AvailabilityView
-            isSummary={ !isOpen }
-            version={ version }
-        />
-        );
     },
 
     renderEditLink() {
@@ -106,29 +92,53 @@ export default React.createClass({
 
     },
 
-    renderDetail() {
+    renderChangeLog() {
         let { version } = this.props;
         let styles = this.styles();
-
         let changeLog = version.get("change_log");
         let converter = new showdown.Converter();
         let changeLogHTML = converter.makeHtml(changeLog);
 
         return (
-            <div
-                style={ styles.content }
-            >
-                <div style={ styles.description }
-                    dangerouslySetInnerHTML={{
-                        __html: changeLogHTML
-                    }}
-                />
-                <div style={ styles.availability }
-                >
-                    { this.renderAvailability() }
-                </div>
+        <div style={ styles.description }
+            dangerouslySetInnerHTML={{
+                __html: changeLogHTML
+            }}
+        />
+       );
+    },
+
+    renderSummary() {
+        let styles = this.styles();
+        return (
+        <div style={ styles.content }>
+            { this.renderChangeLog() }
+        </div>
+       );
+    },
+
+    renderDetail() {
+        let { version } = this.props;
+        let styles = this.styles();
+        let isOpen = this.state.isOpen;
+
+        let providerAvailability;
+        if (context.hasLoggedInUser()) {
+            providerAvailability = (
+                <AvailabilityView
+                    isSummary={ !isOpen }
+                    version={ version } />
+            );
+        }
+
+        return (
+        <div style={ styles.content }>
+            { this.renderChangeLog() }
+            <div style={ styles.availability } >
+                { providerAvailability }
             </div>
-        )
+        </div>
+        );
     },
 
     render() {
@@ -147,10 +157,6 @@ export default React.createClass({
             </span>
         );
 
-        // Note: we are passing 'renderDetail' to both 'detail' and 'summary'
-        // This is because we are toggling the render of 'Availability' based on 'isOpen'
-        // In many cases we would rather pass two different components or are not controling 'isOpen
-        // In this case, the cahnge is so small and we are controlling 'isOpen'
         return (
             <MediaCard
                 onCardClick={ this.onCardClick }
@@ -164,7 +170,7 @@ export default React.createClass({
                         type={type}
                     />
                 }
-                summary={ this.renderDetail() }
+                summary={ this.renderSummary() }
                 detail={ this.renderDetail() }
             />
         );

--- a/troposphere/static/js/components/images/detail/versions/VersionList.react.js
+++ b/troposphere/static/js/components/images/detail/versions/VersionList.react.js
@@ -13,11 +13,9 @@ export default React.createClass({
         image: React.PropTypes.instanceOf(Backbone.Model).isRequired,
         versions: React.PropTypes.instanceOf(Backbone.Collection).isRequired,
         editable: React.PropTypes.bool,
-        showAvailability: React.PropTypes.bool
     },
     getDefaultProps: function() {
         return {
-            showAvailability: true,
             editable: true
         }
     },
@@ -56,7 +54,6 @@ export default React.createClass({
             version={version}
             image={this.props.image}
             editable={this.props.editable}
-            showAvailability={this.props.showAvailability}
             onEditClicked={this.openEditVersion} />
         );
     },

--- a/troposphere/static/js/components/images/detail/versions/VersionsView.react.js
+++ b/troposphere/static/js/components/images/detail/versions/VersionsView.react.js
@@ -1,6 +1,5 @@
 import React from "react";
 import Backbone from "backbone";
-import context from "context";
 import stores from "stores";
 import VersionList from "./VersionList.react";
 

--- a/troposphere/static/js/components/images/detail/versions/VersionsView.react.js
+++ b/troposphere/static/js/components/images/detail/versions/VersionsView.react.js
@@ -13,8 +13,7 @@ export default React.createClass({
     },
     render: function() {
         var image = this.props.image,
-            versions = stores.ImageStore.getVersions(image.id),
-            showAvailableOn = context.hasLoggedInUser();
+            versions = stores.ImageStore.getVersions(image.id);
 
         if (!versions) {
             return (<div className="loading" />);
@@ -24,8 +23,7 @@ export default React.createClass({
             <h4 className="t-title">Versions</h4>
             <VersionList image={image}
                 versions={versions}
-                editable={true}
-                showAvailability={showAvailableOn} />
+                editable={true} />
         </div>
         );
     }


### PR DESCRIPTION
When reviewing the code, I noticed that the availability flag was being passed very far down, which was unneccessary (and it was only being used for this subview). It was removed, in preference of a test whether the user is logged in.

The code for detailView was broken into `summaryView` and `detailView`. The changelog was factored out.

When the card expanded in the public catalog, it would expand to an empty card. Now it displays a message:

![](http://g.recordit.co/FBEy07mU4V.gif)
