### PR TITLE
Fix issues with "Export Credential" modal

### DIFF
--- a/troposphere/static/js/components/modals/ExportCredential.react.js
+++ b/troposphere/static/js/components/modals/ExportCredential.react.js
@@ -194,7 +194,7 @@ export default React.createClass({
                 {this.renderCloseButton()}
                 <h1 className="t-title">Exported Credential</h1>
             </div>
-            <div style={{ minHeight: "500px" }} className="modal-body">
+            <div style={{ minHeight: "300px" }} className="modal-body">
                 <p>
                     Copy the exported credential and paste into a file.
                     This file will be used within a shell scripting

--- a/troposphere/static/js/components/modals/ExportCredential.react.js
+++ b/troposphere/static/js/components/modals/ExportCredential.react.js
@@ -89,7 +89,7 @@ export default React.createClass({
                 inputId = provider.name.replace(' ','-') + key;
 
             return (
-                <div className="form-check">
+                <div key={`check-${key}`} className="form-check">
                 <label className="form-check-label">
                     <input key={key}
                            id={inputId}
@@ -124,7 +124,7 @@ export default React.createClass({
                     Each Atmosphere "provider" will have different credentials for you.
                     Please select the provider to export:
                 </p>
-                <div className="form-group">
+                <div key="export-cred-radio-grp" className="form-group">
                     {this.renderIdentities(identities)}
                 </div>
             </div>

--- a/troposphere/static/js/components/modals/ExportCredential.react.js
+++ b/troposphere/static/js/components/modals/ExportCredential.react.js
@@ -194,7 +194,7 @@ export default React.createClass({
                 {this.renderCloseButton()}
                 <h1 className="t-title">Exported Credential</h1>
             </div>
-            <div style={{ minHeight: "300px" }} className="modal-body">
+            <div style={{ minHeight: "500px" }} className="modal-body">
                 <p>
                     Copy the exported credential and paste into a file.
                     This file will be used within a shell scripting
@@ -234,7 +234,7 @@ export default React.createClass({
 
         return (
         <div className="modal fade">
-            <div className="modal-dialog">
+            <div className="modal-dialog" style={{ minWidth: "705px"}}>
                 {this.renderContent(identities)}
             </div>
         </div>

--- a/troposphere/static/js/models/ClientCredential.js
+++ b/troposphere/static/js/models/ClientCredential.js
@@ -4,7 +4,7 @@ import globals from "globals";
 export default Backbone.Model.extend({
 
     parse: function(response) {
-        debugger;
+        // simple pass-through, no modifications yet
         return response;
     },
 


### PR DESCRIPTION
This pull request has 3 fixes in it:
- fix "width" issue for realistic values of `OS_PASSWORD`
- eliminate React warning about missing `key` prop on children within modal
- remove `debugger;` statement in credential model

![screen shot 2016-11-18 at 2 18 09 pm](https://cloud.githubusercontent.com/assets/5923/20447350/96862a64-ad9b-11e6-8f68-74697073f93e.png)
