### PR TITLE
Improvement add context for Sentry error logging

### DIFF
--- a/troposphere/static/js/components/SplashScreen.react.js
+++ b/troposphere/static/js/components/SplashScreen.react.js
@@ -6,6 +6,8 @@ import stores from "stores";
 import Router from "../Router";
 import routes from "../AppRoutes.react";
 
+import Raven from "raven-js";
+
 export default React.createClass({
     displayName: "SplashScreen",
 
@@ -51,6 +53,15 @@ export default React.createClass({
                     }
                 // TODO: The current logged in user's sign-up date as a Unix timestamp.
                 //created_at: 1234567890
+                });
+            }
+
+            if (Raven && Raven.isSetup()){
+                Raven.setUserContext({
+                    id: profile.get("user"),
+                    name: profile.get("username"),
+                    email: profile.get("email"),
+                    username: profile.get("username")
                 });
             }
 


### PR DESCRIPTION
We get excellent feedback from `raven-js` thanks to Sentry. But, we are missing _out_ on knowing which community member is experiencing that error. 

This pull request including the username & email for the community member in the error report provided via `raven-js`. 