### PR TITLE
Ensure there is a value for "Instance Name"

### DIFF
--- a/troposphere/static/js/components/modals/instance/InstanceLaunchWizardModal.react.js
+++ b/troposphere/static/js/components/modals/instance/InstanceLaunchWizardModal.react.js
@@ -293,6 +293,17 @@ export default React.createClass({
 
     onNameBlur: function(e) {
         let instanceName = this.state.instanceName.trim();
+        // NOTE:
+        // if the instanceName was just *deleted*, we lack required fields
+        // to launch an instance.
+        //
+        // Let's just catch that situation and put something back in the
+        // required `instanceName` textbox
+        if (!instanceName) {
+            let image = this.state.image;
+            instanceName = image ? image.get("name") : "atmosphere-instance";
+        }
+
         this.setState({
             instanceName
         });


### PR DESCRIPTION
The situation is this, someone deletes "Instance Name", tabs out of the field and moves on to other things. When they try to launch, it will *fail*. So, why not be a guardian angel and just _prevent_ them from entering into a situation that will lead to a failure?

That is the notion here.

If we have a `image` model, then get the name and fill it in for `instanceName`. If that is not available, just use some placeholder text that would be easy for a Cloud Operator to identify as having come from Troposphere.

See [ATMO-1595](https://pods.iplantcollaborative.org/jira/browse/ATMO-1595)