### PR TITLE
Export credentials for use with client tools

### DIFF
--- a/troposphere/static/js/bootstrapper.js
+++ b/troposphere/static/js/bootstrapper.js
@@ -29,6 +29,7 @@ import stores from "stores";
 
 stores.AllocationStore = require("stores/AllocationStore");
 stores.BadgeStore = require("stores/BadgeStore");
+stores.ClientCredentialStore = require("stores/ClientCredentialStore");
 stores.ExternalLinkStore = require("stores/ExternalLinkStore");
 stores.HelpLinkStore = require("stores/HelpLinkStore");
 stores.ImageStore = require("stores/ImageStore");

--- a/troposphere/static/js/components/modals/ExportCredential.react.js
+++ b/troposphere/static/js/components/modals/ExportCredential.react.js
@@ -1,0 +1,243 @@
+import React from "react";
+import ReactDOM from "react-dom";
+
+import moment from "moment";
+
+import BootstrapModalMixin from "components/mixins/BootstrapModalMixin.react";
+import stores from "stores";
+
+
+/**
+ * Merges the argument model with a `openrc` credential template.
+ *
+ * @param {Backbone.Model} credModel - contains credential values associated
+ *                                     with a community members OpenStack identity
+ */
+function populateOpenRCTemplate(credModel) {
+    let exportTime = moment().format("MMM DD, YYYY hh:mm a");
+
+    let openrc = `# generated on ${exportTime}
+export OS_PROJECT_NAME=${credModel.get("OS_PROJECT_NAME")}
+export OS_USERNAME=${credModel.get("OS_USERNAME")}
+export OS_IDENTITY_API_VERSION=${credModel.get("OS_IDENTITY_API_VERSION")}
+export OS_USER_DOMAIN_NAME=${credModel.get("OS_USER_DOMAIN_NAME")}
+export OS_TENANT_NAME=${credModel.get("OS_TENANT_NAME")}
+export OS_AUTH_URL=${credModel.get("OS_AUTH_URL")}
+export OS_PROJECT_DOMAIN_NAME=${credModel.get("OS_PROJECT_DOMAIN_NAME")}
+export OS_REGION_NAME=${credModel.get("OS_REGION_NAME")}
+export OS_PASSWORD=<REDACTED>
+`;
+
+    return openrc;
+}
+
+
+export default React.createClass({
+
+    mixins: [BootstrapModalMixin],
+
+    getInitialState() {
+        return {
+            identityUUID: "",
+            step: 0,
+        }
+    },
+
+    updateState() {
+        if (this.state.step === 0) {
+            this.setState(this.getInitialState());
+        } else {
+            // - new data has arrived
+            // - indicate a need for re-render
+            this.setState(this.state);
+        }
+    },
+
+    componentDidMount() {
+        stores.ClientCredentialStore.addChangeListener(this.updateState);
+
+        // NOTE: this is to avoid issues with data arriving after the
+        // component as `mounted`
+        this.updateState();
+    },
+
+    componentWillUnmount() {
+        stores.ClientCredentialStore.removeChangeListener(this.updateState);
+    },
+
+    updateSelect(e) {
+        let identityUUID = e.target.value;
+
+        this.setState({
+            identityUUID
+        });
+    },
+
+    onSelect(e) {
+        e.preventDefault();
+        this.setState({
+            identityUUID: this.state.identityUUID,
+            step: 1
+        });
+    },
+
+    renderIdentities(identities) {
+        return identities.map((identity) => {
+            let provider = identity.get("provider"),
+                identityUUID = identity.get("uuid"),
+                key = identity.id || identity.cid,
+                inputId = provider.name.replace(' ','-') + key;
+
+            return (
+                <div className="form-check">
+                <label className="form-check-label">
+                    <input key={key}
+                           id={inputId}
+                           name="identities"
+                           type="radio"
+                           className="form-check-input"
+                           value={identityUUID}
+                           onChange={this.updateSelect} />
+                    {` ${provider.name}`}
+                </label>
+                </div>
+            );
+
+        });
+    },
+
+    renderSelect(identities) {
+        let cannotGenerate = true;
+
+        if (identities) {
+            cannotGenerate = false;
+        }
+
+        return (
+        <div className="modal-content">
+            <div className="modal-header">
+                {this.renderCloseButton()}
+                <h1 className="t-title">Select provider</h1>
+            </div>
+            <div style={{ minHeight: "300px" }} className="modal-body">
+                <p>
+                    Each Atmosphere "provider" will have different credentials for you.
+                    Please select the provider to export:
+                </p>
+                <div className="form-group">
+                    {this.renderIdentities(identities)}
+                </div>
+            </div>
+            <div className="modal-footer">
+                <button type="button"
+                        className="btn btn-danger"
+                        onClick={this.hide}>
+                    Cancel
+                </button>
+                <button type="button"
+                        aria-invalid={cannotGenerate}
+                        className="btn btn-primary"
+                        onClick={this.onSelect}
+                        disabled={cannotGenerate}>
+                    Export
+                </button>
+            </div>
+        </div>
+        );
+    },
+
+    copyOpenrc(e) {
+        console.log(e);
+        console.log(this.refs.openrcExport);
+        let range = document.createRange(),
+            selection = document.getSelection();
+
+        // for good measure - clear all previous selections
+        selection.removeAllRanges()
+
+        let el = document.querySelector("#openrc");
+        let rhar = ReactDOM.findDOMNode(this.refs.openrcExport);
+
+        range.selectNode(el);
+        selection.addRange(range);
+
+        var successful = document.execCommand('copy');
+
+        // let's leave things in a clean _selection_ state
+        selection.removeAllRanges()
+    },
+
+    renderGenerate() {
+        let identityUUID = this.state.identityUUID,
+            credential =
+                stores.ClientCredentialStore.getForIdentity(identityUUID);
+
+        if (!credential) {
+            return (
+            <div className="modal-content">
+                <div className="modal-header">
+                    {this.renderCloseButton()}
+                    <h1 className="t-title">Exporting credential ...</h1>
+                </div>
+                <div style={{ minHeight: "300px" }} className="modal-body">
+                    <div className="loading"></div>
+                </div>
+            </div>
+            );
+        }
+
+        let openrc = populateOpenRCTemplate(credential);
+
+        return (
+        <div className="modal-content">
+            <div className="modal-header">
+                {this.renderCloseButton()}
+                <h1 className="t-title">Exported Credential</h1>
+            </div>
+            <div style={{ minHeight: "300px" }} className="modal-body">
+                <p>
+                    Copy the exported credential and paste into a file.
+                    This file will be used within a shell scripting
+                    environment to "export" the necessary information
+                    used by command-line interfaces (CLI) for the
+                    OpenStack APIs.
+                </p>
+                <pre id="openrc" ref="openrcExport">
+                    {openrc}
+                </pre>
+            </div>
+            <div className="modal-footer">
+                <button type="button"
+                        className="btn btn-primary"
+                        onClick={this.hide}>
+                    Okay
+                </button>
+            </div>
+        </div>
+        );
+    },
+
+    renderContent(identities) {
+        if (this.state.step === 0) {
+            return this.renderSelect(identities);
+        } else if (this.state.step === 1) {
+            return this.renderGenerate();
+        }
+    },
+
+    render() {
+        let identities = stores.IdentityStore.getAll();
+
+        if (!identities) {
+            return (<div className="loading"></div>);
+        }
+
+        return (
+        <div className="modal fade">
+            <div className="modal-dialog">
+                {this.renderContent(identities)}
+            </div>
+        </div>
+        );
+    }
+});

