### PR TITLE
Use settings.DEBUG to decide if Sentry+Raven should be instantiated. 

### DIFF
--- a/troposphere/static/js/main.js
+++ b/troposphere/static/js/main.js
@@ -3,10 +3,10 @@ import bootstrapper from "bootstrapper";
 import "css/app/app.scss";
 import Raven from "raven-js";
 
-let sentryDSN = "https://27643f06676048be96ad6df686c17da3@app.getsentry.com/73366";
-
-Raven.config(sentryDSN, {
-    release: "205096b5fde3a47303ad8d1fef9ff8052cbbd7d4"
-}).install();
-
+if(!window.SENTRY_ENABLED) {
+    let sentryDSN = window.SENTRY_DSN;
+    Raven.config(sentryDSN, {
+        release: window.SENTRY_RELEASE,
+    }).install();
+}
 bootstrapper.run();

--- a/troposphere/templates/index.html
+++ b/troposphere/templates/index.html
@@ -140,6 +140,14 @@
     var USE_ALLOCATION_SOURCES = false;
 {% endif %}
 
+{% if sentry %}
+    var SENTRY_ENABLED = true;
+    var SENTRY_RELEASE = {{ sentry.release }}
+    var SENTRY_DSN = {{ sentry.dsn }}
+{%  else %}
+    var SENTRY_ENABLED = false;
+{% endif %}
+
 {% if notice %}
     var maint_notice = {
          title: "{{notice.title}}",

--- a/troposphere/views/app.py
+++ b/troposphere/views/app.py
@@ -69,12 +69,22 @@ def _populate_template_params(request, maintenance_records, notice_t, disabled_l
         notice = notice_t[1] if not notice_t[2] else None
     logger.info("maintenance notice tuple: {0}".format(notice_t))
 
+    #NOTE: Now that we've moved this section from .js to Django, sentry configuration _could_ become more dynamic:
+    if settings.DEBUG:
+        sentry_dict = None
+    else:
+        sentry_dict = {
+            "dsn": "https://27643f06676048be96ad6df686c17da3@app.getsentry.com/73366",
+            "release":"205096b5fde3a47303ad8d1fef9ff8052cbbd7d4",
+        }
+
     template_params = {
         'access_token': request.session.get('access_token'),
         'emulator_token': request.session.get('emulator_token'),
         'emulator': request.session.get('emulator'),
         'records': maintenance_records,
         'notice': notice,
+        'sentry': sentry_dict,
         'new_relic_enabled': enable_new_relic,
         'show_public_site': public
     }


### PR DESCRIPTION
Additionally, bring the configuration block from `js` to `python`