--- a/troposphere/static/js/components/modals/ExportCredential.react.js
+++ b/troposphere/static/js/components/modals/ExportCredential.react.js
@@ -25,7 +25,7 @@ export OS_TENANT_NAME=${credModel.get("OS_TENANT_NAME")}
 export OS_AUTH_URL=${credModel.get("OS_AUTH_URL")}
 export OS_PROJECT_DOMAIN_NAME=${credModel.get("OS_PROJECT_DOMAIN_NAME")}
 export OS_REGION_NAME=${credModel.get("OS_REGION_NAME")}
-export OS_PASSWORD=<REDACTED>
+export OS_PASSWORD=${credModel.get("OS_PASSWORD")}
 `;
 
     return openrc;

--- a/troposphere/static/js/components/settings/AdvancedSettingsPage.react.js
+++ b/troposphere/static/js/components/settings/AdvancedSettingsPage.react.js
@@ -1,7 +1,11 @@
 import React from "react";
+
 import SSHConfiguration from "components/settings/advanced/SSHConfiguration.react";
+import ClientCredentials from "components/settings/advanced/ClientCredentials.react";
+
 
 export default React.createClass({
+    displayName: "AdvancedSettingsPages",
 
     getInitialState: function() {
         return {
@@ -22,6 +26,7 @@ export default React.createClass({
     renderMore: function() {
         return (
         <div style={{ marginLeft: "30px" }}>
+            <ClientCredentials/>
             <SSHConfiguration/>
             <button onClick={this.showToggle}>
                 Show Less

--- a/troposphere/static/js/components/settings/advanced/ClientCredentials.react.js
+++ b/troposphere/static/js/components/settings/advanced/ClientCredentials.react.js
@@ -1,0 +1,96 @@
+import React from "react";
+import ModalHelpers from "components/modals/ModalHelpers";
+import ExportCredentialModal from "components/modals/ExportCredential.react";
+
+import stores from "stores";
+import globals from "globals";
+
+export default React.createClass({
+    displayName: "ClientCredentials",
+
+    getInitialState() {
+        // the modal for exporting (cloud client) credentials will
+        // need the identities available to allow for selection ...
+        // this modal will be launched by this components, so we
+        // are trying to do a bit of "eager" data fetching here
+        return {
+            displayMoreInfo: false,
+            identities: stores.IdentityStore.getAll()
+        };
+
+    },
+
+    updateState() {
+        this.setState(this.getInitialState());
+    },
+
+    componentDidMount() {
+        stores.IdentityStore.addChangeListener(this.updateState);
+    },
+
+    componentWillUnmount() {
+        stores.IdentityStore.removeChangeListener(this.updateState);
+    },
+
+    launchExportCred() {
+        ModalHelpers.renderModal(
+            ExportCredentialModal,
+            {},
+            function() {}
+        );
+    },
+
+    onDisplayMoreInfo(e) {
+        e.preventDefault();
+
+        this.setState({
+            displayMoreInfo: true
+        });
+    },
+
+    renderMoreInfo() {
+        if (this.state.displayMoreInfo) {
+            return (
+            <div>
+                <p>
+                    Atmosphere is built on-top of "cloud providers". With exported
+                    credentials, you can use the command-line interfaces (CLI) &
+                    client libraries for OpenStack APIs. One such CLI is openstack,
+                    it is generally equivalent to the CLIs provided by the OpenStack
+                    project client libraries, but with a distinct and consistent
+                    command structure.
+                </p>
+                <p>
+                    For more information about the openstack CLI, see the
+                    OpenStack <a href="http://docs.openstack.org/developer/python-openstackclient/man/openstack.html">
+                    documentation</a>.
+                </p>
+            </div>
+            );
+        }
+        return (
+        <p>
+            Click <a onClick={this.onDisplayMoreInfo}>here</a> to learn more.
+        </p>
+        );
+    },
+
+    render() {
+        return (
+        <div>
+            <h3>Export Credentials</h3>
+            <div style={{maxWidth: "600px"}}>
+                <p>
+                    Bring your credentials outside of Atmosphere to use with client libraries & other cloud tools.
+                    Once you have credentials exported, you can directly use OpenStack API clients.
+                </p>
+                {  this.renderMoreInfo() }
+                <button onClick={this.launchExportCred}>
+                    Export
+                </button>
+            </div>
+
+        </div>
+        );
+    }
+});

--- a/troposphere/static/js/models/ClientCredential.js
+++ b/troposphere/static/js/models/ClientCredential.js
@@ -1,0 +1,20 @@
+import Backbone from "backbone";
+import globals from "globals";
+
+export default Backbone.Model.extend({
+
+    parse: function(response) {
+        debugger;
+        return response;
+    },
+
+    url: function() {
+        let identityId = this.get("identity_uuid");
+
+        return (
+        globals.API_V2_ROOT +
+        "/identities/" + identityId +
+        "/export"
+        );
+    }
+});

--- a/troposphere/static/js/stores/ClientCredentialStore.js
+++ b/troposphere/static/js/stores/ClientCredentialStore.js
@@ -1,0 +1,105 @@
+import _ from "underscore";
+import Dispatcher from "dispatchers/Dispatcher";
+import Store from "stores/Store";
+import ClientCredential from "models/ClientCredential";
+
+import NotificationController from "controllers/NotificationController";
+
+/**
+ * Author note: (@lenards)
+ *
+ * This is a mimic of `models/Profile` & `stores/ProfileStore`.
+ *
+ * Why? Because the functionality of exporting the credentials associated
+ * with an "Identity" (aka AtmosphereUser + Provider) did not appear to
+ * match the examples of :store -> :collection -> :model that commonly
+ * exists within the application.
+ *
+ * Here we introduce a "jargon-y" term, Client Credential as a manner of
+ * capturing what this _thing_ is that we're trying to acquire/export/
+ * grab. It is likely not going to be understood by community members,
+ * but has been selected to indicate that this "credential" has *value*
+ * when used with :cloud: client tools and command-line interfaces.
+ *
+ * Please approach the below code with any amount of healthy sketicism
+ * you can offer - you will likely be rewarded for it
+ */
+
+let _isFetching = false;
+
+/**
+ * Cache credentials, like a singleton of sorts, by `identity_uuid`
+ */
+let _creds = {};
+
+let fetchCredential = function(identityId) {
+    if (!_isFetching) {
+        // the Backbone.Model will need an `identity_uuid` when
+        // fetching the associated information, so pass it on
+        // initialize.
+        let cred = new ClientCredential({
+            "identity_uuid": identityId
+        });
+
+        _isFetching = true;
+
+        cred.fetch().then(function() {
+            _isFetching = false;
+            _creds[identityId] = cred;
+            ClientCredentialStore.emitChange();
+        }).fail(function(result) {
+            let errorMsg = `There was an error exporting credentials. ${result.responseText}`;
+
+            NotificationController.error(
+                null,
+                errorMsg,
+                {
+                    "positionClass": "toast-top-full-width",
+                    "timeOut": "0",
+                    "extendedTimeOut": "0"
+                }
+            );
+        });
+    }
+}
+
+
+//
+// Define Store
+//
+let ClientCredentialStore = {
+    getForIdentity: function(identityId) {
+        if (!_creds[identityId]) {
+            fetchCredential(identityId);
+        }
+        return _creds[identityId];
+    }
+};
+
+
+Dispatcher.register(function(payload) {
+    var action = payload.action;
+
+    switch (action.actionType) {
+// TODO
+// - eventually a "reset" of credentials will be needed
+//   this will require the `identity-uuid` to reset;
+//   other details will be forthcoming
+//
+//        case ClientCredentialConstants.RESET_CREDENTIAL:
+//            update(action.name, action.identity);
+//            break;
+
+        default:
+            return true;
+    }
+
+    ClientCredentialStore.emitChange();
+
+    return true;
+});
+
+
+_.extend(ClientCredentialStore, Store);
+
+export default ClientCredentialStore;


### PR DESCRIPTION
This implements an advanced settings option to "Export Credentials" on a _per Atmosphere Provider_ basis to be used with CLI tools for the OpenStack APIs.

The credentials are provided for "Copy & Paste" into a shell script file that will _export_ the environment variables used by tools like [`openstack`](https://pypi.python.org/pypi/python-openstackclient) when sourced. 

This is a basic, "Phase 0", version of the feature.

See [ATMO-1457](https://pods.iplantcollaborative.org/jira/browse/ATMO-1457#comment-56950)

# Example Interaction (without copy & paste)
![atmo-1457](https://cloud.githubusercontent.com/assets/5923/20442792/513d1576-ad87-11e6-9c3f-a7440c363916.gif)

Textual _copy_ shown for each view within **details**:

<details>

## Initial component shown prior to interaction

![export credential shown in advanced settings](https://cloud.githubusercontent.com/assets/5923/20442864/9ba9d860-ad87-11e6-9aae-79fdf0c8508d.png)

## Component shown with "more info" displayed

![export credential with more info displayed shown in advanced settings](https://cloud.githubusercontent.com/assets/5923/20442862/9b9cdb7e-ad87-11e6-8e13-c65da29d5fc7.png)

## Modal shown when "Export" clicked

![select provider shown](https://cloud.githubusercontent.com/assets/5923/20442863/9ba62940-ad87-11e6-8a94-07f189cbd13b.png)

## Modal shown when "provider" **selected**

![credential exported shown after selection of provider](https://cloud.githubusercontent.com/assets/5923/20442912/d73ea7ca-ad87-11e6-90e7-67e0c115c151.png)

</details>
